### PR TITLE
WIP load children from server only on click

### DIFF
--- a/app/archivesspace/archivesspace.controller.js
+++ b/app/archivesspace/archivesspace.controller.js
@@ -10,6 +10,19 @@
           }
           return a.id === b.id;
         },
+        isLeaf: function(node) {
+          return !node.has_children;
+        },
+      };
+
+      $scope.on_toggle = function(node, expanded) {
+        if (!expanded || !node.has_children || node.children.length > 0) {
+          return;
+        }
+
+        ArchivesSpace.get(node.id).then(function(resource) {
+          node.children = resource.children;
+        });
       };
 
       ArchivesSpace.all().then(function(data) {

--- a/app/archivesspace/archivesspace.html
+++ b/app/archivesspace/archivesspace.html
@@ -1,6 +1,7 @@
 <treecontrol id="archivesspace-tree"
              class="tree-classic"
              tree-model="data"
-             options="options">
+             options="options"
+             on-node-toggle="on_toggle(node, expanded)">
   {{ node.title }} <div ng-if="node.identifier">({{ node.identifier }})</div>
 </treecontrol>

--- a/app/fixtures/archivesspace.json
+++ b/app/fixtures/archivesspace.json
@@ -3,46 +3,8 @@
     "dates": "2015-01-01",
     "title": "Test fonds",
     "levelOfDescription": "fonds",
-    "children": [
-      {
-        "dates": "",
-        "title": "Test series",
-        "levelOfDescription": "series",
-        "children": [
-          {
-            "dates": "",
-            "title": "Test subseries",
-            "levelOfDescription": "subseries",
-            "children": [
-              {
-                "dates": "",
-                "title": "Test file",
-                "levelOfDescription": "file",
-                "children": false,
-                "sortPosition": 5,
-                "identifier": "F1-1-1-1",
-                "id": "/repositories/2/archival_objects/4"
-              }
-            ],
-            "sortPosition": 4,
-            "identifier": "F1-1-1",
-            "id": "/repositories/2/archival_objects/3"
-          }
-        ],
-        "sortPosition": 3,
-        "identifier": "F1-1",
-        "id": "/repositories/2/archival_objects/1"
-      },
-      {
-        "dates": "",
-        "title": "Test series 2",
-        "levelOfDescription": "series",
-        "children": false,
-        "sortPosition": 3,
-        "identifier": "F1-2",
-        "id": "/repositories/2/archival_objects/2"
-      }
-    ],
+    "children": [],
+    "has_children": true,
     "sortPosition": 2,
     "identifier": "F1",
     "id": "/repositories/2/resources/1"

--- a/app/fixtures/archivesspace/-repositories-2-archival_objects-1
+++ b/app/fixtures/archivesspace/-repositories-2-archival_objects-1
@@ -1,0 +1,19 @@
+{
+  "dates": "",
+  "title": "Test series",
+  "levelOfDescription": "series",
+  "children": [{
+    "dates": "",
+    "title": "Test subseries",
+    "levelOfDescription": "subseries",
+    "children": [],
+    "has_children": true,
+    "sortPosition": 4,
+    "identifier": "F1-1-1",
+    "id": "/repositories/2/archival_objects/3"
+  }],
+  "has_children": true,
+  "sortPosition": 3,
+  "identifier": "F1-1",
+  "id": "/repositories/2/archival_objects/1"
+}

--- a/app/fixtures/archivesspace/-repositories-2-archival_objects-2
+++ b/app/fixtures/archivesspace/-repositories-2-archival_objects-2
@@ -1,0 +1,10 @@
+{
+  "dates": "",
+  "title": "Test series 2",
+  "levelOfDescription": "series",
+  "children": false,
+  "has_children": false,
+  "sortPosition": 3,
+  "identifier": "F1-2",
+  "id": "/repositories/2/archival_objects/2"
+}

--- a/app/fixtures/archivesspace/-repositories-2-archival_objects-3
+++ b/app/fixtures/archivesspace/-repositories-2-archival_objects-3
@@ -1,0 +1,19 @@
+{
+  "dates": "",
+  "title": "Test subseries",
+  "levelOfDescription": "subseries",
+  "children": [{
+    "dates": "",
+    "title": "Test file",
+    "levelOfDescription": "file",
+    "children": false,
+    "has_children": false,
+    "sortPosition": 5,
+    "identifier": "F1-1-1-1",
+    "id": "/repositories/2/archival_objects/4"
+  }],
+  "has_children": true,
+  "sortPosition": 4,
+  "identifier": "F1-1-1",
+  "id": "/repositories/2/archival_objects/3"
+}

--- a/app/fixtures/archivesspace/-repositories-2-archival_objects-4
+++ b/app/fixtures/archivesspace/-repositories-2-archival_objects-4
@@ -1,0 +1,10 @@
+{
+  "dates": "",
+  "title": "Test file",
+  "levelOfDescription": "file",
+  "children": false,
+  "has_children": false,
+  "sortPosition": 5,
+  "identifier": "F1-1-1-1",
+  "id": "/repositories/2/archival_objects/4"
+}

--- a/app/fixtures/archivesspace/-repositories-2-resources-1
+++ b/app/fixtures/archivesspace/-repositories-2-resources-1
@@ -1,0 +1,29 @@
+{
+  "dates": "2015-01-01",
+  "title": "Test fonds",
+  "levelOfDescription": "fonds",
+  "children": [{
+    "dates": "",
+    "title": "Test series",
+    "levelOfDescription": "series",
+    "children": [],
+    "has_children": true,
+    "sortPosition": 3,
+    "identifier": "F1-1",
+    "id": "/repositories/2/archival_objects/1"
+  },
+  {
+    "dates": "",
+    "title": "Test series 2",
+    "levelOfDescription": "series",
+    "children": false,
+    "has_children": false,
+    "sortPosition": 3,
+    "identifier": "F1-2",
+    "id": "/repositories/2/archival_objects/2"
+  }],
+  "has_children": true,
+  "sortPosition": 2,
+  "identifier": "F1",
+  "id": "/repositories/2/resources/1"
+}

--- a/app/services/archivesspace.service.js
+++ b/app/services/archivesspace.service.js
@@ -7,6 +7,12 @@
         all: function() {
           return ArchivesSpace.customGET();
         },
+        get: function(id) {
+          var url_fragment = id.replace(/\//g, '-');
+          // TODO make this use the ArchivesSpace object above, once these
+          // are both fetching from real services and not fixtures
+          return Restangular.all('archivesspace').one(url_fragment).get();
+        },
       };
   }]);
 })();

