### PR TITLE
Add routing, break up index.html

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -33,3 +33,23 @@
   height: 500px;
   width: 500px;
 }
+
+.internal a {
+  background-color: #222;
+  color: #FFF;
+}
+
+.transfer-tree {
+  float: left;
+  padding-top: 3em;
+  width: 460px;
+}
+
+.report-panel {
+  margin-left: 30px;
+  float: right;
+}
+
+.facet-box {
+  padding: 0 0 60px 0;
+}

--- a/app/app.js
+++ b/app/app.js
@@ -2,6 +2,9 @@
 
 // Declare app level module which depends on views, and components
 angular.module('appraisalTab', [
+  'ngRoute',
+  'route-segment',
+  'view-segment',
   'angularCharts',
   'restangular',
   'appraisalTab.version',
@@ -20,4 +23,39 @@ angular.module('appraisalTab', [
   'visualizationsController',
 ]).config(function(RestangularProvider) {
     RestangularProvider.setBaseUrl('/app/fixtures');
-});
+}).config(function($routeSegmentProvider) {
+  $routeSegmentProvider.options.autoLoadTemplates = true;
+
+  $routeSegmentProvider.
+    when('/report', 'report').
+    when('/visualizations', 'visualizations').
+    when('/visualizations/files', 'visualizations.files').
+    when('/visualizations/size', 'visualizations.size').
+    when('/archivesspace', 'archivesspace').
+
+    segment('report', {
+      templateUrl: 'report/report.html',
+      controller: 'ReportController',
+    }).
+
+    segment('visualizations', {
+      templateUrl: 'visualizations/visualizations.html',
+      controller: 'VisualizationsController',
+    }).
+    within().
+      segment('files', {
+        default: 'true',
+        templateUrl: 'visualizations/formats_by_files.html',
+      }).
+      segment('size', {
+        templateUrl: 'visualizations/formats_by_size.html',
+      }).
+    up().
+
+    segment('archivesspace', {
+      templateUrl: 'archivesspace/archivesspace.html',
+      controller: 'ArchivesSpaceController',
+    });
+}).controller('MainController', ['$scope', '$routeSegment', function($scope, $routeSegment) {
+  $scope.$routeSegment = $routeSegment;
+}]);

--- a/app/archivesspace/archivesspace.html
+++ b/app/archivesspace/archivesspace.html
@@ -1,0 +1,1 @@
+<tree id="archivesspace-tree" tree-data="data"/>

--- a/app/index.html
+++ b/app/index.html
@@ -2,7 +2,7 @@
 <!--[if lt IE 7]>      <html lang="en" ng-app="appraisalTab" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
 <!--[if IE 7]>         <html lang="en" ng-app="appraisalTab" class="no-js lt-ie9 lt-ie8"> <![endif]-->
 <!--[if IE 8]>         <html lang="en" ng-app="appraisalTab" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html lang="en" ng-app="appraisalTab" class="no-js"> <!--<![endif]-->
+<!--[if gt IE 8]><!--> <html lang="en" ng-app="appraisalTab" ng-controller="MainController" class="no-js"> <!--<![endif]-->
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -68,32 +68,24 @@
     </div>
   </div>
 
+  <ul class="nav nav-tabs">
+    <li ng-class="{ active: $routeSegment.contains('report') }">
+      <a href="#/report">Report</a>
+    </li>
+    <li ng-class="{ active: $routeSegment.contains('visualizations') }">
+      <a href="#/visualizations">Visualizations</a>
+    </li>
+    <li ng-class="{ active: $routeSegment.contains('archivesspace') }">
+      <a href="#/archivesspace">ArchivesSpace</a>
+    </li>
+  </ul>
+
   <div ng-controller="TreeController" style='float:left; width: 460px;'>
     <tree id="tree1" tree-data="data" tree-on-click="on_click"/>
   </div>
 
