### PR TITLE
Add initial ArchivesSpace support

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -5,6 +5,7 @@ angular.module('appraisalTab', [
   'angularCharts',
   'restangular',
   'appraisalTab.version',
+  'archivesSpaceService',
   'facetService',
   'selectedFilesService',
   'transferService',

--- a/app/app.js
+++ b/app/app.js
@@ -13,6 +13,7 @@ angular.module('appraisalTab', [
   'facetFilter',
   'aggregationFilters',
   'treeView',
+  'archivesSpaceController',
   'facetController',
   'reportController',
   'treeController',

--- a/app/archivesspace/archivesspace.controller.js
+++ b/app/archivesspace/archivesspace.controller.js
@@ -1,0 +1,26 @@
+'use strict';
+
+(function() {
+  angular.module('archivesSpaceController', []).controller('ArchivesSpaceController', ['$scope', 'ArchivesSpace', function($scope, ArchivesSpace) {
+      var format_item = function(item) {
+        if (item.children && item.children.length > 0) {
+          item.children = item.children.map(function(child) {
+            return format_item(child);
+          });
+        }
+
+        item.label = item.title;
+        if (item.identifier) {
+          item.label += '(' + item.identifier + ')';
+        }
+
+        return item;
+      };
+
+      ArchivesSpace.all().then(function(data) {
+        $scope.data = data.map(function(child) {
+          return format_item(child);
+        });
+      });
+    }]);
+})();

--- a/app/fixtures/archivesspace.json
+++ b/app/fixtures/archivesspace.json
@@ -1,0 +1,50 @@
+[
+  {
+    "dates": "2015-01-01",
+    "title": "Test fonds",
+    "levelOfDescription": "fonds",
+    "children": [
+      {
+        "dates": "",
+        "title": "Test series",
+        "levelOfDescription": "series",
+        "children": [
+          {
+            "dates": "",
+            "title": "Test subseries",
+            "levelOfDescription": "subseries",
+            "children": [
+              {
+                "dates": "",
+                "title": "Test file",
+                "levelOfDescription": "file",
+                "children": false,
+                "sortPosition": 5,
+                "identifier": "F1-1-1-1",
+                "id": "/repositories/2/archival_objects/4"
+              }
+            ],
+            "sortPosition": 4,
+            "identifier": "F1-1-1",
+            "id": "/repositories/2/archival_objects/3"
+          }
+        ],
+        "sortPosition": 3,
+        "identifier": "F1-1",
+        "id": "/repositories/2/archival_objects/1"
+      },
+      {
+        "dates": "",
+        "title": "Test series 2",
+        "levelOfDescription": "series",
+        "children": false,
+        "sortPosition": 3,
+        "identifier": "F1-2",
+        "id": "/repositories/2/archival_objects/2"
+      }
+    ],
+    "sortPosition": 2,
+    "identifier": "F1",
+    "id": "/repositories/2/resources/1"
+  }
+]

--- a/app/index.html
+++ b/app/index.html
@@ -72,6 +72,10 @@
     <tree id="tree1" tree-data="data" tree-on-click="on_click"/>
   </div>
 
+  <div ng-controller="ArchivesSpaceController" style='float: right;'>
+    <tree id="archivesspace-tree" tree-data="data"/>
+  </div>
+
   <div ng-controller='ReportController' style='margin-left: 30px; float:left;'>
     <h2>Report</h2>
     <b><ng-pluralize count="(records.selected | filter:{root: true}).length" when="{'1': '1 transfer', 'other': '{} transfers'}"></ng-pluralize></b>, <ng-pluralize count="records.selected.length" when="{'1': '1 object', 'other': '{} objects'}"></ng-pluralize></b> selected<br>
@@ -111,6 +115,7 @@
   <script src="services/transfer.service.js"></script>
   <script src="filters/aggregation.filter.js"></script>
   <script src="filters/facet.filter.js"></script>
+  <script src="archivesspace/archivesspace.controller.js"></script>
   <script src="facet_selector/facet_selector.controller.js"></script>
   <script src="tree/tree.controller.js"></script>
   <script src="report/report.controller.js"></script>

--- a/app/index.html
+++ b/app/index.html
@@ -104,6 +104,7 @@
   <script src="bower_components/restangular/dist/restangular.min.js"></script>
   <script src="vendor/angular-charts/angular-charts.js"></script>
   <script src="app.js"></script>
+  <script src="services/archivesspace.service.js"></script>
   <script src="services/facet.service.js"></script>
   <script src="services/file.service.js"></script>
   <script src="services/selected.service.js"></script>

--- a/app/services/archivesspace.service.js
+++ b/app/services/archivesspace.service.js
@@ -1,0 +1,12 @@
+'use strict';
+
+(function() {
+  angular.module('archivesSpaceService', ['restangular']).factory('ArchivesSpace', ['Restangular', function(Restangular) {
+      var ArchivesSpace = Restangular.all('archivesspace.json');
+      return {
+        all: function() {
+          return ArchivesSpace.customGET();
+        },
+      };
+  }]);
+})();

--- a/test/unit/archivesspaceSpec.js
+++ b/test/unit/archivesspaceSpec.js
@@ -1,0 +1,26 @@
+'use strict';
+
+describe('ArchivesSpace', function() {
+  beforeEach(module('archivesSpaceService'));
+  beforeEach(angular.mock.inject(function(_$httpBackend_) {
+    _$httpBackend_.when('GET', '/archivesspace.json').respond([
+      {
+        'dates': '2015-01-01',
+        'title': 'Test fonds',
+        'levelOfDescription': 'fonds',
+        'children': [],
+        'sortPosition': 2,
+        'identifier': 'F1',
+        'id': '/repositories/2/resources/1',
+      },
+    ]);
+  }));
+
+  it('should be able to return a list of all ArchivesSpace records', inject(function(_$httpBackend_, ArchivesSpace) {
+    ArchivesSpace.all().then(function(objects) {
+      expect(objects.length).toEqual(1);
+      expect(objects[0].title).toEqual('Test fonds');
+    });
+    _$httpBackend_.flush();
+  }));
+});


### PR DESCRIPTION
This adds an initial ArchivesSpace tree view, with a new service (that mirrors Transfer), a new controller, and a view.

The data format returned by the new `ArchivesSpace` service is identical to the format already returned by the ArchivesSpaceClient class in the ArchivesSpace upload code, so it should be pretty easy for us to start making this work with real data. This includes fixture data generated from a real ArchivesSpace installation.
