### PR TITLE
Allow Transfer service to track a flat map of data

### DIFF
--- a/app/facet_selector/facet_selector.controller.js
+++ b/app/facet_selector/facet_selector.controller.js
@@ -8,10 +8,7 @@
       Facet.remove_by_id(name, id);
     };
     $scope.Facet = Facet;
-
-    Transfer.all().then(function(transfer_data) {
-      $scope.formats = transfer_data.formats;
-    });
+    $scope.transfers = Transfer;
 
     $scope.$watch('extension', function(selected) {
       if (!selected) {

--- a/app/index.html
+++ b/app/index.html
@@ -88,7 +88,7 @@
 
   <div class="transfer-tree" ng-controller="TreeController">
     <treecontrol class="tree-classic"
-                 tree-model="data"
+                 tree-model="transfers.data"
                  options="options"
                  on-selection="track_selected(node, selected)">
       {{ node.label }}

--- a/app/index.html
+++ b/app/index.html
@@ -56,13 +56,13 @@
     PUID:
     <select ng-model="puid">
       <option value="">All</option>
-      <option ng-repeat="format in formats" ng-if="format.puid" value="{{ format.puid }}">{{ format.label }} ({{ format.puid }})</option>
+      <option ng-repeat="format in transfers.formats" ng-if="format.puid" value="{{ format.puid }}">{{ format.label }} ({{ format.puid }})</option>
     </select>
 
     File extension:
     <select ng-model="extension">
       <option value="">All</option>
-      <option ng-repeat="format in formats" ng-if="format.extension" value="{{ format.extension }}">{{ format.label }} ({{ format.extension }})</option>
+      <option ng-repeat="format in transfers.formats" ng-if="format.extension" value="{{ format.extension }}">{{ format.label }} ({{ format.extension }})</option>
     </select>
 
     <div>

--- a/app/services/transfer.service.js
+++ b/app/services/transfer.service.js
@@ -4,10 +4,32 @@
   var transferService = angular.module('transferService', ['restangular']);
 
   transferService.factory('Transfer', function(Restangular) {
+    var create_flat_map = function(records, map) {
+      if (map === undefined) {
+        map = {};
+      }
+
+      angular.forEach(records, function(record) {
+        map[record.id] = record;
+        create_flat_map(record.children, map);
+      });
+
+      return map;
+    };
+
     var Transfer = Restangular.all('transfers.json');
     return {
+      data: [],
+      id_map: {},
       all: function() {
         return Transfer.customGET();
+      },
+      resolve: function() {
+        var self = this;
+        self.all().then(function(data) {
+          self.data = data.transfers;
+          self.id_map = create_flat_map(data.transfers);
+        });
       },
     };
   });

--- a/app/services/transfer.service.js
+++ b/app/services/transfer.service.js
@@ -20,6 +20,7 @@
     var Transfer = Restangular.all('transfers.json');
     return {
       data: [],
+      formats: [],
       id_map: {},
       all: function() {
         return Transfer.customGET();
@@ -28,6 +29,7 @@
         var self = this;
         self.all().then(function(data) {
           self.data = data.transfers;
+          self.formats = data.formats;
           self.id_map = create_flat_map(data.transfers);
         });
       },

--- a/app/tree/tree.controller.js
+++ b/app/tree/tree.controller.js
@@ -47,9 +47,7 @@
         remove_file(node);
       }
     };
-
-    Transfer.all().then(function(data) {
-      $scope.data = data.transfers;
-    });
+    $scope.transfers = Transfer;
+    Transfer.resolve();
   }]);
 })();

--- a/test/unit/transferSpec.js
+++ b/test/unit/transferSpec.js
@@ -4,7 +4,12 @@ describe('Transfer', function() {
   beforeEach(module('transferService'));
   beforeEach(angular.mock.inject(function(_$httpBackend_) {
     _$httpBackend_.when('GET', '/transfers.json').respond({
-      'formats': [],
+      'formats': [
+        {
+          'label': 'Powerpoint 97-2002',
+          'puid': 'fmt/126',
+        },
+      ],
       'transfers': [
         {
           'id': 'd5700e44-68f1-4eec-a7e4-c5a5c7da2373',
@@ -34,5 +39,12 @@ describe('Transfer', function() {
     Transfer.resolve();
     _$httpBackend_.flush();
     expect(Transfer.id_map['d5700e44-68f1-4eec-a7e4-c5a5c7da2373'].name).toEqual('Images-49c47319-1387-48c4-aab7-381923f07f7c');
+  }));
+
+  it('should be able to track a copy of the fetched transfers\' formats on itself', inject(function(_$httpBackend_, Transfer) {
+    Transfer.resolve();
+    _$httpBackend_.flush();
+    expect(Transfer.formats.length).toEqual(1);
+    expect(Transfer.formats[0].puid).toEqual('fmt/126');
   }));
 });

--- a/test/unit/transferSpec.js
+++ b/test/unit/transferSpec.js
@@ -22,4 +22,17 @@ describe('Transfer', function() {
     });
     _$httpBackend_.flush();
   }));
+
+  it('should be able to track a copy of fetched transfers on itself', inject(function(_$httpBackend_, Transfer) {
+    Transfer.resolve();
+    _$httpBackend_.flush();
+    expect(Transfer.data.length).toEqual(1);
+    expect(Transfer.data[0].id).toEqual('d5700e44-68f1-4eec-a7e4-c5a5c7da2373');
+  }));
+
+  it('should provide a flat map of all stored transfers using IDs as keys', inject(function(_$httpBackend_, Transfer) {
+    Transfer.resolve();
+    _$httpBackend_.flush();
+    expect(Transfer.id_map['d5700e44-68f1-4eec-a7e4-c5a5c7da2373'].name).toEqual('Images-49c47319-1387-48c4-aab7-381923f07f7c');
+  }));
 });


### PR DESCRIPTION
- Allow the Transfer service to track the fetched data, making it easier to share fetched data between multiple components of the application.
- Also allow the Transfer service to track the fetched formats, and update the Facet selector to use this (rather than fetch the data a second time).
- Add a flat map of the fetched data, allowing quick retrieval of individual files via their ID; this makes it easier for outside services to make changes to the data (which will then be reflected by anything downstream which has bound to the data property). For example, this will be used by the upcoming Tag feature to make changes to the stored data.