-  <div ng-controller="ArchivesSpaceController" style='float: right;'>
-    <tree id="archivesspace-tree" tree-data="data"/>
-  </div>
-
-  <div ng-controller='ReportController' style='margin-left: 30px; float:left;'>
-    <h2>Report</h2>
-    <b><ng-pluralize count="(records.selected | filter:{root: true}).length" when="{'1': '1 transfer', 'other': '{} transfers'}"></ng-pluralize></b>, <ng-pluralize count="records.selected.length" when="{'1': '1 object', 'other': '{} objects'}"></ng-pluralize></b> selected<br>
-
-    <div class="span8"><i>File types:</i><br></div>
-    By PUID:<br>
-    <table>
-    <tr ng-repeat="record in records.selected | facet | puid_data">
-      <td><a target="_blank" href="http://apps.nationalarchives.gov.uk/pronom/{{ record.puid }}">{{ record.puid }}</a></td>
-      <td>{{ record.data.count }} objects</td>
-      <td>{{ record.data.size }} MB</td>
-    </tr>
-    </table>
-  </div>
-
-  <div ng-controller='VisualizationsController'>
-    <div style="float: left;"><div ac-chart="puid_chart_type" ac-data="records.selected | facet | puid_data | puid_graph" ac-config="puid_config" class="chart"></div>
-    <div style="float: right;"><div ac-chart="size_chart_type" ac-data="records.selected | facet | puid_data | size_graph" ac-config="size_config" class="chart"></div>
+  <div class="container" id="right-pane">
+    <div app-view-segment="0"></div>
   </div>
 
   <!-- In production use:
@@ -103,6 +95,7 @@
   <script src="bower_components/jqtree/tree.jquery.js"></script>
   <script src="bower_components/angular/angular.js"></script>
   <script src="bower_components/angular-route/angular-route.js"></script>
+  <script src="bower_components/angular-route-segment/build/angular-route-segment.js"></script>
   <script src="bower_components/d3/d3.js"></script>
   <script src="bower_components/lodash/dist/lodash.min.js"></script>
   <script src="bower_components/restangular/dist/restangular.min.js"></script>

--- a/app/index.html
+++ b/app/index.html
@@ -34,12 +34,13 @@
 
         <ul class="nav">
 
-        <li class="{% active request url_transfer %}"><a>Transfer</a></li>
-        <li class="{% active request url_ingest %}"><a>Ingest</a></li>
-        <li class="{% active request url_archival_storage %}"><a>Archival storage</a></li>
-        <li class="{% active request url_fpr %}"><a>Preservation planning</a></li>
-        <li class="{% active request url_access %}"><a>Access</a></li>
-        <li class="{% active request url_administration %}"><a>Administration</a></li>
+        <li><a>Transfer</a></li>
+        <li class="active"><a>Appraisal</a></li>
+        <li><a>Ingest</a></li>
+        <li><a>Archival storage</a></li>
+        <li><a>Preservation planning</a></li>
+        <li><a>Access</a></li>
+        <li><a>Administration</a></li>
 
         </ul>
 
@@ -49,7 +50,7 @@
 
   <div ng-view></div>
 
-  <div style="padding: 0 0 60px 0;" ng-controller="FacetController">
+  <div class="facet-box" ng-controller="FacetController">
     PUID:
     <select ng-model="puid">
       <option value="">All</option>
@@ -68,19 +69,19 @@
     </div>
   </div>
 
-  <ul class="nav nav-tabs">
-    <li ng-class="{ active: $routeSegment.contains('report') }">
+  <ul class="nav links">
+    <li class="internal" ng-class="{ active: $routeSegment.contains('report') }">
       <a href="#/report">Report</a>
     </li>
-    <li ng-class="{ active: $routeSegment.contains('visualizations') }">
+    <li class="internal" ng-class="{ active: $routeSegment.contains('visualizations') }">
       <a href="#/visualizations">Visualizations</a>
     </li>
-    <li ng-class="{ active: $routeSegment.contains('archivesspace') }">
+    <li class="internal" ng-class="{ active: $routeSegment.contains('archivesspace') }">
       <a href="#/archivesspace">ArchivesSpace</a>
     </li>
   </ul>
 
-  <div ng-controller="TreeController" style='float:left; width: 460px;'>
+  <div class="transfer-tree" ng-controller="TreeController">
     <tree id="tree1" tree-data="data" tree-on-click="on_click"/>
   </div>
 

--- a/app/report/report.html
+++ b/app/report/report.html
@@ -1,4 +1,4 @@
-<div style='margin-left: 30px; float:left;'>
+<div class="report-panel">
   <h2>Report</h2>
   <b><ng-pluralize count="(records.selected | filter:{root: true}).length" when="{'1': '1 transfer', 'other': '{} transfers'}"></ng-pluralize></b>, <ng-pluralize count="records.selected.length" when="{'1': '1 object', 'other': '{} objects'}"></ng-pluralize></b> selected<br>
 

