### PR TITLE
Tag feature

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -54,6 +54,13 @@
   padding: 0 0 60px 0;
 }
 
+.tag {
+  box-shadow: 0 0 0 1px black;
+  border-radius: 1px;
+  padding-left: 0.2em;
+  padding-right: 0.2em;
+}
+
 .disabled {
   color: gray;
   text-decoration: line-through;

--- a/app/app.js
+++ b/app/app.js
@@ -14,6 +14,7 @@ angular.module('appraisalTab', [
   'selectedFilesService',
   'transferService',
   'fileService',
+  'tagService',
   'facetFilter',
   'aggregationFilters',
   'archivesSpaceController',

--- a/app/app.js
+++ b/app/app.js
@@ -20,6 +20,7 @@ angular.module('appraisalTab', [
   'examineContentsController',
   'facetController',
   'reportController',
+  'tag',
   'treeController',
   'visualizationsController',
 ]).config(function(RestangularProvider) {
@@ -31,6 +32,7 @@ angular.module('appraisalTab', [
 
   $routeSegmentProvider.
     when('/report', 'report').
+    when('/tag', 'tag').
     when('/contents', 'examine_contents').
     when('/contents/:id/:type', 'examine_contents.file_info').
     when('/visualizations', 'visualizations').
@@ -41,6 +43,11 @@ angular.module('appraisalTab', [
     segment('report', {
       templateUrl: 'report/report.html',
       controller: 'ReportController',
+    }).
+
+    segment('tag', {
+      templateUrl: 'tag/tag.html',
+      controller: 'TagController',
     }).
 
     segment('examine_contents', {

--- a/app/facet_selector/facet_selector.controller.js
+++ b/app/facet_selector/facet_selector.controller.js
@@ -8,10 +8,7 @@
       Facet.remove_by_id(name, id);
     };
     $scope.Facet = Facet;
-
-    Transfer.all().then(function(transfer_data) {
-      $scope.formats = transfer_data.formats;
-    });
+    $scope.transfers = Transfer;
 
     $scope.$watch('extension', function(selected) {
       if (!selected) {

--- a/app/index.html
+++ b/app/index.html
@@ -88,7 +88,7 @@
 
   <div class="transfer-tree" ng-controller="TreeController">
     <treecontrol class="tree-classic"
-                 tree-model="data"
+                 tree-model="transfers.data"
                  options="options"
                  on-selection="track_selected(node, selected)">
       {{ node.label }}

--- a/app/index.html
+++ b/app/index.html
@@ -94,7 +94,7 @@
                  tree-model="transfers.data"
                  options="options"
                  on-selection="track_selected(node, selected)">
-      {{ node.label }}
+      {{ node.label }} <span class="tag" ng-repeat="tag in node.tags">{{ tag }} <span ng-click="remove_tag(id, tag)"><i class="fa fa-minus-square"></i></span></span>
     </treecontrol>
   </div>
 

--- a/app/index.html
+++ b/app/index.html
@@ -56,13 +56,13 @@
     PUID:
     <select ng-model="puid">
       <option value="">All</option>
-      <option ng-repeat="format in formats" ng-if="format.puid" value="{{ format.puid }}">{{ format.label }} ({{ format.puid }})</option>
+      <option ng-repeat="format in transfers.formats" ng-if="format.puid" value="{{ format.puid }}">{{ format.label }} ({{ format.puid }})</option>
     </select>
 
     File extension:
     <select ng-model="extension">
       <option value="">All</option>
-      <option ng-repeat="format in formats" ng-if="format.extension" value="{{ format.extension }}">{{ format.label }} ({{ format.extension }})</option>
+      <option ng-repeat="format in transfers.formats" ng-if="format.extension" value="{{ format.extension }}">{{ format.label }} ({{ format.extension }})</option>
     </select>
 
     <div>

--- a/app/index.html
+++ b/app/index.html
@@ -75,6 +75,9 @@
     <li class="internal" ng-class="{ active: $routeSegment.contains('report') }">
       <a href="#/report">Report</a>
     </li>
+    <li class="internal" ng-class="{ active: $routeSegment.contains('tag') }">
+      <a href="#/tag">Tag</a>
+    </li>
     <li class="internal" ng-class="{ active: $routeSegment.contains('examine_contents') }">
       <a href="#/contents">Examine contents</a>
     </li>
@@ -121,6 +124,7 @@
   <script src="archivesspace/archivesspace.controller.js"></script>
   <script src="examine_contents/examine_contents.controller.js"></script>
   <script src="facet_selector/facet_selector.controller.js"></script>
+  <script src="tag/tag.controller.js"></script>
   <script src="tree/tree.controller.js"></script>
   <script src="report/report.controller.js"></script>
   <script src="visualizations/visualizations.controller.js"></script>

--- a/app/index.html
+++ b/app/index.html
@@ -118,6 +118,7 @@
   <script src="services/facet.service.js"></script>
   <script src="services/file.service.js"></script>
   <script src="services/selected.service.js"></script>
+  <script src="services/tag.service.js"></script>
   <script src="services/transfer.service.js"></script>
   <script src="filters/aggregation.filter.js"></script>
   <script src="filters/facet.filter.js"></script>

--- a/app/index.html
+++ b/app/index.html
@@ -50,7 +50,7 @@
 
   <div class="facet-box" ng-controller="FacetController">
     <div ng-repeat="facet in Facet.facet_list">
-      {{ facet.name }}: {{ facet.text }} <span ng-click="remove_facet(facet.facet, facet.id);">x</span>
+      {{ facet.name }}: {{ facet.text }} <span ng-click="remove_facet(facet.facet, facet.id);"><i class="fa fa-minus-square"></i></span>
     </div>
 
     PUID:

--- a/app/services/selected.service.js
+++ b/app/services/selected.service.js
@@ -17,6 +17,11 @@
           return el.id !== uuid;
         });
       },
+      list_ids: function() {
+        return this.selected.map(function(record) {
+          return record.id;
+        });
+      },
       selected: [],
     };
   });

--- a/app/services/tag.service.js
+++ b/app/services/tag.service.js
@@ -1,0 +1,81 @@
+'use strict';
+
+(function() {
+  angular.module('tagService', ['transferService']).
+
+  factory('Tag', ['$log', 'Transfer', function($log, Transfer) {
+    var tags = {};
+
+    var add = function(id, tag) {
+      tags[id] = tags[id] || [];
+
+      if (tags[id].indexOf(tag) !== -1) {
+        return;
+      }
+
+      tags[id].push(tag);
+      var record = Transfer.id_map[id];
+      if (!record) {
+        $log.warn('Tried to add tag for file with ID ' + String(id) + ' which was not found in Transfer map');
+        return;
+      }
+      record.tags = record.tags || [];
+      record.tags.push(tag);
+    };
+
+    var add_list = function(ids, tag) {
+      angular.forEach(ids, function(id) {
+        add(id, tag);
+      });
+    };
+
+    var remove = function(id, tag) {
+      if (tags[id] === undefined) {
+        $log.warn('Tried to remove tag for file with ID ' + String(id) + ' but no tags are specified for that file');
+        return;
+      }
+
+      tags[id].pop(tag);
+      var record = Transfer.id_map[id];
+      if (!record) {
+        $log.warn('Tried to remove tag for file with ID ' + String(id) + ' which was not found in Transfer map');
+        return;
+      }
+      if (record.tags) {
+        record.tags.pop(tag);
+      }
+    };
+
+    var clear = function(id) {
+      tags[id] = [];
+      var record = Transfer.id_map[id];
+      if (record) {
+        record.tags = [];
+      }
+    };
+
+    var get = function(id) {
+      return tags[id] || [];
+    };
+
+    var list = function(tag) {
+      var results = [];
+      angular.forEach(tags, function(taglist, id) {
+        if (taglist.indexOf(tag) !== -1) {
+          results.push(id);
+        }
+      });
+
+      return results;
+    };
+
+    return {
+      add: add,
+      add_list: add_list,
+      get: get,
+      remove: remove,
+      clear: clear,
+      list: list,
+    };
+  }]);
+})();

--- a/app/services/transfer.service.js
+++ b/app/services/transfer.service.js
@@ -4,10 +4,32 @@
   var transferService = angular.module('transferService', ['restangular']);
 
   transferService.factory('Transfer', function(Restangular) {
+    var create_flat_map = function(records, map) {
+      if (map === undefined) {
+        map = {};
+      }
+
+      angular.forEach(records, function(record) {
+        map[record.id] = record;
+        create_flat_map(record.children, map);
+      });
+
+      return map;
+    };
+
     var Transfer = Restangular.all('transfers.json');
     return {
+      data: [],
+      id_map: {},
       all: function() {
         return Transfer.customGET();
+      },
+      resolve: function() {
+        var self = this;
+        self.all().then(function(data) {
+          self.data = data.transfers;
+          self.id_map = create_flat_map(data.transfers);
+        });
       },
     };
   });

--- a/app/services/transfer.service.js
+++ b/app/services/transfer.service.js
@@ -20,6 +20,7 @@
     var Transfer = Restangular.all('transfers.json');
     return {
       data: [],
+      formats: [],
       id_map: {},
       all: function() {
         return Transfer.customGET();
@@ -28,6 +29,7 @@
         var self = this;
         self.all().then(function(data) {
           self.data = data.transfers;
+          self.formats = data.formats;
           self.id_map = create_flat_map(data.transfers);
         });
       },

--- a/app/tag/tag.controller.js
+++ b/app/tag/tag.controller.js
@@ -1,8 +1,9 @@
 (function() {
   angular.module('tag', []).
 
-  controller('TagController', ['$scope', function($scope) {
+  controller('TagController', ['$scope', 'SelectedFiles', 'Tag', function($scope, SelectedFiles, Tag) {
     $scope.tags = [];
+    $scope.files = SelectedFiles;
 
     $scope.tag_watcher = function(val) {
       if (val.slice(-1) !== ' ') {
@@ -11,7 +12,7 @@
 
       var tag = val.slice(0, -1);
       if ($scope.tags.indexOf(tag) === -1) {
-        $scope.tags.push(tag);
+        Tag.add_list(SelectedFiles.list_ids(), tag);
       }
       $scope.tag_input = '';
     };

--- a/app/tag/tag.controller.js
+++ b/app/tag/tag.controller.js
@@ -1,0 +1,19 @@
+(function() {
+  angular.module('tag', []).
+
+  controller('TagController', ['$scope', function($scope) {
+    $scope.tags = [];
+
+    $scope.tag_watcher = function(val) {
+      if (val.slice(-1) !== ' ') {
+        return;
+      }
+
+      var tag = val.slice(0, -1);
+      if ($scope.tags.indexOf(tag) === -1) {
+        $scope.tags.push(tag);
+      }
+      $scope.tag_input = '';
+    };
+  }]);
+})();

--- a/app/tag/tag.html
+++ b/app/tag/tag.html
@@ -1,0 +1,5 @@
+<ul ng-if="tags.length > 0">
+  <li ng-repeat="tag in tags">{{ tag }}</li>
+</ul>
+
+<input type="text" ng-model="tag_input" ng-change="tag_watcher(tag_input)" ng-trim="false">

--- a/app/tag/tag.html
+++ b/app/tag/tag.html
@@ -1,5 +1,5 @@
-<ul ng-if="tags.length > 0">
-  <li ng-repeat="tag in tags">{{ tag }}</li>
-</ul>
-
-<input type="text" ng-model="tag_input" ng-change="tag_watcher(tag_input)" ng-trim="false">
+<input type="text"
+       ng-model="tag_input"
+       ng-change="tag_watcher(tag_input)"
+       ng-trim="false"
+       ng-disabled="files.selected.length < 1">

--- a/app/tree/tree.controller.js
+++ b/app/tree/tree.controller.js
@@ -47,9 +47,7 @@
         remove_file(node);
       }
     };
-
-    Transfer.all().then(function(data) {
-      $scope.data = data.transfers;
-    });
+    $scope.transfers = Transfer;
+    Transfer.resolve();
   }]);
 })();

--- a/app/tree/tree.controller.js
+++ b/app/tree/tree.controller.js
@@ -3,7 +3,7 @@
 (function() {
   var treeController = angular.module('treeController', []);
 
-  treeController.controller('TreeController', ['$scope', 'SelectedFiles', 'Transfer', function($scope, SelectedFiles, Transfer) {
+  treeController.controller('TreeController', ['$scope', 'SelectedFiles', 'Tag', 'Transfer', function($scope, SelectedFiles, Tag, Transfer) {
 
     $scope.options = {
       dirSelectable: true,
@@ -16,6 +16,10 @@
       },
     };
     $scope.selected = [];
+
+    $scope.remove_tag = function(id, tag) {
+      Tag.remove(id, tag);
+    };
 
     var add_file = function(node) {
       SelectedFiles.add(node.id);

--- a/test/unit/selectedFilesSpec.js
+++ b/test/unit/selectedFilesSpec.js
@@ -11,6 +11,10 @@ describe('SelectedFiles', function() {
       'id': '939110fa-8c73-4531-8aa0-aa28e90ca108',
       'text': 'garnet.jpg',
     });
+    _$httpBackend_.when('GET', '/file/3400c608-4dbf-4eeb-af22-7fb4ca6a5de6').respond({
+      'id': '3400c608-4dbf-4eeb-af22-7fb4ca6a5de6',
+      'text': 'amethyst.tif',
+    });
   }));
   beforeEach(angular.mock.inject(function(SelectedFiles) {
     SelectedFiles.selected = [];
@@ -39,4 +43,11 @@ describe('SelectedFiles', function() {
     expect(SelectedFiles.selected.length).toEqual(1);
     expect(SelectedFiles.selected[0].text).toEqual('garnet.jpg');
   }));
+
+  it('should be able to return a list of IDs', inject(function(_$httpBackend_, SelectedFiles) {
+      expect(SelectedFiles.list_ids().length).toEqual(0);
+      SelectedFiles.add('3400c608-4dbf-4eeb-af22-7fb4ca6a5de6');
+      _$httpBackend_.flush();
+      expect(SelectedFiles.list_ids()).toEqual(['3400c608-4dbf-4eeb-af22-7fb4ca6a5de6']);
+    }));
 });

--- a/test/unit/tagSpec.js
+++ b/test/unit/tagSpec.js
@@ -1,0 +1,38 @@
+'use strict';
+
+describe('Tag', function() {
+  beforeEach(module('tagService'));
+
+  it('should be able to track tags for a given file', inject(function(Tag) {
+    Tag.add('2d3fbf28-0102-4de7-9bd0-77af2808d5f0', 'testtag');
+    expect(Tag.get('2d3fbf28-0102-4de7-9bd0-77af2808d5f0')).toEqual(['testtag']);
+  }));
+
+  it('should be able to track tags for multiple files', inject(function(Tag) {
+    Tag.add_list(['2bd03175-b9a2-4047-a34d-7328000ade9a', '2562f838-67cb-49d0-9b45-4bb4860a2d74'], 'testtag');
+    expect(Tag.get('2bd03175-b9a2-4047-a34d-7328000ade9a')).toEqual(['testtag']);
+    expect(Tag.get('2562f838-67cb-49d0-9b45-4bb4860a2d74')).toEqual(['testtag']);
+  }));
+
+  it('should be able to remove tags for a given file', inject(function(Tag) {
+    Tag.add('f2c52912-0297-4f7a-90a7-f7a9323eeb5d', 'testtag');
+    expect(Tag.get('f2c52912-0297-4f7a-90a7-f7a9323eeb5d')).toEqual(['testtag']);
+    Tag.remove('f2c52912-0297-4f7a-90a7-f7a9323eeb5d', 'testtag');
+    expect(Tag.get('f2c52912-0297-4f7a-90a7-f7a9323eeb5d')).toEqual([]);
+  }));
+
+  it('should be able to clear tags for a given file', inject(function(Tag) {
+    Tag.add('f9416832-13df-411a-b0ad-ad994689b760', 'testtag1');
+    Tag.add('f9416832-13df-411a-b0ad-ad994689b760', 'testtag2');
+    expect(Tag.get('f9416832-13df-411a-b0ad-ad994689b760')).toEqual(['testtag1', 'testtag2']);
+    Tag.clear('f9416832-13df-411a-b0ad-ad994689b760');
+    expect(Tag.get('f9416832-13df-411a-b0ad-ad994689b760')).toEqual([]);
+  }));
+
+  it('should be able to list all files for a given tag', inject(function(Tag) {
+    expect(Tag.list('testtag')).toEqual([]);
+    Tag.add('87c16fac-01a5-444c-b88a-e1de8cb9500d', 'testtag');
+    Tag.add('3661b2ba-4341-45a6-bb74-b41e95eaeb7a', 'testtag');
+    expect(Tag.list('testtag')).toEqual(['87c16fac-01a5-444c-b88a-e1de8cb9500d', '3661b2ba-4341-45a6-bb74-b41e95eaeb7a']);
+  }));
+});

--- a/test/unit/transferSpec.js
+++ b/test/unit/transferSpec.js
@@ -4,7 +4,12 @@ describe('Transfer', function() {
   beforeEach(module('transferService'));
   beforeEach(angular.mock.inject(function(_$httpBackend_) {
     _$httpBackend_.when('GET', '/transfers.json').respond({
-      'formats': [],
+      'formats': [
+        {
+          'label': 'Powerpoint 97-2002',
+          'puid': 'fmt/126',
+        },
+      ],
       'transfers': [
         {
           'id': 'd5700e44-68f1-4eec-a7e4-c5a5c7da2373',
@@ -34,5 +39,12 @@ describe('Transfer', function() {
     Transfer.resolve();
     _$httpBackend_.flush();
     expect(Transfer.id_map['d5700e44-68f1-4eec-a7e4-c5a5c7da2373'].name).toEqual('Images-49c47319-1387-48c4-aab7-381923f07f7c');
+  }));
+
+  it('should be able to track a copy of the fetched transfers\' formats on itself', inject(function(_$httpBackend_, Transfer) {
+    Transfer.resolve();
+    _$httpBackend_.flush();
+    expect(Transfer.formats.length).toEqual(1);
+    expect(Transfer.formats[0].puid).toEqual('fmt/126');
   }));
 });

--- a/test/unit/transferSpec.js
+++ b/test/unit/transferSpec.js
@@ -22,4 +22,17 @@ describe('Transfer', function() {
     });
     _$httpBackend_.flush();
   }));
+
+  it('should be able to track a copy of fetched transfers on itself', inject(function(_$httpBackend_, Transfer) {
+    Transfer.resolve();
+    _$httpBackend_.flush();
+    expect(Transfer.data.length).toEqual(1);
+    expect(Transfer.data[0].id).toEqual('d5700e44-68f1-4eec-a7e4-c5a5c7da2373');
+  }));
+
+  it('should provide a flat map of all stored transfers using IDs as keys', inject(function(_$httpBackend_, Transfer) {
+    Transfer.resolve();
+    _$httpBackend_.flush();
+    expect(Transfer.id_map['d5700e44-68f1-4eec-a7e4-c5a5c7da2373'].name).toEqual('Images-49c47319-1387-48c4-aab7-381923f07f7c');
+  }));
 });


### PR DESCRIPTION
This adds a new tagging feature, 
- A new "tag" tab has been added; this has an input box which adds tags to the selected files. The input box splits tags on spaces; rather than have an explicit "add" button, just typing "space" adds the tag immediately.
- Tags are added via the Tag service, which updates transfer objects held by the Transfer service; this triggers the transfer tree to rerender items with tag nodes, which can be clicked to remove them on a per-file basis.

This requires #12.
