### PR TITLE
Facet improvements

### DIFF
--- a/app/facet_selector/facet_selector.controller.js
+++ b/app/facet_selector/facet_selector.controller.js
@@ -14,7 +14,6 @@
     });
 
     $scope.$watch('extension', function(selected) {
-      Facet.remove('text');
       if (!selected) {
         return;
       }
@@ -40,8 +39,6 @@
     };
 
     $scope.$watch('date_start', function(start_date) {
-      Facet.remove('date');
-
       var end_date = $scope.date_end;
       if (!start_date && !end_date) {
         return;
@@ -58,7 +55,6 @@
     });
 
     $scope.$watch('puid', function(selected) {
-      Facet.remove('puid');
       if (!selected) {
         return;
       }

--- a/app/facet_selector/facet_selector.controller.js
+++ b/app/facet_selector/facet_selector.controller.js
@@ -4,6 +4,11 @@
   var facetController = angular.module('facetController', []);
 
   facetController.controller('FacetController', function($scope, Transfer, Facet) {
+    $scope.remove_facet = function(name, id) {
+      Facet.remove_by_id(name, id);
+    };
+    $scope.Facet = Facet;
+
     Transfer.all().then(function(transfer_data) {
       $scope.formats = transfer_data.formats;
     });
@@ -14,10 +19,25 @@
         return;
       }
 
-      Facet.add('text', function(value) {
+      var facet_fn = function(value) {
         return selected === value.substr(value.lastIndexOf('.')).toLowerCase();
-      });
+      };
+      Facet.add('text', facet_fn, {name: 'Extension', text: selected});
     });
+
+    var format_date = function(start, end) {
+      var s;
+      if (!start) {
+        s = ' -';
+      } else {
+        s = start + ' -';
+      }
+      if (end) {
+        s += ' ' + end;
+      }
+
+      return s;
+    };
 
     $scope.$watch('date_start', function(start_date) {
       Facet.remove('date');
@@ -29,24 +49,21 @@
       start_date = Date.parse(start_date || '0');
       end_date = Date.parse(end_date || '999999999');
 
-      Facet.add('date', function(date) {
+      var facet_fn = function(data) {
         // TODO: handle unparseable dates
         var date_as_int = Date.parse(date);
         return date_as_int > start_date && date_as_int < end_date;
-      });
+      };
+      Facet.add('date', facet_fn, {name: 'Date', text: format_date($scope.date_start, $scope.date_end)});
     });
 
-    var facets = ['puid'];
-    for (var i in facets) {
-      var facet = facets[i];
-      $scope.$watch(facet, function(selected) {
-        Facet.remove(facet);
-        if (!selected) {
-          return;
-        }
+    $scope.$watch('puid', function(selected) {
+      Facet.remove('puid');
+      if (!selected) {
+        return;
+      }
 
-        Facet.add(facet, selected);
-      });
-    }
+      Facet.add('puid', selected, {name: 'Format', text: selected});
+    });
   });
 })();

--- a/app/index.html
+++ b/app/index.html
@@ -52,6 +52,10 @@
   <div ng-view></div>
 
   <div class="facet-box" ng-controller="FacetController">
+    <div ng-repeat="facet in Facet.facet_list">
+      {{ facet.name }}: {{ facet.text }} <span ng-click="remove_facet(facet.facet, facet.id);">x</span>
+    </div>
+
     PUID:
     <select ng-model="puid">
       <option value="">All</option>

--- a/app/index.html
+++ b/app/index.html
@@ -59,13 +59,13 @@
     PUID:
     <select ng-model="puid">
       <option value="">All</option>
-      <option ng-repeat="format in formats" value="{{ format.puid }}">{{ format.label }} ({{ format.puid }})</option>
+      <option ng-repeat="format in formats" ng-if="format.puid" value="{{ format.puid }}">{{ format.label }} ({{ format.puid }})</option>
     </select>
 
     File extension:
     <select ng-model="extension">
       <option value="">All</option>
-      <option ng-repeat="format in formats" value="{{ format.extension }}">{{ format.label }} ({{ format.extension }})</option>
+      <option ng-repeat="format in formats" ng-if="format.extension" value="{{ format.extension }}">{{ format.label }} ({{ format.extension }})</option>
     </select>
 
     <div>