--- a/app/report/report.html
+++ b/app/report/report.html
@@ -1,0 +1,14 @@
+<div style='margin-left: 30px; float:left;'>
+  <h2>Report</h2>
+  <b><ng-pluralize count="(records.selected | filter:{root: true}).length" when="{'1': '1 transfer', 'other': '{} transfers'}"></ng-pluralize></b>, <ng-pluralize count="records.selected.length" when="{'1': '1 object', 'other': '{} objects'}"></ng-pluralize></b> selected<br>
+
+  <div class="span8"><i>File types:</i><br></div>
+  By PUID:<br>
+  <table>
+  <tr ng-repeat="record in records.selected | facet | puid_data">
+    <td><a target="_blank" href="http://apps.nationalarchives.gov.uk/pronom/{{ record.puid }}">{{ record.puid }}</a></td>
+    <td>{{ record.data.count }} objects</td>
+    <td>{{ record.data.size }} MB</td>
+  </tr>
+  </table>
+</div>

--- a/app/visualizations/formats_by_files.html
+++ b/app/visualizations/formats_by_files.html
@@ -1,1 +1,1 @@
-<div style="float: left;"><div ac-chart="puid_chart_type" ac-data="records.selected | facet | puid_data | puid_graph" ac-config="puid_config" class="chart"></div>
+<div ac-chart="puid_chart_type" ac-data="records.selected | facet | puid_data | puid_graph" ac-config="puid_config" class="chart">

--- a/app/visualizations/formats_by_files.html
+++ b/app/visualizations/formats_by_files.html
@@ -1,0 +1,1 @@
+<div style="float: left;"><div ac-chart="puid_chart_type" ac-data="records.selected | facet | puid_data | puid_graph" ac-config="puid_config" class="chart"></div>

--- a/app/visualizations/formats_by_size.html
+++ b/app/visualizations/formats_by_size.html
@@ -1,0 +1,1 @@
+<div style="float: right;"><div ac-chart="size_chart_type" ac-data="records.selected | facet | puid_data | size_graph" ac-config="size_config" class="chart"></div>

--- a/app/visualizations/formats_by_size.html
+++ b/app/visualizations/formats_by_size.html
@@ -1,1 +1,1 @@
-<div style="float: right;"><div ac-chart="size_chart_type" ac-data="records.selected | facet | puid_data | size_graph" ac-config="size_config" class="chart"></div>
+<div ac-chart="size_chart_type" ac-data="records.selected | facet | puid_data | size_graph" ac-config="size_config" class="chart">

--- a/app/visualizations/visualizations.html
+++ b/app/visualizations/visualizations.html
@@ -1,10 +1,10 @@
 <div app-view-segment="1"></div>
 
-<ul>
-  <li ng-class="{ active: $routeSegment.contains('files') }">
+<ul class="nav links">
+  <li class="internal" ng-class="{ active: $routeSegment.contains('files') }">
     <a href="#/visualizations/files">Formats (by total number of files)</a>
   </li>
-  <li ng-class="{ active: $routeSegment.contains('size') }">
+  <li class="internal" ng-class="{ active: $routeSegment.contains('size') }">
     <a href="#/visualizations/size">Formats (by total size of files)</a>
   </li>
 </ul>

--- a/app/visualizations/visualizations.html
+++ b/app/visualizations/visualizations.html
@@ -1,0 +1,10 @@
+<div app-view-segment="1"></div>
+
+<ul>
+  <li ng-class="{ active: $routeSegment.contains('files') }">
+    <a href="#/visualizations/files">Formats (by total number of files)</a>
+  </li>
+  <li ng-class="{ active: $routeSegment.contains('size') }">
+    <a href="#/visualizations/size">Formats (by total size of files)</a>
+  </li>
+</ul>

--- a/bower.json
+++ b/bower.json
@@ -7,9 +7,10 @@
   "private": true,
   "dependencies": {
     "angular": "1.3.x",
-    "angular-route": "1.3.x",
     "angular-loader": "1.3.x",
     "angular-mocks": "~1.3.x",
+    "angular-route": "~1.3.x",
+    "angular-route-segment": "1.4.x",
     "bootstrap": "~1.4.0",
     "d3": "~3.3.10",
     "html5-boilerplate": "~4.3.0",


### PR DESCRIPTION
This adds routing, and breaks up the components into separate templates.

I decided to use [angular-route-segment](http://angular-route-segment.com/), as it has a clear and readable syntax to define subroutes. For example, the visualizations panel only displays one chart at a time, and segments within the visualization route are used to let the user switch between different charts.

For the time being I've left all of the common components in `index.html`, and only moved the separate routes' contents into separate files.

I've also added some initial styling, which makes the page start to feel usable again. I also removed all of the `style=""` attributes and moved those into the CSS. It still needs quite a bit of work though.