--- a/test/unit/archivesspaceSpec.js
+++ b/test/unit/archivesspaceSpec.js
@@ -14,6 +14,15 @@ describe('ArchivesSpace', function() {
         'id': '/repositories/2/resources/1',
       },
     ]);
+    _$httpBackend_.when('GET', '/archivesspace/-repositories-2-archival_objects-4').respond({
+        'dates': '',
+        'title': 'Test file',
+        'levelOfDescription': 'file',
+        'children': false,
+        'sortPosition': 5,
+        'identifier': 'F1-1-1-1',
+        'id': '/repositories/2/archival_objects/4',
+    });
   }));
 
   it('should be able to return a list of all ArchivesSpace records', inject(function(_$httpBackend_, ArchivesSpace) {
@@ -22,5 +31,12 @@ describe('ArchivesSpace', function() {
       expect(objects[0].title).toEqual('Test fonds');
     });
     _$httpBackend_.flush();
+  }));
+
+  it('should be able to fetch a specific ArchivesSpace record', inject(function(_$httpBackend_, ArchivesSpace) {
+    ArchivesSpace.get('/repositories/2/archival_objects/4').then(function(object) {
+      expect(object.children).toBe(false);
+      expect(object.title).toEqual('Test file');
+    });
   }));
 });


### PR DESCRIPTION
Still have a few tweaks, but wanted to put up a PR for the current version.

This alters the ArchivesSpace code to fetch only a list of parent resources at the time the page is loaded; the contents of that tree are loaded only when the resource is first clicked. This loads the entire tree recursively, but we may want to load more granularly than that.

TODOs:
- [x] Expand the resource when it's clicked.
- [x] Find a way to indicate that the resource has children; jqTree doesn't show the usual folder icon, since the children aren't loaded yet.