--- a/app/services/facet.service.js
+++ b/app/services/facet.service.js
@@ -14,6 +14,7 @@
       }
       var facet_id = generate_id();
       this.facets[name].push({id: facet_id, value: value});
+      this.facet_list.push({id: facet_id, facet: name, value: value});
 
       return facet_id;
     };
@@ -51,21 +52,32 @@
       // If no value is provided, delete all values
       if (undefined === value) {
         delete this.facets[name];
+        this.facet_list = this.facet_list.filter(function(element) {
+          return element.facet !== name;
+        });
       } else if (undefined !== this.facets[name]) {
+        // TODO: filtering over two arrays is unnecessarily expensive;
+        //       see about ways to optimize this later
         this.facets[name] = this.facets[name].filter(function(element) {
           return element.value !== value;
+        });
+        this.facet_list = this.facet_list.filter(function(element) {
+          return element.facet !== name || element.value !== value;
         });
       }
     };
 
     var remove_by_id = function(name, id) {
-      this.facets[name] = this.facets[name].filter(function(element) {
+      var filter_fn = function(element) {
         return element.id !== id;
-      });
+      };
+      this.facets[name] = this.facets[name].filter(filter_fn);
+      this.facet_list = this.facet_list.filter(filter_fn);
     };
 
     var clear = function() {
       this.facets = {};
+      this.facet_list = [];
     };
 
     var filter = function(values) {
@@ -123,6 +135,7 @@
 
     return {
       facets: {},
+      facet_list: [],
       add: add,
       get: get,
       get_by_id: get_by_id,

--- a/app/services/facet.service.js
+++ b/app/services/facet.service.js
@@ -4,7 +4,7 @@
   var facetService = angular.module('facetService', []);
 
   facetService.factory('Facet', function() {
-    var add = function(name, value, data) {
+    var add = function(name, value, data, id) {
       data = data || {};
 
       if (undefined === this.facets[name]) {
@@ -14,7 +14,7 @@
       if (this.facets[name].indexOf(value) !== -1) {
         return;
       }
-      data.id = generate_id();
+      data.id = id || generate_id();
       data.value = value;
       data.facet = name;
       this.facets[name].push(data);

--- a/app/services/facet.service.js
+++ b/app/services/facet.service.js
@@ -12,20 +12,39 @@
       if (this.facets[name].indexOf(value) !== -1) {
         return;
       }
-      this.facets[name].push(value);
+      var facet_id = generate_id();
+      this.facets[name].push({id: facet_id, value: value});
+
+      return facet_id;
     };
 
     var get = function(name, value) {
+      // If the facet doesn't exist, just return nothing
+      if (undefined === this.facets[name]) {
+        return;
+      }
       // If no value is requested, return all facets for this field
       if (undefined === value) {
-        return this.facets[name];
+        return this.facets[name].map(function(element) {
+          return element.value;
+        });
       }
       // Return undefined if the requested facet isn't present
-      if (this.facets[name].indexOf(value) !== -1) {
+      var facets = this.facets[name].filter(function(element) {
+        return element.value === value;
+      });
+      if (facets.length === 0) {
         return;
       } else {
-        return value;
+        return facets[0].value;
       }
+    };
+
+    var get_by_id = function(name, id) {
+      var facets = this.facets[name].filter(function(element) {
+        return element.id === id;
+      });
+      return facets[0].value;
     };
 
     var remove = function(name, value) {
@@ -34,9 +53,15 @@
         delete this.facets[name];
       } else if (undefined !== this.facets[name]) {
         this.facets[name] = this.facets[name].filter(function(element) {
-          return element !== value;
+          return element.value !== value;
         });
       }
+    };
+
+    var remove_by_id = function(name, id) {
+      this.facets[name] = this.facets[name].filter(function(element) {
+        return element.id !== id;
+      });
     };
 
     var clear = function() {
@@ -68,7 +93,7 @@
       }
       for (var i in this.facets[key]) {
         var result;
-        var filter = this.facets[key][i];
+        var filter = this.facets[key][i].value;
         // filter is a function
         if (filter.call) {
           result = filter(value);
@@ -87,11 +112,22 @@
       return true;
     };
 
+    var generate_id = function() {
+      var s = '';
+      for (var i = 0; i < 16; i++) {
+        s += String.fromCharCode(Math.random() * 255);
+      }
+
+      return s;
+    };
+
     return {
       facets: {},
       add: add,
       get: get,
+      get_by_id: get_by_id,
       remove: remove,
+      remove_by_id: remove_by_id,
       clear: clear,
       filter: filter,
     };

--- a/app/services/facet.service.js
+++ b/app/services/facet.service.js
@@ -13,7 +13,6 @@
         return;
       }
       this.facets[name].push(value);
-      return this; // return self so that calls can be chained
     };
 
     var get = function(name, value) {

--- a/app/services/facet.service.js
+++ b/app/services/facet.service.js
@@ -4,7 +4,9 @@
   var facetService = angular.module('facetService', []);
 
   facetService.factory('Facet', function() {
-    var add = function(name, value) {
+    var add = function(name, value, data) {
+      data = data || {};
+
       if (undefined === this.facets[name]) {
         this.facets[name] = [];
       }
@@ -12,11 +14,13 @@
       if (this.facets[name].indexOf(value) !== -1) {
         return;
       }
-      var facet_id = generate_id();
-      this.facets[name].push({id: facet_id, value: value});
-      this.facet_list.push({id: facet_id, facet: name, value: value});
+      data.id = generate_id();
+      data.value = value;
+      data.facet = name;
+      this.facets[name].push(data);
+      this.facet_list.push(data);
 
-      return facet_id;
+      return data.id;
     };
 
     var get = function(name, value) {
@@ -56,14 +60,13 @@
           return element.facet !== name;
         });
       } else if (undefined !== this.facets[name]) {
+        var filter_fn = function(element) {
+          return element.facet !== name || element.value !== value;
+        };
         // TODO: filtering over two arrays is unnecessarily expensive;
         //       see about ways to optimize this later
-        this.facets[name] = this.facets[name].filter(function(element) {
-          return element.value !== value;
-        });
-        this.facet_list = this.facet_list.filter(function(element) {
-          return element.facet !== name || element.value !== value;
-        });
+        this.facets[name] = this.facets[name].filter(filter_fn);
+        this.facet_list = this.facet_list.filter(filter_fn);
       }
     };
 

--- a/app/visualizations/visualizations.controller.js
+++ b/app/visualizations/visualizations.controller.js
@@ -1,12 +1,16 @@
 'use strict';
 
 (function() {
-  angular.module('visualizationsController', ['angularCharts', 'selectedFilesService']).controller('VisualizationsController', function($scope, SelectedFiles) {
+  angular.module('visualizationsController', ['angularCharts', 'selectedFilesService']).controller('VisualizationsController', ['$scope', 'Facet', 'SelectedFiles', function($scope, Facet, SelectedFiles) {
     // Displays aggregate information about file formats;
     // the selected record data is filtered/reformatted in the view.
     $scope.records = SelectedFiles;
     $scope.puid_chart_type = 'pie';
     $scope.puid_config = {
+      click: function(d) {
+        Facet.remove('puid');
+        Facet.add('puid', d.data.x);
+      },
       title: 'Formats (total)',
       tooltips: true,
       labels: false,
@@ -18,6 +22,10 @@
 
     $scope.size_chart_type = 'pie';
     $scope.size_config = {
+      click: function(d) {
+        Facet.remove('puid');
+        Facet.add('puid', d.data.x);
+      },
       title: 'Formats (by size)',
       tooltips: true,
       labels: false,
@@ -26,5 +34,5 @@
         position: 'right',
       },
     };
-  });
+  }]);
 })();

--- a/test/unit/facetSpec.js
+++ b/test/unit/facetSpec.js
@@ -60,6 +60,11 @@ describe('Facet', function() {
     expect(id1).toNotEqual(id2);
   }));
 
+  it('should allow a facet ID to be specified', inject(function(Facet) {
+    var id = Facet.add('manual_id', '1', {}, 'this is an ID');
+    expect(id).toEqual('this is an ID');
+  }));
+
   it('should allow a facet to be fetched by ID', inject(function(Facet) {
     var id = Facet.add('get_id', '1');
     Facet.add('get_id', '2');

--- a/test/unit/facetSpec.js
+++ b/test/unit/facetSpec.js
@@ -52,4 +52,25 @@ describe('Facet', function() {
     });
     expect(Facet.filter([{'date': '1950:1999'}, {'date': '1975:1980'}])).toEqual([{'date': '1975:1980'}]);
   }));
+
+  it('should return a unique ID for each newly-added value', inject(function(Facet) {
+    var id1 = Facet.add('id', '1');
+    var id2 = Facet.add('id', '2');
+    expect(id1).toNotBe(undefined);
+    expect(id1).toNotEqual(id2);
+  }));
+
+  it('should allow a facet to be fetched by ID', inject(function(Facet) {
+    var id = Facet.add('get_id', '1');
+    Facet.add('get_id', '2');
+    expect(Facet.get_by_id('get_id', id)).toEqual('1');
+  }));
+
+  it('should allow a facet to be removed by ID', inject(function(Facet) {
+    var id = Facet.add('remove_id', '1');
+    Facet.add('remove_id', '2');
+    expect(Facet.get('remove_id').length).toEqual(2);
+    Facet.remove_by_id('remove_id', id);
+    expect(Facet.get('remove_id').length).toEqual(1);
+  }));
 });

--- a/test/unit/facetSpec.js
+++ b/test/unit/facetSpec.js
@@ -73,4 +73,10 @@ describe('Facet', function() {
     Facet.remove_by_id('remove_id', id);
     expect(Facet.get('remove_id').length).toEqual(1);
   }));
+
+  it('should provide a read-only flat list of every facet', inject(function(Facet) {
+    Facet.add('list_a', '1');
+    Facet.add('list_b', '2');
+    expect(Facet.facet_list.length).toEqual(2);
+  }));
 });

--- a/test/unit/facetSpec.js
+++ b/test/unit/facetSpec.js
@@ -10,21 +10,24 @@ describe('Facet', function() {
   }));
 
   it('should allow a specific facet to be removed', inject(function(Facet) {
-    Facet.add('removeOne', '1').add('removeOne', '2');
+    Facet.add('removeOne', '1');
+    Facet.add('removeOne', '2');
     expect(Facet.get('removeOne').length).toBe(2);
     Facet.remove('removeOne', '1');
     expect(Facet.get('removeOne').length).toBe(1);
   }));
 
   it('should remove every facet if no facet is specified', inject(function(Facet) {
-    Facet.add('removeAll', '1').add('removeAll', '2');
+    Facet.add('removeAll', '1');
+    Facet.add('removeAll', '2');
     expect(Facet.get('removeAll').length).toBe(2);
     Facet.remove('removeAll');
     expect(Facet.get('removeAll')).toBe(undefined);
   }));
 
   it('should allow all facets to be removed', inject(function(Facet) {
-    Facet.add('clearOne', '1').add('clearTwo', '1');
+    Facet.add('clearOne', '1');
+    Facet.add('clearTwo', '1');
     expect(Facet.get('clearOne').length).toBe(1);
     expect(Facet.get('clearTwo').length).toBe(1);
     Facet.clear();


### PR DESCRIPTION
This branch contains several improvements to the Facet service and to code that uses it:
- The charts now add a facet if you click on a format in the graph; this isn't very useful now, but the eventual goal is to have that filter the transfer tree.
- The Facet service now generates and returns a unique ID for each passed facet; this makes it easier to unambiguously remove facets whose value isn't a string (for example, facets which use filter functions).
- The Facet service now provides a read-only array of all active facets, as a more convenient way to iterate over facets for display in templates.
- When adding a facet, it's possible to pass additional data to be included in the facet object in the facet array; this makes it easier to store additional data to be used in templates.
- The facet selector template and controller make use of these new features to display all current facets, allow individual facets to be removed, and allow more than one facet to be specified for a given field.
