### PR TITLE
Updates to transferdata

### DIFF
--- a/app/fixtures/transfers.json
+++ b/app/fixtures/transfers.json
@@ -194,91 +194,106 @@
                   "id": "4e3ad48e-425e-4e8a-9ce3-02cca100409f",
                   "label": "ASL-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 34.27294921875
                 },
                 {
                   "id": "fba05cf5-5eb2-4051-b7ce-4db43c97f9fc",
                   "label": "Ore-Dock-1.bmp",
                   "format": "Windows BItmap 3.0",
-                  "puid": "fmt/116"
+                  "puid": "fmt/116",
+                  "size": 8.077878952026367
                 },
                 {
                   "id": "fd54a7dd-6d40-4257-9be5-13df0b3e9a09",
                   "label": "Ore-Dock-1j.JPG",
                   "format": "JPEG 1.01",
-                  "puid": "fmt/43"
+                  "puid": "fmt/43",
+                  "size": 0.32271575927734375
                 },
                 {
                   "id": "b1ed33b9-ba6b-41e0-9063-00099f809d57",
                   "label": "Ore-Dock-2.bmp",
                   "format": "Windows BItmap 3.0",
-                  "puid": "fmt/116"
+                  "puid": "fmt/116",
+                  "size": 4.162527084350586
                 },
                 {
                   "id": "7c7af5e8-0b61-4490-a30d-cb414d1b7303",
                   "label": "Ore-Dock-2j.JPG",
                   "format": "JPEG 1.01",
-                  "puid": "fmt/43"
+                  "puid": "fmt/43",
+                  "size": 0.15170955657958984
                 },
                 {
                   "id": "e2f8e0fe-8620-4814-abc0-e50dfd7872de",
                   "label": "Ore-Dock-3.bmp",
                   "format": "Windows BItmap 3.0",
-                  "puid": "fmt/116"
+                  "puid": "fmt/116",
+                  "size": 8.459562301635742
                 },
                 {
                   "id": "980c54d1-b4f2-41c9-b0f2-5556512f26ed",
                   "label": "Ore-Dock-3j.JPG",
                   "format": "JPEG 1.01",
-                  "puid": "fmt/43"
+                  "puid": "fmt/43",
+                  "size": 0.3149404525756836
                 },
                 {
                   "id": "cb5ab84e-52d0-473c-896b-c380cc41fb05",
                   "label": "Ore-Dock-4.bmp",
                   "format": "Windows BItmap 3.0",
-                  "puid": "fmt/116"
+                  "puid": "fmt/116",
+                  "size": 5.125577926635742
                 },
                 {
                   "id": "3b80e783-3ad3-4fca-9c66-d5cae4b649bd",
                   "label": "Ore-Dock-4j.bmp",
                   "format": "Windows BItmap 3.0",
-                  "puid": "fmt/116"
+                  "puid": "fmt/116",
+                  "size": 5.125577926635742
                 },
                 {
                   "id": "404a4e1f-abb5-4d14-86cd-6f2f9ea72189",
                   "label": "Ore-Dock-5.bmp",
                   "format": "Windows BItmap 3.0",
-                  "puid": "fmt/116"
+                  "puid": "fmt/116",
+                  "size": 8.580511093139648
                 },
                 {
                   "id": "0d09569d-e6e3-4207-94dd-3c9cbd5a153f",
                   "label": "Ore-Dock-5j.JPG",
                   "format": "JPEG 1.01",
-                  "puid": "fmt/43"
+                  "puid": "fmt/43",
+                  "size": 0.3166322708129883
                 },
                 {
                   "id": "939a1545-91ee-484b-9d87-af3b61b13758",
                   "label": "Ore-Dock-6.bmp",
                   "format": "Windows BItmap 3.0",
-                  "puid": "fmt/116"
+                  "puid": "fmt/116",
+                  "size": 1.299734115600586
                 },
                 {
                   "id": "594719c0-b8d6-4dc6-9fa9-3e03154d5e90",
                   "label": "Scrap.shs",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 1.625
                 },
                 {
                   "id": "e72a068d-c634-4194-8910-ba474d001427",
                   "label": "pptBA.tmp",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 34.27294921875
                 },
                 {
                   "id": "dc08bcee-c4b9-490e-a98e-a884c4a9973c",
                   "label": "pptC1.tmp",
                   "format": "Generic AIFF",
-                  "extension": ".aif"
+                  "extension": ".aif",
+                  "size": 34.27294921875
                 }
               ]
             },
@@ -296,7 +311,8 @@
                   "id": "3d2f56e3-9917-44a7-a799-8b1f2efa83a6",
                   "label": "UPDON-2-12-09.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 2.423828125
                 }
               ]
             },
@@ -326,523 +342,610 @@
                       "id": "34716b4f-44fb-4b73-856c-573500f2614d",
                       "label": "Governor-on-porch.jpg",
                       "format": "JPEG 1.01",
-                      "puid": "fmt/43"
+                      "puid": "fmt/43",
+                      "size": 0.08105278015136719
                     },
                     {
                       "id": "497d3903-a7d2-4645-8033-14842ff7725f",
                       "label": "P1000523.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8009662628173828
                     },
                     {
                       "id": "be9f817f-c17d-4475-b735-2bd898bce100",
                       "label": "P1000524.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.814112663269043
                     },
                     {
                       "id": "7ff32b8d-bd5e-4aaf-83bb-42d86a0feafd",
                       "label": "P1000525.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7834558486938477
                     },
                     {
                       "id": "132c18e8-a1fa-4f01-b1ca-469e037d06f5",
                       "label": "P1000526.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.781224250793457
                     },
                     {
                       "id": "f7985dea-9e3f-428e-933a-0f410bc70c06",
                       "label": "P1000527.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7889175415039062
                     },
                     {
                       "id": "e3407b7a-9fdc-4e2f-b976-2a0140a7df62",
                       "label": "P1000528.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7830429077148438
                     },
                     {
                       "id": "761d4f12-6cee-4c99-b8c8-49ba5728357e",
                       "label": "P1000529.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7952718734741211
                     },
                     {
                       "id": "3eb7a763-a55c-4149-af48-84d8ad0755d0",
                       "label": "P1000530.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8044652938842773
                     },
                     {
                       "id": "05e38971-f835-4828-b643-f74396a073b7",
                       "label": "P1000531.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8060264587402344
                     },
                     {
                       "id": "20961c83-a976-4bed-909d-41fe82938325",
                       "label": "P1000532.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8330612182617188
                     },
                     {
                       "id": "50928d0f-7855-4775-82d7-f5b9db3654cc",
                       "label": "P1000533.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7969169616699219
                     },
                     {
                       "id": "ebb8345f-80e8-45d3-8470-338c66931f5c",
                       "label": "P1000534.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7953319549560547
                     },
                     {
                       "id": "5c14dc3f-93ed-4bd7-b234-ec4e8299cd1c",
                       "label": "P1000535.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7913856506347656
                     },
                     {
                       "id": "7cbd68c0-a33c-4987-aedd-2af406fd69c3",
                       "label": "P1000536.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7980022430419922
                     },
                     {
                       "id": "e56b9643-24db-4adf-85ca-cdde977abfb0",
                       "label": "P1000537.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.755314826965332
                     },
                     {
                       "id": "2e31051c-965c-4b91-b882-0cc23d939d17",
                       "label": "P1000538.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7527074813842773
                     },
                     {
                       "id": "d476f3a5-1071-44c3-87ba-eb2bed302492",
                       "label": "P1000539.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7618980407714844
                     },
                     {
                       "id": "22397de5-7ff3-4c65-8e00-d02123df2cdc",
                       "label": "P1000540.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7491569519042969
                     },
                     {
                       "id": "de8c868d-9f68-43f6-a104-31b225095714",
                       "label": "P1000541.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8187351226806641
                     },
                     {
                       "id": "a9dea238-a58c-4e47-bb4d-20cd4e968daf",
                       "label": "P1000542.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7689790725708008
                     },
                     {
                       "id": "d7822633-b99e-40c2-a789-f9ff4bed50b4",
                       "label": "P1000543.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.747706413269043
                     },
                     {
                       "id": "76b49be6-2ef0-40a6-afcd-55e037324ffd",
                       "label": "P1000544.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8688259124755859
                     },
                     {
                       "id": "e3abf244-378b-42f5-9bb0-52de529aadb6",
                       "label": "P1000545.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7807531356811523
                     },
                     {
                       "id": "5596a7cc-1152-4c4e-9242-6af68f959970",
                       "label": "P1000546.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7750053405761719
                     },
                     {
                       "id": "8483d5f9-d52f-453f-a728-fd4532f1124f",
                       "label": "P1000547.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7576465606689453
                     },
                     {
                       "id": "a5c6d5ff-1a07-497a-b1e2-cb3818a191aa",
                       "label": "P1000548.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8059453964233398
                     },
                     {
                       "id": "65fecb74-0db3-425b-81be-756a28b65333",
                       "label": "P1000549.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7613468170166016
                     },
                     {
                       "id": "c04d9251-771a-49ee-8f81-4da082779d34",
                       "label": "P1000550.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.782597541809082
                     },
                     {
                       "id": "dc76634e-8f65-4f32-9002-7877b2e7bc82",
                       "label": "P1000551.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8213558197021484
                     },
                     {
                       "id": "5b6e53ac-cf5c-4317-869e-f2e5d53b15df",
                       "label": "P1000552.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7818355560302734
                     },
                     {
                       "id": "84e9b639-4e73-4251-a199-eba0e0175b70",
                       "label": "P1000553.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.763340950012207
                     },
                     {
                       "id": "785efffc-ab11-43b3-84ae-f529e6a5bc0e",
                       "label": "P1000554.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8000144958496094
                     },
                     {
                       "id": "f79b20ae-8afe-4a97-b5cd-7f3fc44e917a",
                       "label": "P1000555.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.772007942199707
                     },
                     {
                       "id": "cc87baf1-ca3c-4ec5-890f-f8d78b300b9f",
                       "label": "P1000556.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.793736457824707
                     },
                     {
                       "id": "157988d8-da8b-42e3-b27b-da3cd84c5036",
                       "label": "P1000557.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7690486907958984
                     },
                     {
                       "id": "0142ab23-7ad4-4e4d-a40a-f727f2e8b9c1",
                       "label": "P1000558.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7751045227050781
                     },
                     {
                       "id": "f3501517-d363-435f-a5de-b2d6374ce4f3",
                       "label": "P1000559.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7689371109008789
                     },
                     {
                       "id": "88192250-59c0-4f9d-b21f-05102e8b36b1",
                       "label": "P1000560.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7914190292358398
                     },
                     {
                       "id": "0793f544-83b5-49cc-8862-3d0b8fcde3d8",
                       "label": "P1000561.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7871770858764648
                     },
                     {
                       "id": "1f63a706-cf3e-4a8d-8569-5092e6edc2c4",
                       "label": "P1000562.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8139705657958984
                     },
                     {
                       "id": "f5bed50d-ec8b-4bc5-8f78-08bd81db830f",
                       "label": "P1000563.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7992067337036133
                     },
                     {
                       "id": "0d650bbc-c323-429c-9720-74262580d356",
                       "label": "P1000564.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7871217727661133
                     },
                     {
                       "id": "9d970656-204e-4536-85c5-e6fbbc859082",
                       "label": "P1000565.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7658786773681641
                     },
                     {
                       "id": "461668df-7cab-44ca-a530-dbc82216b478",
                       "label": "P1000566.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7848920822143555
                     },
                     {
                       "id": "f756d45f-c4fe-4181-b7d4-932edb79c0b0",
                       "label": "P1000567.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7803659439086914
                     },
                     {
                       "id": "a0cf623f-11b8-43c0-bc55-8039fed63465",
                       "label": "P1000568.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7725648880004883
                     },
                     {
                       "id": "24e38fd3-4e53-48c1-84cc-a4c36cc1fa53",
                       "label": "P1000569.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8094930648803711
                     },
                     {
                       "id": "d40562b8-160e-45b2-a722-4c0a66b6757d",
                       "label": "P1000570.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7844257354736328
                     },
                     {
                       "id": "88a5bb2e-f97e-4ab5-aed5-cebbdd8a956e",
                       "label": "P1000571.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7758417129516602
                     },
                     {
                       "id": "9b77a50f-21bd-4b1e-9bc8-bc7401efb524",
                       "label": "P1000572.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8068809509277344
                     },
                     {
                       "id": "faaae401-3b69-4529-bf01-ead46223e9da",
                       "label": "P1000573.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8430023193359375
                     },
                     {
                       "id": "7197e739-68ef-4475-b4ff-b0b380da4f83",
                       "label": "P1000574.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7767734527587891
                     },
                     {
                       "id": "cb5503b7-b8e7-422f-bd71-b8a18cc87908",
                       "label": "P1000575.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8145170211791992
                     },
                     {
                       "id": "f43e7a56-c3a0-4d75-9ccb-68884d226b5c",
                       "label": "P1000576.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7862424850463867
                     },
                     {
                       "id": "68083f0f-b8a6-4f42-9511-bc56d6bb82fb",
                       "label": "P1000577.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7979192733764648
                     },
                     {
                       "id": "f97697b1-4f9f-4ff9-a458-56467c85f884",
                       "label": "P1000578.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7981901168823242
                     },
                     {
                       "id": "30c43413-e0aa-418c-b0c4-42a7c86afda2",
                       "label": "P1000579.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7796869277954102
                     },
                     {
                       "id": "dd34d12d-b14b-417c-977d-7b136f1e755e",
                       "label": "P1000580.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.765960693359375
                     },
                     {
                       "id": "8397474d-5c4b-440f-9121-2c5650003aec",
                       "label": "P1000581.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8168249130249023
                     },
                     {
                       "id": "48c5e31d-8c51-4708-a6ef-cd6e4c78d609",
                       "label": "P1000582.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8315887451171875
                     },
                     {
                       "id": "501f0542-c4e1-48c2-b2ed-1fe8a1da198a",
                       "label": "P1000583.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7961263656616211
                     },
                     {
                       "id": "3672bbea-ac24-464a-849f-3fcc2ba167dd",
                       "label": "P1000584.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8884744644165039
                     },
                     {
                       "id": "99de286e-324c-4e88-964f-75c6c8c84d60",
                       "label": "P1000585.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8134365081787109
                     },
                     {
                       "id": "2eb3b488-b691-4f99-bf96-97d4acaa054f",
                       "label": "P1000586.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7922048568725586
                     },
                     {
                       "id": "efc67149-fbad-440a-b2fe-4319feec5d55",
                       "label": "P1000587.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7921237945556641
                     },
                     {
                       "id": "c6d3e75b-a371-4d2f-a79f-1e79c592a140",
                       "label": "P1000588.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7933330535888672
                     },
                     {
                       "id": "70f65deb-9e7a-4f92-a99c-0fdf294f7fdd",
                       "label": "P1000589.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8035268783569336
                     },
                     {
                       "id": "f54243ae-a4f5-4ac6-8202-30d30a91261c",
                       "label": "P1000590.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8170976638793945
                     },
                     {
                       "id": "ab51e1b5-fccd-4b6e-b3f1-b88f9251b07a",
                       "label": "P1000591.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.800572395324707
                     },
                     {
                       "id": "6d906217-6458-439d-b739-9d6f6ed5de1a",
                       "label": "P1000592.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7927703857421875
                     },
                     {
                       "id": "25826c3f-6644-4560-ad1d-90d63d16b977",
                       "label": "P1000593.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8036422729492188
                     },
                     {
                       "id": "d3c0df7e-7e21-4a2f-8347-7b7d34144551",
                       "label": "P1000594.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8312406539916992
                     },
                     {
                       "id": "b3e2ab77-273e-412b-8c02-6807f12f8ae9",
                       "label": "P1000595.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8409929275512695
                     },
                     {
                       "id": "060bda3a-654c-4f72-ac8e-16aaddf4a7e1",
                       "label": "P1000596.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8118019104003906
                     },
                     {
                       "id": "c23823a9-42c4-4546-aeb6-1507a38b9236",
                       "label": "P1000597.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8356647491455078
                     },
                     {
                       "id": "be421136-a8dd-457d-9537-3e8154647824",
                       "label": "P1000598.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7507753372192383
                     },
                     {
                       "id": "77ef26ef-a5e5-49b2-a7fb-0742c5f848b2",
                       "label": "P1000599.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7954301834106445
                     },
                     {
                       "id": "5b80a6a3-e73a-4366-b130-287aa002f237",
                       "label": "P1000600.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7864618301391602
                     },
                     {
                       "id": "7c090df9-afbc-4ebd-9832-ef8da3d44c04",
                       "label": "P1000601.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7706813812255859
                     },
                     {
                       "id": "6d72b786-4718-4d80-a50a-9286ec23c628",
                       "label": "P1000602.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.9040975570678711
                     },
                     {
                       "id": "0e0f4919-f21e-49db-8f91-44bad02fb9e7",
                       "label": "P1000603.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8049325942993164
                     },
                     {
                       "id": "940238cc-aa0c-441a-8a41-35364728e429",
                       "label": "P1000604.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8940935134887695
                     },
                     {
                       "id": "a5a04280-8846-4c91-9a3f-135cacd737b5",
                       "label": "P1000605.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7748327255249023
                     },
                     {
                       "id": "086be05e-e97c-402e-b5f8-901142fade2f",
                       "label": "P1000606.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.828333854675293
                     },
                     {
                       "id": "1fb3558a-ae76-4149-af0d-eec945782861",
                       "label": "P1000607.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8012609481811523
                     },
                     {
                       "id": "14b07096-9ea6-48a7-a2e5-271aed872474",
                       "label": "P1000608.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.8071603775024414
                     }
                   ]
                 }
@@ -864,25 +967,29 @@
                   "id": "0312fd48-7f2c-4cc7-a4ba-ee41ead4ef1c",
                   "label": "Cool-Cities-Attendees-xls.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.04345703125
                 },
                 {
                   "id": "6e6000f2-bb3c-4e1f-900f-b5366a6c6770",
                   "label": "Cool-Cities-Overflow.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.01318359375
                 },
                 {
                   "id": "7c1e12e1-740a-4cdb-9b6a-c66a4d0d425f",
                   "label": "Cool-cities-panel-marquette.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.01708984375
                 },
                 {
                   "id": "6f4b530e-6a43-4631-8784-ef5bedfbfa76",
                   "label": "Copy-of-Cool-Cities-Overflow-xls.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.02978515625
                 }
               ]
             },
@@ -904,151 +1011,176 @@
                   "id": "13564e4d-8d60-4c57-889a-f8d065cd1c26",
                   "label": "2010-Updates.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.0517578125
                 },
                 {
                   "id": "17454352-a46e-4515-84ca-067da09d3615",
                   "label": "Academic-SL-2005.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.02490234375
                 },
                 {
                   "id": "7b8c218c-e209-491b-91b2-1b24887a823f",
                   "label": "All-American-City-Award.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.033203125
                 },
                 {
                   "id": "81f6924c-40df-4ce5-9511-d8c73da3f8e4",
                   "label": "CCI-CEO-Meeting.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.02734375
                 },
                 {
                   "id": "3039bd86-cb4a-4897-b273-93b4a3980434",
                   "label": "Dedications-Groundbreakings-2010.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.03466796875
                 },
                 {
                   "id": "2508bef1-0161-4505-b0bc-0769b99a44e2",
                   "label": "Final-Leadership-Michigan-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 8.13134765625
                 },
                 {
                   "id": "3e88bdf3-eb30-4789-9682-30d208971048",
                   "label": "GOVERNORS-UP-Events-xls.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.033203125
                 },
                 {
                   "id": "032b31d6-5850-4fd7-8cbd-7367b0553a1a",
                   "label": "Intergovernmental-Relations.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 7.2451171875
                 },
                 {
                   "id": "6dd14b4a-e174-439f-a13a-629a0ec14956",
                   "label": "Khoury-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 11.59326171875
                 },
                 {
                   "id": "b64fef12-3e74-4f15-ae77-d77c308fface",
                   "label": "LeadAcadJan6.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 3.40283203125
                 },
                 {
                   "id": "2d421c3a-c412-4f5c-93c6-a24c88b707f2",
                   "label": "Logging-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 1.287109375
                 },
                 {
                   "id": "938b88fd-83d3-4be6-aa32-71a19b74a0b1",
                   "label": "Negaunee-Regional-Dispatch-Center.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.19482421875
                 },
                 {
                   "id": "f057bc7a-5805-4a67-8ca2-3821c0707449",
                   "label": "Revised-UP-Events2.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.0205078125
                 },
                 {
                   "id": "88468acc-c3ef-480f-8172-c396f5d70649",
                   "label": "SERVICE-SHARING-MEETINGS-SUMMARY.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.04833984375
                 },
                 {
                   "id": "58092af3-d330-42ff-87c9-9792f2cd0b09",
                   "label": "UP-EVENTS-2005.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.04541015625
                 },
                 {
                   "id": "540b03c1-d170-4846-9139-7b51b540107d",
                   "label": "UP-Events-by-County.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.01904296875
                 },
                 {
                   "id": "1a9fca5e-dc8a-43eb-84b4-c4fa24a59797",
                   "label": "UP-accomplishments.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.0341796875
                 },
                 {
                   "id": "5edd8fe9-0dd3-4ce0-a3ca-b0cd7b459481",
                   "label": "USFS-Memo.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.0263671875
                 },
                 {
                   "id": "e6121271-2e44-4d6b-8c8b-c7157b942e19",
                   "label": "Updated-Govs-UP-Events.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.02001953125
                 },
                 {
                   "id": "9a847fe6-33cc-4f8c-81fd-9c42619744ac",
                   "label": "Upper-Peninsula-Hot-Topics.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.0615234375
                 },
                 {
                   "id": "dafc2bc7-2081-4882-8763-2cce2ae59f4b",
                   "label": "Viosport-briefing.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.025390625
                 },
                 {
                   "id": "b839983f-3b05-4ae3-8831-d4b0f012b76b",
                   "label": "goals-resp.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.03662109375
                 },
                 {
                   "id": "557195d2-7554-4581-9957-e00278d3af2e",
                   "label": "kipling-meeting-notes.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.037109375
                 },
                 {
                   "id": "25fbad5c-1043-4539-a9b7-1600c1bfbc7c",
                   "label": "smurfit-stone.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.03125
                 },
                 {
                   "id": "6f196df8-8612-40be-9882-e15a8ac6aec5",
                   "label": "up-CHAMBER-CONTACTS.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.0390625
                 }
               ]
             },
@@ -1086,31 +1218,36 @@
                       "id": "70d3312c-f3ae-42ee-b4e4-06905644327a",
                       "label": "Briefing-Format.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.021484375
                     },
                     {
                       "id": "16d6595e-4675-4e5a-9d10-06c317e602cd",
                       "label": "Luncheon-8-21-Briefing-Format.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.03125
                     },
                     {
                       "id": "48712dd2-bb58-4716-80ad-e8e839afe59b",
                       "label": "governors-up-tour-schedule-tentative.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.03466796875
                     },
                     {
                       "id": "1dd6fb3c-5bb5-4610-b8e6-9cabb580c24f",
                       "label": "governors-up-tour-schedule.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.03857421875
                     },
                     {
                       "id": "cdf81782-ec5a-4ded-bd2a-074a011fd53f",
                       "label": "governors-up-tour-schedule2.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.056640625
                     }
                   ]
                 },
@@ -1151,97 +1288,113 @@
                           "id": "1adf6523-c311-4eab-8aac-d5ed82a0fb58",
                           "label": "August-2005.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.0283203125
                         },
                         {
                           "id": "6da5567a-a26f-4aa3-8712-e8cb91c99ee0",
                           "label": "August-20052.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.03173828125
                         },
                         {
                           "id": "228cd181-73ab-4abd-a951-cb526816581c",
                           "label": "Baldini.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.0263671875
                         },
                         {
                           "id": "561fe044-c4d3-49f1-ac2b-9a48c9750715",
                           "label": "Briefing-2-17-05-Hockey-NMU-vs-MTU.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.02197265625
                         },
                         {
                           "id": "bce0b0e4-3226-43f2-ac93-9bb1bbb50368",
                           "label": "December-2005-027.jpg",
                           "format": "Exchangeable Image File Format (Compressed) 2.2",
-                          "puid": "x-fmt/391"
+                          "puid": "x-fmt/391",
+                          "size": 0.18732166290283203
                         },
                         {
                           "id": "86489154-8ac4-4c70-893e-7217d90581fe",
                           "label": "December-2005-076.jpg",
                           "format": "Exchangeable Image File Format (Compressed) 2.2",
-                          "puid": "x-fmt/391"
+                          "puid": "x-fmt/391",
+                          "size": 0.3082914352416992
                         },
                         {
                           "id": "adee224e-683d-40a9-8d40-dca105407d92",
                           "label": "Eagle-River-Community-BBQ.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.02978515625
                         },
                         {
                           "id": "996feff5-173c-4b68-84d3-93ea53f214c3",
                           "label": "Feb18-19-2005.rtf",
                           "format": "RTF 1.7",
-                          "puid": "fmt/52"
+                          "puid": "fmt/52",
+                          "size": 0.026185989379882812
                         },
                         {
                           "id": "75ea4441-a3ba-4c66-aec9-30c1a2f81a34",
                           "label": "February-18-2005-Alpha-List-Final.xls",
                           "format": "Excel 97 Workbook",
-                          "puid": "fmt/61"
+                          "puid": "fmt/61",
+                          "size": 0.03125
                         },
                         {
                           "id": "7fcc13da-e5d2-47d1-9917-e1914c8f83cc",
                           "label": "February-18-2005-Alpha-List.xls",
                           "format": "Excel 97 Workbook",
-                          "puid": "fmt/61"
+                          "puid": "fmt/61",
+                          "size": 0.03125
                         },
                         {
                           "id": "14a87165-ba8b-4642-af58-a78941518598",
                           "label": "List-of-Govs-Community-Meeting-2-18-05.xls",
                           "format": "Excel 97 Workbook",
-                          "puid": "fmt/61"
+                          "puid": "fmt/61",
+                          "size": 0.02880859375
                         },
                         {
                           "id": "69443f0e-6891-4b77-afbe-69714d4b9c05",
                           "label": "Raildroad-Issue.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.02978515625
                         },
                         {
                           "id": "dbb284aa-48d1-40de-9d5c-f73bf2a61619",
                           "label": "Saturday-Trip.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.0263671875
                         },
                         {
                           "id": "f60a55aa-dd28-42f9-a9e6-f4ef552d7090",
                           "label": "UP-Sheriffs-Meeting.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.03369140625
                         },
                         {
                           "id": "f7e605d7-5302-424e-9c69-864c6bd7dc9a",
                           "label": "stacys-info-for-oct-15.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.201171875
                         },
                         {
                           "id": "d2d8260f-1a38-40e2-9ca5-d4d376f28f9b",
                           "label": "stacys-info-for-oct-15.docm",
                           "format": "Macro enabled Microsoft Word Document OOXML",
-                          "puid": "fmt/523"
+                          "puid": "fmt/523",
+                          "size": 0.09428215026855469
                         }
                       ]
                     },
@@ -1262,115 +1415,134 @@
                           "id": "fbcb966d-799a-4a3d-bed1-cbec3f7e1898",
                           "label": "August-2005.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.0283203125
                         },
                         {
                           "id": "d9c5a5ee-6d48-4449-ba27-d012ba7b8351",
                           "label": "Briefing-2-17-05-WNMU.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.02099609375
                         },
                         {
                           "id": "adaf98fb-8b4e-4f1c-8cf3-18026cd192ed",
                           "label": "Channel-5-10-TapeBriefing.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.02197265625
                         },
                         {
                           "id": "c796e845-7cf5-493d-a369-00e580bc7f3b",
                           "label": "Channel6-Briefing.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.021484375
                         },
                         {
                           "id": "cde87da1-3981-45ce-9e64-a6272bc150a1",
                           "label": "List-of-Govs-Community-Meeting-2-17-05.xls",
                           "format": "Excel 97 Workbook",
-                          "puid": "fmt/61"
+                          "puid": "fmt/61",
+                          "size": 0.0283203125
                         },
                         {
                           "id": "9e20a2fe-18cc-4d1e-a2f4-430feae7ab46",
                           "label": "MEA-Briefing.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.02099609375
                         },
                         {
                           "id": "04579e84-0073-450a-b551-5f97e5302733",
                           "label": "MTUvsNMU-Hockey.rtf",
                           "format": "RTF 1.7",
-                          "puid": "fmt/52"
+                          "puid": "fmt/52",
+                          "size": 0.02553844451904297
                         },
                         {
                           "id": "e60ef089-94e8-4261-9a50-33d5a9ca35dc",
                           "label": "Mining-Journal-Reception.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.021484375
                         },
                         {
                           "id": "f546db3f-e04e-40db-9b3e-fd226ebf6e2d",
                           "label": "Mushers-Banquet.rtf",
                           "format": "RTF 1.7",
-                          "puid": "fmt/52"
+                          "puid": "fmt/52",
+                          "size": 0.029611587524414062
                         },
                         {
                           "id": "f1345d7c-3f39-470f-b945-da091d8b5f84",
                           "label": "Radio-InterviewBriefing.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.02197265625
                         },
                         {
                           "id": "d33bb877-b513-46ce-91a8-02f4c52441ed",
                           "label": "State-of-State-Event.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.0224609375
                         },
                         {
                           "id": "00a94dd2-4a7e-43dc-ab38-ca2601b4eafe",
                           "label": "Student-List-for-2-18-05-final.xls",
                           "format": "Excel 97 Workbook",
-                          "puid": "fmt/61"
+                          "puid": "fmt/61",
+                          "size": 0.02001953125
                         },
                         {
                           "id": "cf1d1a63-b7e9-4498-8e92-7804bc144c44",
                           "label": "Student-List-for-2-18-05.xls",
                           "format": "Excel 97 Workbook",
-                          "puid": "fmt/61"
+                          "puid": "fmt/61",
+                          "size": 0.02001953125
                         },
                         {
                           "id": "995878a4-48e2-4685-bfe1-254aaeb04132",
                           "label": "StudentPhoto-Op.rtf",
                           "format": "RTF 1.7",
-                          "puid": "fmt/52"
+                          "puid": "fmt/52",
+                          "size": 0.09092235565185547
                         },
                         {
                           "id": "741b89ad-afcf-4e78-bbf4-d3445d973b94",
                           "label": "Thank-yous-for-UP-200.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.03662109375
                         },
                         {
                           "id": "0d6d11f5-cb26-45ad-85ef-a42f81c9de60",
                           "label": "UP-200-Briefing.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.0283203125
                         },
                         {
                           "id": "ed5e4a1e-f8f6-4511-98e3-87e19d99f6a2",
                           "label": "UP-200-TOdo.xls",
                           "format": "Excel 97 Workbook",
-                          "puid": "fmt/61"
+                          "puid": "fmt/61",
+                          "size": 0.0146484375
                         },
                         {
                           "id": "af96037d-13ec-4e8c-8087-64a06e186c96",
                           "label": "UP-Roadbuilders.rtf",
                           "format": "RTF 1.7",
-                          "puid": "fmt/52"
+                          "puid": "fmt/52",
+                          "size": 0.024362564086914062
                         },
                         {
                           "id": "cdf0d9a1-8e9c-4a2f-bed0-cdf8897053cb",
                           "label": "addresses.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.02587890625
                         },
                         {
                           "id": "6f8389e8-5af4-40f1-9dbc-e7db0ffdf548",
@@ -1387,49 +1559,57 @@
                               "id": "d024b75b-6743-48b8-af2a-406300a79492",
                               "label": "Channel-5-10-TapeBriefing.doc",
                               "format": "Microsoft Word Document 97-2003",
-                              "puid": "fmt/40"
+                              "puid": "fmt/40",
+                              "size": 0.02197265625
                             },
                             {
                               "id": "9892f551-2d10-416c-a2a8-2a03035ae93a",
                               "label": "Channel6-Briefing.doc",
                               "format": "Microsoft Word Document 97-2003",
-                              "puid": "fmt/40"
+                              "puid": "fmt/40",
+                              "size": 0.021484375
                             },
                             {
                               "id": "6e5234ab-1901-46b8-883e-75cef99cc59a",
                               "label": "MTUvsNMU-Hockey.rtf",
                               "format": "RTF 1.7",
-                              "puid": "fmt/52"
+                              "puid": "fmt/52",
+                              "size": 0.021958351135253906
                             },
                             {
                               "id": "5ff22c6b-8d8d-4135-912d-49cf93f2c0f0",
                               "label": "Mushers-Banquet.rtf",
                               "format": "RTF 1.7",
-                              "puid": "fmt/52"
+                              "puid": "fmt/52",
+                              "size": 0.027553558349609375
                             },
                             {
                               "id": "b80d9661-332a-4c3e-be8d-35fafc56fff3",
                               "label": "Radio-InterviewBriefing.doc",
                               "format": "Microsoft Word Document 97-2003",
-                              "puid": "fmt/40"
+                              "puid": "fmt/40",
+                              "size": 0.02197265625
                             },
                             {
                               "id": "6196dc90-41fd-4494-ad51-b8c9fa96851f",
                               "label": "UP-Higher-Ed.rtf",
                               "format": "RTF 1.7",
-                              "puid": "fmt/52"
+                              "puid": "fmt/52",
+                              "size": 0.09070301055908203
                             },
                             {
                               "id": "cb810a02-00de-40dc-bdfc-67ef868752ee",
                               "label": "UP-Roadbuilders.rtf",
                               "format": "RTF 1.7",
-                              "puid": "fmt/52"
+                              "puid": "fmt/52",
+                              "size": 0.019263267517089844
                             },
                             {
                               "id": "a8edcb1d-611d-4d94-99f1-958b347123a2",
                               "label": "addresses.doc",
                               "format": "Microsoft Word Document 97-2003",
-                              "puid": "fmt/40"
+                              "puid": "fmt/40",
+                              "size": 0.02587890625
                             }
                           ]
                         }
@@ -1450,127 +1630,148 @@
                           "id": "9588bfe2-01d4-4f08-9b8e-3eaad2c82ff9",
                           "label": "Brinzo.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.033203125
                         },
                         {
                           "id": "8d4d91aa-316f-472f-b966-e701def05a08",
                           "label": "CCI-Reception.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.02783203125
                         },
                         {
                           "id": "12630596-c19e-45d8-84ac-f9b1ea4f2c3d",
                           "label": "HOT-TOPICS-Stacy.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.09228515625
                         },
                         {
                           "id": "43144f4f-3301-465f-91b8-5c90b152a5ba",
                           "label": "HOT-TOPICS.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.07666015625
                         },
                         {
                           "id": "b389f053-a87d-418b-bac2-8b864775ef97",
                           "label": "Holiday-Reception-w-State-Employees.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.02978515625
                         },
                         {
                           "id": "c1a8777c-3e8a-4e60-b9c4-6b39a1e3d864",
                           "label": "Jacobetti.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.0458984375
                         },
                         {
                           "id": "abb2c7fd-7192-4005-942a-e9970e44bb0e",
                           "label": "MTEC-Smartzone.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.166015625
                         },
                         {
                           "id": "963b83eb-5e78-4d49-bad7-a4275b23f5fb",
                           "label": "Media-Meet.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.02490234375
                         },
                         {
                           "id": "2a3a96f2-0398-4197-b39e-d9de872c5a0c",
                           "label": "Mqt-Dem-Reception.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.0283203125
                         },
                         {
                           "id": "5cff93c5-9534-4019-abb2-450e54177333",
                           "label": "Pioneer-Surgical-Jobs-Stop.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.03369140625
                         },
                         {
                           "id": "b31461ec-3baf-4f20-b557-8f973aeb9d77",
                           "label": "Precision-Edge-Jobs-Stop.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.03662109375
                         },
                         {
                           "id": "ee10e602-11a6-4e09-bbca-87b7a643c179",
                           "label": "Radio-Call-Houghton.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.02587890625
                         },
                         {
                           "id": "8aa7103c-f139-4a47-af80-da9254c0dd7c",
                           "label": "Sheriffs.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.0302734375
                         },
                         {
                           "id": "27f24a9f-7937-4b6b-9e19-119f592e53f1",
                           "label": "Soo-Evening-News.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.0244140625
                         },
                         {
                           "id": "3a9792fe-8538-4c0e-aade-86dc5e19d3b9",
                           "label": "Speed-Skating.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.03076171875
                         },
                         {
                           "id": "e997cc16-a01e-4ce0-aff2-093f36b99055",
                           "label": "Tellurex-Jobs-Stop.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.03564453125
                         },
                         {
                           "id": "20676ce4-29f2-42cf-81df-2e19cf5cb3ab",
                           "label": "Thank-you-list.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.0400390625
                         },
                         {
                           "id": "493fb126-0d9b-4d78-a579-8d45f74792ee",
                           "label": "WSOO.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.025390625
                         },
                         {
                           "id": "be9e0242-3434-4c06-b4bb-55d1e09304c5",
                           "label": "Walt-Lindala.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.0244140625
                         },
                         {
                           "id": "ccf7d3eb-28f0-4701-b314-2c5ed4e024b3",
                           "label": "dec-schedule.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.0322265625
                         },
                         {
                           "id": "825d1146-1f8a-4039-9371-598b1fefcabc",
                           "label": "skeleton-schedule.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.0322265625
                         },
                         {
                           "id": "7fa523ad-dbef-4b56-9735-1f9d909240e2",
@@ -1587,13 +1788,15 @@
                               "id": "80d5379d-7b42-48ba-a601-a377be775b76",
                               "label": "Document-Scrap-UPDATE-ON-THE-MA.shs",
                               "format": "Generic AIFF",
-                              "extension": ".aif"
+                              "extension": ".aif",
+                              "size": 0.076171875
                             },
                             {
                               "id": "395842f5-a575-45c7-abc0-dce0781139a7",
                               "label": "Hot-topics.doc",
                               "format": "Microsoft Word Document 97-2003",
-                              "puid": "fmt/40"
+                              "puid": "fmt/40",
+                              "size": 0.0419921875
                             }
                           ]
                         }
@@ -1635,133 +1838,155 @@
                           "id": "0a07027f-d80f-416b-97f7-93160134b0d6",
                           "label": "Ag-Solutions-1.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.029296875
                         },
                         {
                           "id": "b5542de6-a0bd-42f6-afb5-452b536f368e",
                           "label": "Ag-Solutions-Attach-1.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.0302734375
                         },
                         {
                           "id": "a6186720-5430-462a-a28b-eb53e7276512",
                           "label": "Ag-Solutions-Attach-2.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.029296875
                         },
                         {
                           "id": "a448c397-795a-455b-9cb5-e68c8a3ac677",
                           "label": "Attendance-Listing-Fair-Luncheon.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.2744140625
                         },
                         {
                           "id": "ae2a1475-940f-41c2-a66b-224a05e401a0",
                           "label": "EMP-BusAug06.ppt",
                           "format": "Powerpoint 97-2002",
-                          "puid": "fmt/126"
+                          "puid": "fmt/126",
+                          "size": 0.52001953125
                         },
                         {
                           "id": "8ce1a0d8-8feb-4956-8458-36fb8cb7db72",
                           "label": "Fair-growing-up-foresters-exhibit.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.08056640625
                         },
                         {
                           "id": "edaf7a5a-6cc2-494d-a816-7841e1d9057d",
                           "label": "Issues-and-Answers.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.02685546875
                         },
                         {
                           "id": "05fc75fd-6f60-4534-903d-fd4c446c4d0b",
                           "label": "OSF-St-Francis-Hospital.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.04833984375
                         },
                         {
                           "id": "1bdff87b-9632-444f-b909-50b0063f277e",
                           "label": "Road-Projects-Photo-Op.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.037109375
                         },
                         {
                           "id": "f48dc0ac-3596-4f5a-915d-925c3d978b13",
                           "label": "Schedule-Aug-17-18.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.04248046875
                         },
                         {
                           "id": "89ddb9ea-36cf-45b6-8a0a-690a5e918abf",
                           "label": "Systems-Control.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.03076171875
                         },
                         {
                           "id": "eca4896c-f745-47a1-8262-1ac29168b15b",
                           "label": "Thomas-St-Onge-Musuem.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.04638671875
                         },
                         {
                           "id": "86144a4a-8602-4d3e-97de-5cf38a2d7b0e",
                           "label": "UP-State-Fair-Governors-Luncheon.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.0810546875
                         },
                         {
                           "id": "4d30eaf2-055e-4f73-bc64-74233e73aa7f",
                           "label": "UP-State-Fair-Luncheon-SPEECH-Info.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.02001953125
                         },
                         {
                           "id": "d1fd867a-fda7-45d2-a8ed-f4f44b825f9e",
                           "label": "hospital-5.jpg",
                           "format": "JPEG 1.01",
-                          "puid": "fmt/43"
+                          "puid": "fmt/43",
+                          "size": 0.4102621078491211
                         },
                         {
                           "id": "db28ed82-029d-4c43-9b1d-fa11829a9f24",
                           "label": "hospital-attach-3.jpg",
                           "format": "JPEG 1.01",
-                          "puid": "fmt/43"
+                          "puid": "fmt/43",
+                          "size": 0.2659187316894531
                         },
                         {
                           "id": "63dc34fe-9a1e-4a4f-906c-6ab6a4b34631",
                           "label": "hospital-attach-4.jpg",
                           "format": "JPEG 1.01",
-                          "puid": "fmt/43"
+                          "puid": "fmt/43",
+                          "size": 0.3942089080810547
                         },
                         {
                           "id": "df9e5388-5a0a-49f7-9aee-531f7ccdc7e9",
                           "label": "hospital-attach1.jpg",
                           "format": "JPEG 1.01",
-                          "puid": "fmt/43"
+                          "puid": "fmt/43",
+                          "size": 0.3028888702392578
                         },
                         {
                           "id": "b2ac4479-96a1-4faf-b0b7-e32bd65a1dc9",
                           "label": "hospital-attach2.jpg",
                           "format": "JPEG 1.01",
-                          "puid": "fmt/43"
+                          "puid": "fmt/43",
+                          "size": 0.2250232696533203
                         },
                         {
                           "id": "7735175b-a3ae-4c16-a9af-7a55367f0f84",
                           "label": "hospital-map-2.jpg",
                           "format": "JPEG 1.01",
-                          "puid": "fmt/43"
+                          "puid": "fmt/43",
+                          "size": 0.2515392303466797
                         },
                         {
                           "id": "d4a3ae3a-8a27-4bef-b324-956fe5df8282",
                           "label": "hospital-map.jpg",
                           "format": "JPEG 1.01",
-                          "puid": "fmt/43"
+                          "puid": "fmt/43",
+                          "size": 0.3233680725097656
                         },
                         {
                           "id": "0b106727-712c-46b8-8dce-55cab5518280",
                           "label": "skelton-schedule-draft.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.041015625
                         }
                       ]
                     },
@@ -1781,55 +2006,64 @@
                           "id": "1379a73c-b1b4-4dae-852d-e1045812746b",
                           "label": "2nd-annual-Veterans-Ride.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.025390625
                         },
                         {
                           "id": "a51a71cf-6887-4691-b7d0-945598df2fd5",
                           "label": "Governors-summer-06-up-trip1.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.03759765625
                         },
                         {
                           "id": "1af5ea2f-e411-4f3e-b3e9-d7603ad21e3c",
                           "label": "Issues-and-Answers.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.02685546875
                         },
                         {
                           "id": "45e19805-ebd5-4ce8-b7c5-60bf2f1f545f",
                           "label": "May-30.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.0400390625
                         },
                         {
                           "id": "39f93859-661a-4ae8-8a00-7be3e81ff16d",
                           "label": "RSVP-State-Employee-Rec.xls",
                           "format": "Excel 97 Workbook",
-                          "puid": "fmt/61"
+                          "puid": "fmt/61",
+                          "size": 0.0166015625
                         },
                         {
                           "id": "1e2d3c50-e569-46bd-94b4-6be3040136ec",
                           "label": "Schedule-Aug-17-18.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.04052734375
                         },
                         {
                           "id": "06d8687e-4e78-4324-adbc-06f6d996ada6",
                           "label": "Summer-06-up-trip1.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.03759765625
                         },
                         {
                           "id": "d207dcf6-3612-4898-9ba0-523b49ffd49f",
                           "label": "letter-presentation-311.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.02392578125
                         },
                         {
                           "id": "189584fd-3b38-49fb-b9dd-d32abfa3c207",
                           "label": "manistique-diner-meet-and-greet.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.02294921875
                         }
                       ]
                     },
@@ -1847,31 +2081,36 @@
                           "id": "7407c806-6f70-4f3e-aa3d-080d7851ceb9",
                           "label": "Daily-News-Interview-Hannahville.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.02587890625
                         },
                         {
                           "id": "43cf44c1-ccce-4e4f-87fe-88fc3c85debd",
                           "label": "Daily-Press-Interview.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.02294921875
                         },
                         {
                           "id": "dd25b8c3-bc2f-4aea-ad99-d8dc4057f087",
                           "label": "MIX-106-Interview.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.02294921875
                         },
                         {
                           "id": "b6d83d7b-b24b-475e-af9f-9e2311f6df08",
                           "label": "What-is-MCAC.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.23486328125
                         },
                         {
                           "id": "59768f7f-f592-4211-84d6-48298ac409d5",
                           "label": "minimum-wage-info.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.04443359375
                         }
                       ]
                     },
@@ -1889,19 +2128,22 @@
                           "id": "8f8429b5-f89d-4f49-ba4a-1f1e3ef2cacb",
                           "label": "Employee-Appreciation.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.03076171875
                         },
                         {
                           "id": "ee571b4f-2563-43fd-9268-247e1ce735ab",
                           "label": "SERA-attachment.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.0263671875
                         },
                         {
                           "id": "ae7960a5-bf2b-4246-a665-de5e864e9b13",
                           "label": "SERA.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.0283203125
                         }
                       ]
                     }
@@ -1923,31 +2165,36 @@
                       "id": "3d31cc17-5539-4d28-84c3-22c5b4b7ca88",
                       "label": "Detailed-Western-Lime-Agenda-2.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02001953125
                     },
                     {
                       "id": "77e60beb-4896-4f3b-9cf2-36f307136d27",
                       "label": "Govs-luncheon-Attendees.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.63134765625
                     },
                     {
                       "id": "f0ae0d82-42c0-457a-b8d5-2328521bfe4e",
                       "label": "Open-House-Invitations.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.0302734375
                     },
                     {
                       "id": "fbc9698f-0f15-40d8-8206-c92ffb9ac87d",
                       "label": "UP-State-Fair-Governors-Luncheon-2007.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.08203125
                     },
                     {
                       "id": "30b58a1d-8c9e-4fd0-9695-099c5b6717ec",
                       "label": "Vet-of-the-Year-Background-2007.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0224609375
                     }
                   ]
                 }
@@ -1982,73 +2229,85 @@
                       "id": "4242a664-34ce-4b46-8cb4-61d60d658e45",
                       "label": "Bridge-Walk-Overview-2.jpg",
                       "format": "JPEG 1.01",
-                      "puid": "fmt/43"
+                      "puid": "fmt/43",
+                      "size": 0.09985733032226562
                     },
                     {
                       "id": "b8a1356e-4563-4a66-b952-099e03de6f18",
                       "label": "Gov-Mackinac-Island.jpg",
                       "format": "JPEG 1.02",
-                      "puid": "fmt/44"
+                      "puid": "fmt/44",
+                      "size": 2.651556968688965
                     },
                     {
                       "id": "31335337-5557-4658-bc84-45dde970ae17",
                       "label": "Governor-Granholm-Press-Photo.jpg",
                       "format": "JPEG 1.01",
-                      "puid": "fmt/43"
+                      "puid": "fmt/43",
+                      "size": 3.1488656997680664
                     },
                     {
                       "id": "4cf9172c-d9e1-4a69-ae76-ab05fe9bd425",
                       "label": "Governor-on-porch.jpg",
                       "format": "JPEG 1.01",
-                      "puid": "fmt/43"
+                      "puid": "fmt/43",
+                      "size": 0.08105278015136719
                     },
                     {
                       "id": "03ca0930-3e51-4f69-a2df-1e598132c380",
                       "label": "Governor-with-child.jpg",
                       "format": "JPEG 1.01",
-                      "puid": "fmt/43"
+                      "puid": "fmt/43",
+                      "size": 0.06903934478759766
                     },
                     {
                       "id": "5518d947-40cd-4999-b320-06c0a41c21be",
                       "label": "Scan0002.jpg",
                       "format": "JPEG 1.02",
-                      "puid": "fmt/44"
+                      "puid": "fmt/44",
+                      "size": 2.8761367797851562
                     },
                     {
                       "id": "68862e72-c8bc-4c44-a216-7cc527b7a3fc",
                       "label": "Scan0003.jpg",
                       "format": "JPEG 1.02",
-                      "puid": "fmt/44"
+                      "puid": "fmt/44",
+                      "size": 2.986827850341797
                     },
                     {
                       "id": "84cea3d5-9142-4a66-8880-cff5ddf0deb1",
                       "label": "Scan0004.jpg",
                       "format": "JPEG 1.02",
-                      "puid": "fmt/44"
+                      "puid": "fmt/44",
+                      "size": 2.8685474395751953
                     },
                     {
                       "id": "e8268c00-579d-4c51-aa31-bc8e2c052917",
                       "label": "Scan0005.jpg",
                       "format": "JPEG 1.02",
-                      "puid": "fmt/44"
+                      "puid": "fmt/44",
+                      "size": 2.816020965576172
                     },
                     {
                       "id": "7b38982a-d607-42f1-b5ec-0ec5401cc98d",
                       "label": "Scan0006.jpg",
                       "format": "JPEG 1.02",
-                      "puid": "fmt/44"
+                      "puid": "fmt/44",
+                      "size": 2.466215133666992
                     },
                     {
                       "id": "cda74914-1572-429c-af65-7aa061e64b75",
                       "label": "Scan0007.jpg",
                       "format": "JPEG 1.02",
-                      "puid": "fmt/44"
+                      "puid": "fmt/44",
+                      "size": 2.4286623001098633
                     },
                     {
                       "id": "962a887a-9bea-4dd0-b66b-e20a6b1c02bf",
                       "label": "bridge-walk.jpg",
                       "format": "JPEG 1.01",
-                      "puid": "fmt/43"
+                      "puid": "fmt/43",
+                      "size": 0.03153800964355469
                     }
                   ]
                 },
@@ -2066,19 +2325,22 @@
                       "id": "ff69f01d-6507-43da-a3e1-e91213b4075f",
                       "label": "Tristan-and-the-Gov-001.jpg",
                       "format": "JPEG 1.01",
-                      "puid": "fmt/43"
+                      "puid": "fmt/43",
+                      "size": 0.06311321258544922
                     },
                     {
                       "id": "456f0ea8-b7f7-4b1d-ab87-f86a3b9ff248",
                       "label": "Tristan-and-the-Gov-002.jpg",
                       "format": "JPEG 1.01",
-                      "puid": "fmt/43"
+                      "puid": "fmt/43",
+                      "size": 0.19769001007080078
                     },
                     {
                       "id": "eef8eae4-6f9a-444f-a3d7-13a1d136a191",
                       "label": "Tristan-and-the-Gov.jpg",
                       "format": "JPEG 1.01",
-                      "puid": "fmt/43"
+                      "puid": "fmt/43",
+                      "size": 0.07115650177001953
                     }
                   ]
                 },
@@ -2100,437 +2362,519 @@
                       "id": "36fb3a10-c55d-4bd3-9cc8-019153768b43",
                       "label": "101505-govn-002.jpg",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.26255130767822266
                     },
                     {
                       "id": "7128291d-2bda-467a-baba-5fe7498c9730",
                       "label": "11-8-04-006.jpg",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.1508474349975586
                     },
                     {
                       "id": "426826a7-5ba2-4fc9-b184-88325d148138",
                       "label": "Arnold-Transit.JPG",
                       "format": "JPEG 1.01",
-                      "puid": "fmt/43"
+                      "puid": "fmt/43",
+                      "size": 1.6122140884399414
                     },
                     {
                       "id": "eb2fd7d9-8615-4461-a9d0-717a09f1248a",
                       "label": "Bridge-Walk-101.JPG",
                       "format": "Generic AIFF",
-                      "extension": ".aif"
+                      "extension": ".aif",
+                      "size": 1.546875
                     },
                     {
                       "id": "1a075e38-9446-43c3-bc64-c9bbf01bb838",
                       "label": "DI-00251-136.JPG",
                       "format": "JPEG 1.01",
-                      "puid": "fmt/43"
+                      "puid": "fmt/43",
+                      "size": 1.310537338256836
                     },
                     {
                       "id": "e9f590c8-8f11-43cc-8cc8-f71d799061c9",
                       "label": "DI-00251-169.JPG",
                       "format": "JPEG 1.02",
-                      "puid": "fmt/44"
+                      "puid": "fmt/44",
+                      "size": 0.4252357482910156
                     },
                     {
                       "id": "4a0a06e8-5576-4d25-aa84-d97b22ad204d",
-                      "label": "DI-00337-033.JPG"
+                      "label": "DI-00337-033.JPG",
+                      "size": 1.6778106689453125
                     },
                     {
                       "id": "99ec6d3c-a1a3-4f08-b300-18c024aaf310",
-                      "label": "DI-00337-034.JPG"
+                      "label": "DI-00337-034.JPG",
+                      "size": 1.690093994140625
                     },
                     {
                       "id": "7d26fa73-8417-42fb-856c-07a7e0841ccc",
                       "label": "DI-00337-038.JPG",
                       "format": "JPEG 1.02",
-                      "puid": "fmt/44"
+                      "puid": "fmt/44",
+                      "size": 0.45624446868896484
                     },
                     {
                       "id": "dd1f2850-f5b5-4ec5-ae45-9772a62883a9",
                       "label": "DI-00337-039.JPG",
                       "format": "JPEG 1.02",
-                      "puid": "fmt/44"
+                      "puid": "fmt/44",
+                      "size": 0.4790630340576172
                     },
                     {
                       "id": "bc521ce2-291c-4271-a77b-177997e706ac",
                       "label": "DI-00337-047.JPG",
                       "format": "JPEG 1.02",
-                      "puid": "fmt/44"
+                      "puid": "fmt/44",
+                      "size": 0.46386051177978516
                     },
                     {
                       "id": "a6467b12-dc28-4435-808a-cac2ae1085c8",
                       "label": "DI-00337-082.JPG",
                       "format": "JPEG 1.02",
-                      "puid": "fmt/44"
+                      "puid": "fmt/44",
+                      "size": 0.3663969039916992
                     },
                     {
                       "id": "3926c73e-8c1b-496c-9037-593c7d069630",
                       "label": "DI-00337-156.JPG",
                       "format": "JPEG 1.02",
-                      "puid": "fmt/44"
+                      "puid": "fmt/44",
+                      "size": 0.32360172271728516
                     },
                     {
                       "id": "5f7348ac-8244-49c0-abbe-76a485d37271",
                       "label": "DI-00337-157.JPG",
                       "format": "JPEG 1.02",
-                      "puid": "fmt/44"
+                      "puid": "fmt/44",
+                      "size": 0.34370899200439453
                     },
                     {
                       "id": "37b59115-4ecd-4d72-be12-9541be2abcb2",
                       "label": "DI-00337-236.JPG",
                       "format": "JPEG 1.02",
-                      "puid": "fmt/44"
+                      "puid": "fmt/44",
+                      "size": 0.41729068756103516
                     },
                     {
                       "id": "0b5d130f-1aa1-40a8-9a78-8f2a55adcd07",
                       "label": "DI-00337-254.JPG",
                       "format": "JPEG 1.02",
-                      "puid": "fmt/44"
+                      "puid": "fmt/44",
+                      "size": 0.44594573974609375
                     },
                     {
                       "id": "524bc610-82d8-4e58-ae87-a9953bca8141",
                       "label": "DI-00528-019.jpg",
                       "format": "JPEG 1.02",
-                      "puid": "fmt/44"
+                      "puid": "fmt/44",
+                      "size": 0.43531322479248047
                     },
                     {
                       "id": "cd8cd995-90df-4989-9dd4-a3ddb02ffd40",
                       "label": "DI-00528-020.jpg",
                       "format": "JPEG 1.02",
-                      "puid": "fmt/44"
+                      "puid": "fmt/44",
+                      "size": 0.4439363479614258
                     },
                     {
                       "id": "13f743fc-465c-4566-b981-eb9efb0d02d1",
                       "label": "DI-00551-254.jpg",
                       "format": "JPEG 1.02",
-                      "puid": "fmt/44"
+                      "puid": "fmt/44",
+                      "size": 0.4545326232910156
                     },
                     {
                       "id": "f97d556c-6b14-4324-8903-79773b043695",
-                      "label": "DSC-0020.JPG"
+                      "label": "DSC-0020.JPG",
+                      "size": 2.4220075607299805
                     },
                     {
                       "id": "d930552a-e387-4a64-baee-3bf94c633fa1",
-                      "label": "DSC-0026.JPG"
+                      "label": "DSC-0026.JPG",
+                      "size": 2.373368263244629
                     },
                     {
                       "id": "bb66cc1d-71f1-4c46-ab4e-d196f74d8d6d",
-                      "label": "DSC-0027.JPG"
+                      "label": "DSC-0027.JPG",
+                      "size": 2.2718429565429688
                     },
                     {
                       "id": "bd2cf859-def3-41d7-bde5-0bb283158284",
-                      "label": "DSC-0029.JPG"
+                      "label": "DSC-0029.JPG",
+                      "size": 2.2628393173217773
                     },
                     {
                       "id": "7b18e227-cc5e-49ac-9bd6-f48dfc47c772",
-                      "label": "DSC-0031.JPG"
+                      "label": "DSC-0031.JPG",
+                      "size": 2.668882369995117
                     },
                     {
                       "id": "589286bf-eb5a-4175-bd90-eb04ab021b75",
-                      "label": "DSC-0041.JPG"
+                      "label": "DSC-0041.JPG",
+                      "size": 2.673015594482422
                     },
                     {
                       "id": "482db1d6-50b8-468d-aa3f-05b206de7daa",
-                      "label": "DSC-0071.JPG"
+                      "label": "DSC-0071.JPG",
+                      "size": 2.633615493774414
                     },
                     {
                       "id": "ba9754f5-bd67-4a93-9fd0-76885de30112",
-                      "label": "DSC-0076.JPG"
+                      "label": "DSC-0076.JPG",
+                      "size": 2.455699920654297
                     },
                     {
                       "id": "18353b0c-0d2b-46be-89bb-a05c7935dde1",
                       "label": "DSC-0077.JPG",
                       "format": "JPEG 1.02",
-                      "puid": "fmt/44"
+                      "puid": "fmt/44",
+                      "size": 3.08640193939209
                     },
                     {
                       "id": "1186c3f5-a462-4634-818e-ae096f84702a",
-                      "label": "DSC-0083.JPG"
+                      "label": "DSC-0083.JPG",
+                      "size": 2.7744016647338867
                     },
                     {
                       "id": "832bd4a8-c51f-4ca2-b855-04c4651ca66a",
-                      "label": "DSC-0084.JPG"
+                      "label": "DSC-0084.JPG",
+                      "size": 2.270421028137207
                     },
                     {
                       "id": "679bb192-689d-44b8-a7da-46249d82d768",
                       "label": "DSC00164.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.1",
-                      "puid": "x-fmt/390"
+                      "puid": "x-fmt/390",
+                      "size": 0.2032642364501953
                     },
                     {
                       "id": "036b6dc6-b6ff-4232-87c7-dcaf4d4e5d90",
                       "label": "G-and-MTU.JPG",
                       "format": "JPEG 1.01",
-                      "puid": "fmt/43"
+                      "puid": "fmt/43",
+                      "size": 1.377579689025879
                     },
                     {
                       "id": "6610e54d-2c50-4056-8030-791d79408078",
                       "label": "Granholm-Bridge-2-2004.JPG",
                       "format": "JPEG 1.01",
-                      "puid": "fmt/43"
+                      "puid": "fmt/43",
+                      "size": 1.6088199615478516
                     },
                     {
                       "id": "baa58485-7efc-48e4-b919-27f8e6421d81",
                       "label": "Group-Photo.jpg",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.14389705657958984
                     },
                     {
                       "id": "f17bab8f-4293-4255-baf3-c32d56c48601",
-                      "label": "IMG-5274-fix.jpg"
+                      "label": "IMG-5274-fix.jpg",
+                      "size": 0.1832447052001953
                     },
                     {
                       "id": "f140c613-848e-40bf-925f-6dcd98c31f48",
-                      "label": "IMG-5274.jpg"
+                      "label": "IMG-5274.jpg",
+                      "size": 0.13155460357666016
                     },
                     {
                       "id": "c46b50a5-40d4-48e6-b6bc-97064be68ce2",
-                      "label": "IMG-5279.jpg"
+                      "label": "IMG-5279.jpg",
+                      "size": 0.12340450286865234
                     },
                     {
                       "id": "81239a76-a2d8-4ac8-983e-03ef188ba450",
-                      "label": "IMG-5287.jpg"
+                      "label": "IMG-5287.jpg",
+                      "size": 0.11258602142333984
                     },
                     {
                       "id": "158da30d-a323-41a1-9b49-d780010091a9",
-                      "label": "IMG-5297.jpg"
+                      "label": "IMG-5297.jpg",
+                      "size": 0.1011962890625
                     },
                     {
                       "id": "e8d76c2e-2983-4662-ac82-558326469836",
-                      "label": "IMG-5313.jpg"
+                      "label": "IMG-5313.jpg",
+                      "size": 0.10376358032226562
                     },
                     {
                       "id": "7b80d953-ba5d-4605-a85b-6c84723db310",
-                      "label": "IMG-5319-Fix.jpg"
+                      "label": "IMG-5319-Fix.jpg",
+                      "size": 0.13099384307861328
                     },
                     {
                       "id": "18266a11-ff93-4860-82d9-72a5adcb053b",
-                      "label": "IMG-5323.jpg"
+                      "label": "IMG-5323.jpg",
+                      "size": 0.1215972900390625
                     },
                     {
                       "id": "7402f5b6-c652-4bc0-9e18-00583f51d1a9",
-                      "label": "IMG-5327.jpg"
+                      "label": "IMG-5327.jpg",
+                      "size": 0.11837291717529297
                     },
                     {
                       "id": "e738d031-4460-43e7-8499-72e755e4e943",
-                      "label": "IMG-5332.jpg"
+                      "label": "IMG-5332.jpg",
+                      "size": 0.1204996109008789
                     },
                     {
                       "id": "a45dda7f-82e8-42ff-88f8-bdd1532df627",
-                      "label": "IMG-5351.jpg"
+                      "label": "IMG-5351.jpg",
+                      "size": 0.09708595275878906
                     },
                     {
                       "id": "4dbb101b-0aa9-4c3f-9af8-9c95c4083b67",
-                      "label": "IMG-5360.jpg"
+                      "label": "IMG-5360.jpg",
+                      "size": 0.10139942169189453
                     },
                     {
                       "id": "eff707a4-e120-4552-ac6b-f5d005965874",
-                      "label": "IMG-5372.jpg"
+                      "label": "IMG-5372.jpg",
+                      "size": 0.10463619232177734
                     },
                     {
                       "id": "d1f3d7b0-b561-4788-8b0e-c6feb5b0cc36",
-                      "label": "IMG-5380-fix.jpg"
+                      "label": "IMG-5380-fix.jpg",
+                      "size": 0.13574981689453125
                     },
                     {
                       "id": "fb677ab7-7c9f-49b7-bb30-6c8ffd7f2b8e",
-                      "label": "IMG-5387.jpg"
+                      "label": "IMG-5387.jpg",
+                      "size": 0.14077186584472656
                     },
                     {
                       "id": "06ffdc7c-8b8e-43f3-a664-6b42ef368ce3",
-                      "label": "IMG-5398.jpg"
+                      "label": "IMG-5398.jpg",
+                      "size": 0.12474918365478516
                     },
                     {
                       "id": "4866a15f-b943-4c61-b9ee-1cbe594a502d",
                       "label": "P1000552.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.7818355560302734
                     },
                     {
                       "id": "8ef7abe1-36e2-4230-b8de-b6dcee4d0cb4",
                       "label": "P1000553.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.763340950012207
                     },
                     {
                       "id": "7a0fe2fb-2a03-4e89-b094-318907f93c27",
                       "label": "Prusi-Girls.JPG",
                       "format": "JPEG 1.01",
-                      "puid": "fmt/43"
+                      "puid": "fmt/43",
+                      "size": 3.209157943725586
                     },
                     {
                       "id": "34010b68-0542-4977-9e40-636291f718a5",
                       "label": "SA400215.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.17055892944335938
                     },
                     {
                       "id": "6b14ca18-343a-4561-bfe3-623a0d7bfdc0",
                       "label": "SA400217.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.1499309539794922
                     },
                     {
                       "id": "b42527b5-6684-49ea-86de-c3b71d0e9037",
                       "label": "SA400219.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.31831836700439453
                     },
                     {
                       "id": "cf7db69b-9ba4-4656-a828-d834cf0e1681",
                       "label": "SA400223.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.21117401123046875
                     },
                     {
                       "id": "9788e6d1-9180-49a8-b03a-b0e1ab919385",
                       "label": "SA400228.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.28608131408691406
                     },
                     {
                       "id": "0b394751-85d5-4318-ae0c-92e5db7bb912",
                       "label": "SA400231.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.2673311233520508
                     },
                     {
                       "id": "bcb03667-11da-45fe-ab53-3c27c89f8456",
                       "label": "SA400245.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.27196598052978516
                     },
                     {
                       "id": "6df4c73c-dae5-4d78-883d-a4e7f6b18088",
                       "label": "SA400247.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.2172842025756836
                     },
                     {
                       "id": "ecb7779f-6666-46bd-a59c-9fa1f4cabfc5",
                       "label": "SA400250.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.1890125274658203
                     },
                     {
                       "id": "10457f76-9f06-46b0-8902-1840c568858d",
                       "label": "SA400251.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.21115779876708984
                     },
                     {
                       "id": "8d830bc1-3b32-4dce-a902-ed67c5d3c114",
                       "label": "SA400252.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.2390613555908203
                     },
                     {
                       "id": "ebcecc63-db45-4d04-a971-25e4a0d60228",
                       "label": "SA400253.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.3374481201171875
                     },
                     {
                       "id": "b85c5a88-ae47-4bee-9ea1-4cef6c996aaf",
                       "label": "SA400259.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.30179500579833984
                     },
                     {
                       "id": "3e167416-a38e-40d9-a4c6-911f19850bf3",
                       "label": "SA400267.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.17090320587158203
                     },
                     {
                       "id": "c88390ac-5289-45bc-881e-e4e2a6603361",
                       "label": "SA400273.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.17932510375976562
                     },
                     {
                       "id": "e1f232bd-db21-42eb-98e1-9b756c2e20f0",
                       "label": "SA400274.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.19205665588378906
                     },
                     {
                       "id": "f573226d-a1c7-4d73-b018-7fe5f8c62518",
                       "label": "SA400275.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.15217113494873047
                     },
                     {
                       "id": "22ad29a5-113d-47dc-80d6-413d2def0feb",
                       "label": "SA400276.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.17298507690429688
                     },
                     {
                       "id": "21626442-a671-40eb-9083-7d9a27ab3500",
                       "label": "SA400277.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.20209980010986328
                     },
                     {
                       "id": "d598a31f-fbe7-4d51-8710-3a71a0af46f2",
                       "label": "SA400280.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.2320108413696289
                     },
                     {
                       "id": "b4998d61-f59d-4598-bbf1-cb67feb71a04",
                       "label": "SA400286.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.23481273651123047
                     },
                     {
                       "id": "d5a959a3-9f5f-421e-b109-73d59161e322",
                       "label": "SA400290.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.2750892639160156
                     },
                     {
                       "id": "6326035e-a98f-4956-8357-dca490452968",
                       "label": "SA400294.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.18602752685546875
                     },
                     {
                       "id": "93ffa7c0-a095-4d26-b95b-7abb173e4466",
                       "label": "Timber-Award.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
-                      "puid": "x-fmt/391"
+                      "puid": "x-fmt/391",
+                      "size": 0.19728374481201172
                     },
                     {
                       "id": "75a615c4-bce3-409b-9dc7-261f4fc54ab4",
                       "label": "Two-Families.JPG",
                       "format": "JPEG 1.01",
-                      "puid": "fmt/43"
+                      "puid": "fmt/43",
+                      "size": 1.415628433227539
                     },
                     {
                       "id": "3d5ad885-5abf-47fa-aab2-3fa4e7b29657",
                       "label": "UP-200-Family-Pic.jpg",
                       "format": "JPEG 1.01",
-                      "puid": "fmt/43"
+                      "puid": "fmt/43",
+                      "size": 0.03112316131591797
                     },
                     {
                       "id": "7585c403-b4a9-4609-8f5e-0400a2dd66f9",
                       "label": "gov.JPG",
                       "format": "JPEG 1.01",
-                      "puid": "fmt/43"
+                      "puid": "fmt/43",
+                      "size": 1.7589893341064453
                     },
                     {
                       "id": "691fa6d2-b738-4cce-bdcf-139242882ea9",
                       "label": "pistons.jpg",
                       "format": "JPEG 1.01",
-                      "puid": "fmt/43"
+                      "puid": "fmt/43",
+                      "size": 0.8100271224975586
                     },
                     {
                       "id": "c79204e4-c6ec-483d-afb7-3fb00a810620",
                       "label": "tree-pic.JPG",
                       "format": "JPEG 1.01",
-                      "puid": "fmt/43"
+                      "puid": "fmt/43",
+                      "size": 2.6764650344848633
                     }
                   ]
                 }
@@ -2556,83 +2900,97 @@
                   "id": "115fcced-edc2-486c-b46b-ba214e6c8b21",
                   "label": "December-2005-004.jpg",
                   "format": "Exchangeable Image File Format (Compressed) 2.2",
-                  "puid": "x-fmt/391"
+                  "puid": "x-fmt/391",
+                  "size": 0.14422321319580078
                 },
                 {
                   "id": "1a35801d-573c-433b-908c-da4cd857da33",
                   "label": "December-2005-027.jpg",
                   "format": "Exchangeable Image File Format (Compressed) 2.2",
-                  "puid": "x-fmt/391"
+                  "puid": "x-fmt/391",
+                  "size": 0.18732166290283203
                 },
                 {
                   "id": "104183db-923b-41d0-b1b2-face6543e1f2",
                   "label": "December-2005-051.jpg",
                   "format": "Exchangeable Image File Format (Compressed) 2.2",
-                  "puid": "x-fmt/391"
+                  "puid": "x-fmt/391",
+                  "size": 0.16927814483642578
                 },
                 {
                   "id": "0e8632a7-2721-49aa-9bdd-abf0505d2350",
                   "label": "December-2005-074.jpg",
                   "format": "Exchangeable Image File Format (Compressed) 2.2",
-                  "puid": "x-fmt/391"
+                  "puid": "x-fmt/391",
+                  "size": 0.28711509704589844
                 },
                 {
                   "id": "37eebc6b-e4d0-4cf2-8756-6f2b814bd5c5",
                   "label": "December-2005-078.jpg",
                   "format": "Exchangeable Image File Format (Compressed) 2.2",
-                  "puid": "x-fmt/391"
+                  "puid": "x-fmt/391",
+                  "size": 0.2734041213989258
                 },
                 {
                   "id": "ef72fa90-e94a-4bd5-9dee-5a83d3427100",
                   "label": "December-2005-088.jpg",
                   "format": "Exchangeable Image File Format (Compressed) 2.2",
-                  "puid": "x-fmt/391"
+                  "puid": "x-fmt/391",
+                  "size": 0.20899200439453125
                 },
                 {
                   "id": "8553e67f-31e3-4f41-b1fd-3b58c6ee6fab",
                   "label": "December-2005-090.jpg",
                   "format": "Exchangeable Image File Format (Compressed) 2.2",
-                  "puid": "x-fmt/391"
+                  "puid": "x-fmt/391",
+                  "size": 0.33354949951171875
                 },
                 {
                   "id": "8b35cfb0-d7c6-4373-b395-be3dc5441996",
                   "label": "Inaugural-Invite-List-1.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.03271484375
                 },
                 {
                   "id": "7bba8e15-1ae9-44a0-a104-19ae94cd84ec",
-                  "label": "Inaugural-Invite-List-2.xls"
+                  "label": "Inaugural-Invite-List-2.xls",
+                  "size": 0.04345703125
                 },
                 {
                   "id": "8358a4d9-b5d9-4f90-aeeb-1a41cad3dac4",
                   "label": "Inaugural-Invite-List-3.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.02783203125
                 },
                 {
                   "id": "0efdfb9f-b49e-4925-b3fa-9b44bd775d0c",
                   "label": "Inaugural-Invite-List-4.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.03955078125
                 },
                 {
                   "id": "cde55a81-8177-4631-ae6b-389f238df034",
                   "label": "Inaugural-Invite-List-5.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.04248046875
                 },
                 {
                   "id": "51b165cd-3206-4139-852a-7d2ce667802f",
                   "label": "pistons.jpg",
                   "format": "JPEG 1.01",
-                  "puid": "fmt/43"
+                  "puid": "fmt/43",
+                  "size": 0.8100271224975586
                 },
                 {
                   "id": "899932ad-4292-4e12-b524-ed9c8e617df9",
                   "label": "up-staff-slide.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 4.3955078125
                 }
               ]
             },
@@ -2658,211 +3016,246 @@
                   "id": "faa8c154-1139-4fb6-a34d-4f279a63e760",
                   "label": "2005-numbers.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.01708984375
                 },
                 {
                   "id": "e6172444-fa09-42ec-b050-c31c3e391666",
                   "label": "COMBINED-CODEBOOK.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.1650390625
                 },
                 {
                   "id": "90dc1ac8-973d-4b50-bdcb-57b17fcc7312",
                   "label": "Combined-Data-Sheet-without-no-response.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.03125
                 },
                 {
                   "id": "9972b98d-5640-45a7-ada7-584fd7ca0494",
                   "label": "Final-Draft-II.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.0341796875
                 },
                 {
                   "id": "db642396-61f4-4b23-99c1-78437442f133",
                   "label": "Final-Draft.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.0341796875
                 },
                 {
                   "id": "ab0cc285-d7d0-427b-8d6a-faf4bf3a46eb",
                   "label": "Iron-Mountain-Survey-Data-Sheet-without-no-response.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.02001953125
                 },
                 {
                   "id": "6719ee5a-e00a-40e3-aed3-c4fe4644c6b2",
                   "label": "Iron-Mountain-Survey-Data-Sheet.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.0205078125
                 },
                 {
                   "id": "7b830f92-93dc-4853-be6b-67d6dbd58ccb",
                   "label": "LANSE-CODEBOOK.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.107421875
                 },
                 {
                   "id": "12fa00be-faaa-43e1-b5d8-b3d974a02757",
                   "label": "LAnse-Survey-Data-Sheet-without-no-response.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.02001953125
                 },
                 {
                   "id": "fbad70fe-59b8-4bb0-a6d9-3fcd48400fd1",
                   "label": "LAnse-Survey-Data-Sheet.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.0205078125
                 },
                 {
                   "id": "70f7bc23-7614-4ee0-8e86-f1ba76ec151d",
                   "label": "Log-Truck-Safety-Study-OVERALL.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.0322265625
                 },
                 {
                   "id": "ed60d665-4666-4a67-a9a8-e842b43c3532",
                   "label": "Logging-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.7734375
                 },
                 {
                   "id": "88248250-c0f7-4ba4-b0fc-767ced819959",
                   "label": "Logging-Stats-04-05.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.01513671875
                 },
                 {
                   "id": "5bc85298-e317-49b3-87a9-3e522bf6be02",
                   "label": "Logging-Truck-Safety-Survey-CODEBOOK-iRON-MT.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.052734375
                 },
                 {
                   "id": "b4447196-2adf-4f6e-a1a8-e2d61b877e92",
                   "label": "Logging-Truck-Safety-Survey-CODEBOOK.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.0810546875
                 },
                 {
                   "id": "f8486360-f4ef-43b2-b5a8-23961763dabd",
                   "label": "Logging-Truck-Safety-Survey.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.07958984375
                 },
                 {
                   "id": "96381fd3-0546-4532-a401-f747b57944a7",
                   "label": "Narrative-Log-Truck-Safety-Study.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.08447265625
                 },
                 {
                   "id": "d439fca5-a632-4d55-8d82-3a424b40cfdd",
                   "label": "Newberry-Codebook.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.0908203125
                 },
                 {
                   "id": "f0cec30a-0e3a-4fba-a96a-cb4960832ea7",
                   "label": "Newberry-Codebook2.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.09033203125
                 },
                 {
                   "id": "22b8bda5-e1d6-4cb1-81f2-162a83d1a6f4",
                   "label": "Newberry-Survey-Data-Sheet-without-no-response.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.02001953125
                 },
                 {
                   "id": "8be6703d-0195-4fdf-ae4f-9226ebc9708a",
                   "label": "Newberry-Survey-Data-Sheet.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.0205078125
                 },
                 {
                   "id": "4833fdf1-23f3-46e0-98a7-6c783872c41d",
                   "label": "Original-overall.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.02197265625
                 },
                 {
                   "id": "6a43227a-e7ce-4eaf-a125-20fbe122fb87",
                   "label": "Preliminary-Stats-Logging-April-05.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.0244140625
                 },
                 {
                   "id": "b34ec5a1-5989-4eb8-9ef5-29490310dcba",
                   "label": "Truck-study-Raw-comments-COMBINED.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.08544921875
                 },
                 {
                   "id": "5158bf21-ad8d-41bc-ad09-ab9b06835596",
                   "label": "Truck-study-Raw-comments-Iron-Mountain.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.0478515625
                 },
                 {
                   "id": "87860d86-1034-42ee-b18a-1f738cc5894e",
                   "label": "Truck-study-Raw-comments-Lanse.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.06640625
                 },
                 {
                   "id": "bf250b2c-5155-41bb-ba78-31d8faa76574",
                   "label": "Truck-study-Raw-comments-Newberry-1.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.03125
                 },
                 {
                   "id": "d83f5b19-66ae-448f-9595-b9d293d5924f",
                   "label": "Truck-study-Raw-comments-Newberry.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.046875
                 },
                 {
                   "id": "85ca38c6-a756-4855-9758-1835f795cae8",
                   "label": "Truck-study-Raw-comments.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.02978515625
                 },
                 {
                   "id": "70b87896-c7ac-4643-a3e4-f8f4ffbb5fb0",
                   "label": "UP-Map-Large.JPG",
                   "format": "JPEG 1.01",
-                  "puid": "fmt/43"
+                  "puid": "fmt/43",
+                  "size": 1.4146223068237305
                 },
                 {
                   "id": "e4ae1d81-6a1a-4b70-b61a-0e8d6c00cfad",
                   "label": "combo-map.pdf",
                   "format": "Acrobat PDF 1.3",
-                  "puid": "fmt/17"
+                  "puid": "fmt/17",
+                  "size": 0.25935840606689453
                 },
                 {
                   "id": "1e84e6b0-0579-4169-8c01-87ff993fe9be",
                   "label": "final-numbers.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.03369140625
                 },
                 {
                   "id": "45b96dff-daf5-4a08-8002-0a1098d78abe",
                   "label": "legend.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.02294921875
                 },
                 {
                   "id": "a8cfc31c-1645-4285-ba20-bd69bf9a8332",
                   "label": "log-truck-study-map-with-pins.JPG",
                   "format": "JPEG 1.01",
-                  "puid": "fmt/43"
+                  "puid": "fmt/43",
+                  "size": 0.18114852905273438
                 },
                 {
                   "id": "f4024182-1b48-4a49-932a-4f31ce6aca7c",
                   "label": "overall.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.03076171875
                 },
                 {
                   "id": "89d1887b-a0a2-4369-832c-b1b9bc7695fa",
@@ -2886,199 +3279,232 @@
                       "id": "d3688b4d-0308-453e-a20b-d58997676218",
                       "label": "2005-numbers.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.01708984375
                     },
                     {
                       "id": "d3ef8d99-8cee-4c30-b5e3-0baf54bbe252",
                       "label": "COMBINED-CODEBOOK.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.1650390625
                     },
                     {
                       "id": "4d90bd8b-b36a-4475-b67b-014f84ef6c4e",
                       "label": "Combined-Data-Sheet-without-no-response.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.03125
                     },
                     {
                       "id": "c5eab27d-37af-4e60-a531-201470bbebea",
                       "label": "Final-Draft-II.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.0341796875
                     },
                     {
                       "id": "cf1076c1-72b9-4241-9631-38d4409b8068",
                       "label": "Final-Draft.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.0341796875
                     },
                     {
                       "id": "904e9aff-5b51-424a-addb-6c1214f17cab",
                       "label": "Iron-Mountain-Survey-Data-Sheet-without-no-response.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.02001953125
                     },
                     {
                       "id": "a29234cc-57fa-44bf-a4b0-ab25ad838711",
                       "label": "Iron-Mountain-Survey-Data-Sheet.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.0205078125
                     },
                     {
                       "id": "35a7a1e2-05c2-4eaa-8368-23933da9a30f",
                       "label": "LANSE-CODEBOOK.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.107421875
                     },
                     {
                       "id": "2e768e67-be09-40a1-b608-8ac24470e26e",
                       "label": "LAnse-Survey-Data-Sheet-without-no-response.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.02001953125
                     },
                     {
                       "id": "9366bc54-f742-4eba-bbcf-d8b19c0376c7",
                       "label": "LAnse-Survey-Data-Sheet.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.0205078125
                     },
                     {
                       "id": "862cdedb-90a2-4c3d-9d4f-9b8e5ef86e4e",
                       "label": "Log-Truck-Safety-Study-OVERALL.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.0322265625
                     },
                     {
                       "id": "3fd2135d-fb8d-4d1c-ae2c-fde24cf3881b",
                       "label": "Logging-Presentation.ppt",
                       "format": "Powerpoint 97-2002",
-                      "puid": "fmt/126"
+                      "puid": "fmt/126",
+                      "size": 0.7734375
                     },
                     {
                       "id": "481f2ff7-e4eb-4b24-9bff-b5ca9608606a",
                       "label": "Logging-Stats-04-05.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.01513671875
                     },
                     {
                       "id": "c083a940-d8d0-4ded-972c-ef9c38c6f143",
                       "label": "Logging-Truck-Safety-Survey-CODEBOOK-iRON-MT.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.052734375
                     },
                     {
                       "id": "c595a5d4-e274-4794-a039-c2a0946b36dd",
                       "label": "Logging-Truck-Safety-Survey-CODEBOOK.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.0810546875
                     },
                     {
                       "id": "03bdb447-5b7b-459d-82f6-c9b6647de9b9",
                       "label": "Logging-Truck-Safety-Survey.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.07958984375
                     },
                     {
                       "id": "f901219e-abc8-4913-bc3a-cdc9aba6699a",
                       "label": "Newberry-Codebook.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.0908203125
                     },
                     {
                       "id": "c5712cd1-ec28-4c08-bf43-4d323c7d82dd",
                       "label": "Newberry-Codebook2.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.09033203125
                     },
                     {
                       "id": "e28b8207-7c5d-446b-867e-1b0624f39e57",
                       "label": "Newberry-Survey-Data-Sheet-without-no-response.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.02001953125
                     },
                     {
                       "id": "f861d61e-0a7c-47c0-aed5-902eb13ff453",
                       "label": "Newberry-Survey-Data-Sheet.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.0205078125
                     },
                     {
                       "id": "3a14ddb6-5653-4868-9611-be023ee7cff4",
                       "label": "Preliminary-Stats-Logging-April-05.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.0244140625
                     },
                     {
                       "id": "c73b7d3b-805c-4236-ae2f-ea83f9583eca",
                       "label": "Truck-study-Raw-comments-COMBINED.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.08544921875
                     },
                     {
                       "id": "0d5bfa5d-012e-41bb-acca-77f17571d28e",
                       "label": "Truck-study-Raw-comments-Iron-Mountain.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0478515625
                     },
                     {
                       "id": "bedfa2a1-c98f-408d-a7a1-62559b040672",
                       "label": "Truck-study-Raw-comments-Lanse.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.06640625
                     },
                     {
                       "id": "d48b614a-ab47-4a15-bce9-ad5671e30ce6",
                       "label": "Truck-study-Raw-comments-Newberry-1.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.03125
                     },
                     {
                       "id": "502a9bdc-8c05-436e-9513-8009837a868f",
                       "label": "Truck-study-Raw-comments-Newberry.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.046875
                     },
                     {
                       "id": "0d431223-b9a9-40f7-9439-ba01d9755289",
                       "label": "Truck-study-Raw-comments.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02978515625
                     },
                     {
                       "id": "6d9ea667-a038-48dc-8a02-9014ccaa3a4b",
                       "label": "UP-Map-Large.JPG",
                       "format": "JPEG 1.01",
-                      "puid": "fmt/43"
+                      "puid": "fmt/43",
+                      "size": 1.4146223068237305
                     },
                     {
                       "id": "733fef21-bb68-41cf-a66f-bbe81ef1f6f2",
                       "label": "combo-map.pdf",
                       "format": "Acrobat PDF 1.3",
-                      "puid": "fmt/17"
+                      "puid": "fmt/17",
+                      "size": 0.25935840606689453
                     },
                     {
                       "id": "1a5771ea-bbef-4ab5-950e-f678a6b25af5",
                       "label": "final-numbers.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.03369140625
                     },
                     {
                       "id": "b009ca37-fc92-4d7d-83c0-9f55b1dd6750",
                       "label": "legend.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02294921875
                     },
                     {
                       "id": "d93de470-c3ef-45cf-a599-be6f9ee30daa",
                       "label": "log-truck-study-map-with-pins.JPG",
                       "format": "JPEG 1.01",
-                      "puid": "fmt/43"
+                      "puid": "fmt/43",
+                      "size": 0.18114852905273438
                     },
                     {
                       "id": "5acfc44e-348d-4882-9615-3c90fb01ef57",
                       "label": "overall.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.03076171875
                     }
                   ]
                 }
@@ -3107,7 +3533,8 @@
                   "id": "bf6c5e01-b4e2-42f4-b4a8-363552f8c603",
                   "label": "final-48-take1.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 6.14501953125
                 },
                 {
                   "id": "3da0777a-da75-49f1-862f-b117cd3aae50",
@@ -3131,127 +3558,148 @@
                       "id": "ed871ef9-bdaf-41c5-9de8-822960b87e17",
                       "label": "2005-Existing-TST.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.01953125
                     },
                     {
                       "id": "ac5792f8-e310-4fe6-9b27-45f1d16ea3ed",
                       "label": "2005-TST-MAP.pdf",
                       "format": "Acrobat PDF 1.3",
-                      "puid": "fmt/17"
+                      "puid": "fmt/17",
+                      "size": 0.25484752655029297
                     },
                     {
                       "id": "61641a11-bb43-41e8-8984-df0288efc910",
                       "label": "2005-submitted-report.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0244140625
                     },
                     {
                       "id": "69517523-890a-4481-b235-6b2a491b35db",
                       "label": "Alpena-SFI.ppt",
                       "format": "Powerpoint 97-2002",
-                      "puid": "fmt/126"
+                      "puid": "fmt/126",
+                      "size": 7.5048828125
                     },
                     {
                       "id": "c22aad0d-4379-4f0d-8d22-2d81176a5ae9",
                       "label": "Book5.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.0146484375
                     },
                     {
                       "id": "102e3480-1644-4348-bc0e-b2604a25c5e7",
                       "label": "Book9.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.0166015625
                     },
                     {
                       "id": "00cc69eb-04f2-472a-9d7f-d36b40c6777d",
                       "label": "Individual-Files.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.0146484375
                     },
                     {
                       "id": "a7acdb94-8ced-446e-b826-7390af6194bd",
                       "label": "Logging-Presentation.ppt",
                       "format": "Powerpoint 97-2002",
-                      "puid": "fmt/126"
+                      "puid": "fmt/126",
+                      "size": 1.66796875
                     },
                     {
                       "id": "904e62c7-14eb-434b-a255-461f6ae0913b",
                       "label": "Logging-Truck-Safety-Survey-Part-II-2.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0302734375
                     },
                     {
                       "id": "b83512ee-e3b0-4c79-a0af-3565d863bb57",
                       "label": "Old-truck.jpg",
                       "format": "JPEG 1.00",
-                      "puid": "fmt/42"
+                      "puid": "fmt/42",
+                      "size": 0.008736610412597656
                     },
                     {
                       "id": "f0024ccb-d6bb-4ac6-b4c0-7c2ea7765ed0",
                       "label": "POST-Alpena-SFI.ppt",
                       "format": "Powerpoint 97-2002",
-                      "puid": "fmt/126"
+                      "puid": "fmt/126",
+                      "size": 6.24169921875
                     },
                     {
                       "id": "61d37a19-802c-4071-b900-2f7cd34fff8c",
                       "label": "Question1Chart.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.0166015625
                     },
                     {
                       "id": "345467c7-9a82-40e5-a505-545f3bb287d5",
                       "label": "Question2.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.0166015625
                     },
                     {
                       "id": "9c13a4ad-5b78-4899-9db2-4bd1fafbdce7",
                       "label": "Question3.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.01513671875
                     },
                     {
                       "id": "1824dcd2-27e8-44f3-84a4-ea16ae226b60",
                       "label": "Question4-What-type-of-additional-training.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.0712890625
                     },
                     {
                       "id": "86a9e61a-73e4-4af5-866f-e4bae5878ed8",
                       "label": "Question5.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.0166015625
                     },
                     {
                       "id": "ba8c79af-f69e-4f8e-bef3-e22ea56cf1cd",
                       "label": "Should-Truck-Safety-be-an-Industry-Standard-tABLE.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.05908203125
                     },
                     {
                       "id": "a1449bfb-9f7f-46c7-b7c3-cefb2305709d",
                       "label": "St-Ignace-SFI-113.ppt",
                       "format": "Powerpoint 97-2002",
-                      "puid": "fmt/126"
+                      "puid": "fmt/126",
+                      "size": 6.5654296875
                     },
                     {
                       "id": "96e7105f-d244-4ccb-a5d2-991bd008e458",
                       "label": "What-type-of-additional-training.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.01318359375
                     },
                     {
                       "id": "6861983c-0dc3-435b-bf13-bf5258f1b654",
                       "label": "combo-map.pdf",
                       "format": "Acrobat PDF 1.3",
-                      "puid": "fmt/17"
+                      "puid": "fmt/17",
+                      "size": 0.25981807708740234
                     },
                     {
                       "id": "10af630a-3245-4843-8e2a-0fba660f5249",
                       "label": "final-final-final-2005-logging.ppt",
                       "format": "Powerpoint 97-2002",
-                      "puid": "fmt/126"
+                      "puid": "fmt/126",
+                      "size": 6.142578125
                     },
                     {
                       "id": "2eff7757-93df-41a3-876f-ff6092661cfb",
@@ -3267,7 +3715,8 @@
                           "id": "5c5a8525-2945-4082-84cc-33c2353a8212",
                           "label": "final-48-take1.ppt",
                           "format": "Powerpoint 97-2002",
-                          "puid": "fmt/126"
+                          "puid": "fmt/126",
+                          "size": 6.14501953125
                         }
                       ]
                     }
@@ -3304,49 +3753,57 @@
                           "id": "607f20be-2467-46e5-9726-f1309f1459b8",
                           "label": "Question-6.xls",
                           "format": "Excel 97 Workbook",
-                          "puid": "fmt/61"
+                          "puid": "fmt/61",
+                          "size": 0.0146484375
                         },
                         {
                           "id": "1c8f28de-7e65-4e7e-bd49-745496c32b75",
                           "label": "Question-7.xls",
                           "format": "Excel 97 Workbook",
-                          "puid": "fmt/61"
+                          "puid": "fmt/61",
+                          "size": 0.0166015625
                         },
                         {
                           "id": "473283c0-4a89-467d-8d37-3bf63f57d91b",
                           "label": "Question1Chart.xls",
                           "format": "Excel 97 Workbook",
-                          "puid": "fmt/61"
+                          "puid": "fmt/61",
+                          "size": 0.0166015625
                         },
                         {
                           "id": "7e562a1f-8fff-40c0-ab5e-bcbb9a524140",
                           "label": "Question2.xls",
                           "format": "Excel 97 Workbook",
-                          "puid": "fmt/61"
+                          "puid": "fmt/61",
+                          "size": 0.0166015625
                         },
                         {
                           "id": "60622636-d3f5-4a5b-ba3f-4dbb7bcdf8af",
                           "label": "Question3.xls",
                           "format": "Excel 97 Workbook",
-                          "puid": "fmt/61"
+                          "puid": "fmt/61",
+                          "size": 0.01708984375
                         },
                         {
                           "id": "dd6cc36e-fa2a-49eb-abc6-5556f6349078",
                           "label": "Question4-What-type-of-additional-training.xls",
                           "format": "Excel 97 Workbook",
-                          "puid": "fmt/61"
+                          "puid": "fmt/61",
+                          "size": 0.05859375
                         },
                         {
                           "id": "d328bcbb-bbc7-47b7-8fce-3d1ff68b5cd4",
                           "label": "Question5.xls",
                           "format": "Excel 97 Workbook",
-                          "puid": "fmt/61"
+                          "puid": "fmt/61",
+                          "size": 0.0166015625
                         },
                         {
                           "id": "66cfe287-47f6-4f3b-a61d-2bae5bf4106f",
                           "label": "What-type-of-additional-training.xls",
                           "format": "Excel 97 Workbook",
-                          "puid": "fmt/61"
+                          "puid": "fmt/61",
+                          "size": 0.01318359375
                         }
                       ]
                     },
@@ -3371,127 +3828,148 @@
                           "id": "781ca3f2-988e-4ac2-860f-3468abcb6183",
                           "label": "2005-numbers.xls",
                           "format": "Excel 97 Workbook",
-                          "puid": "fmt/61"
+                          "puid": "fmt/61",
+                          "size": 0.0166015625
                         },
                         {
                           "id": "d36476e2-c63a-4f91-9d7d-8492e199fe9a",
                           "label": "36ford.jpg",
                           "format": "JPEG 1.00",
-                          "puid": "fmt/42"
+                          "puid": "fmt/42",
+                          "size": 0.013105392456054688
                         },
                         {
                           "id": "27aed5c0-1715-4ede-8759-2bb98854f34f",
                           "label": "Big-Wheels-T02.jpg",
                           "format": "JPEG 1.01",
-                          "puid": "fmt/43"
+                          "puid": "fmt/43",
+                          "size": 0.016592979431152344
                         },
                         {
                           "id": "a64e4705-c5af-410f-b4c6-310b80d45880",
                           "label": "Book5.xls",
                           "format": "Excel 97 Workbook",
-                          "puid": "fmt/61"
+                          "puid": "fmt/61",
+                          "size": 0.01318359375
                         },
                         {
                           "id": "b464d03c-739d-45f7-a141-4e360d6fd836",
                           "label": "Comments-Logging-Iron-Mt-05.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.02587890625
                         },
                         {
                           "id": "8db78705-2075-4c6e-810d-37920e026eaf",
                           "label": "Doc3.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.12109375
                         },
                         {
                           "id": "338064c7-aedf-4c76-889a-8fc23e199b1a",
                           "label": "Logging-Presentation.ppt",
                           "format": "Powerpoint 97-2002",
-                          "puid": "fmt/126"
+                          "puid": "fmt/126",
+                          "size": 1.435546875
                         },
                         {
                           "id": "40f6e155-0a8d-437f-96ba-be43bacb5842",
                           "label": "Logging-Truck-Safety-Survey-Part-II-2.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.029296875
                         },
                         {
                           "id": "540e0ee4-2936-4308-8ede-a15c99dad408",
                           "label": "MDOT.jpg",
                           "format": "JPEG 1.01",
-                          "puid": "fmt/43"
+                          "puid": "fmt/43",
+                          "size": 0.00270843505859375
                         },
                         {
                           "id": "dd55d0a4-0011-4dc8-984a-2b8674fa0fd8",
                           "label": "MUNISING-NUMBERS.xls",
                           "format": "Excel 97 Workbook",
-                          "puid": "fmt/61"
+                          "puid": "fmt/61",
+                          "size": 0.01318359375
                         },
                         {
                           "id": "aaa3cc15-3e6f-48d6-aa8b-70d46d21d221",
                           "label": "Narrative-Log-Truck-Safety-Study.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.16357421875
                         },
                         {
                           "id": "660ad288-99c3-4f0d-95ab-6103016f2239",
                           "label": "Old-truck.jpg",
                           "format": "JPEG 1.00",
-                          "puid": "fmt/42"
+                          "puid": "fmt/42",
+                          "size": 0.008736610412597656
                         },
                         {
                           "id": "fbfd2206-c8b6-4581-ae13-4402d0ea8a6a",
                           "label": "Police-and-Driver.jpg",
                           "format": "JPEG 1.01",
-                          "puid": "fmt/43"
+                          "puid": "fmt/43",
+                          "size": 0.024092674255371094
                         },
                         {
                           "id": "cda57011-4b5c-4140-b388-c77447800dfa",
                           "label": "PulpTruck-small.jpg",
                           "format": "JPEG 1.01",
-                          "puid": "fmt/43"
+                          "puid": "fmt/43",
+                          "size": 0.015050888061523438
                         },
                         {
                           "id": "6a2838a4-1305-4a57-a8f3-c7368a258698",
                           "label": "PulpTruckLoading-small.jpg",
                           "format": "JPEG 1.01",
-                          "puid": "fmt/43"
+                          "puid": "fmt/43",
+                          "size": 0.021584510803222656
                         },
                         {
                           "id": "1f74b08b-903b-4b8b-b430-81c624704967",
                           "label": "Stacys-Grandpa.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.53662109375
                         },
                         {
                           "id": "da685b82-7084-4edc-ba98-2edcda2bca10",
                           "label": "Truck-study-Raw-comments-COMBINED.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.0859375
                         },
                         {
                           "id": "c9d97393-b234-4b30-83c1-f938c4200f76",
                           "label": "Truck-study-Raw-comments.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.02783203125
                         },
                         {
                           "id": "49ac3c30-3367-40a4-a9eb-f4ef788f3e01",
                           "label": "final-48-take1.ppt",
                           "format": "Powerpoint 97-2002",
-                          "puid": "fmt/126"
+                          "puid": "fmt/126",
+                          "size": 5.6044921875
                         },
                         {
                           "id": "3a683e6e-f394-446a-a3ce-4651357d9ec0",
                           "label": "loading-logs.jpg",
                           "format": "JPEG 1.01",
-                          "puid": "fmt/43"
+                          "puid": "fmt/43",
+                          "size": 0.04587841033935547
                         },
                         {
                           "id": "b41adb00-7864-4a0a-8147-954fe12d25e7",
                           "label": "loggers.jpg",
                           "format": "JPEG 1.01",
-                          "puid": "fmt/43"
+                          "puid": "fmt/43",
+                          "size": 0.02455902099609375
                         }
                       ]
                     }
@@ -3523,684 +4001,798 @@
                   "id": "1032e6df-4df6-4d27-9ed6-2a5b5e3361f6",
                   "label": "1Governors-Conference-Nashville.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.23974609375
                 },
                 {
                   "id": "81a9a867-b84c-42c7-ad61-096f2214261a",
                   "label": "1MTU-Forest-Certification-Strategy.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 1.79296875
                 },
                 {
                   "id": "7f82324f-f6d4-4e0d-b4b0-aa8aacabe568",
                   "label": "2007-GOVERNOR’S-UPPER-PENINSULA-INAUGURAL.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 36.5107421875
                 },
                 {
                   "id": "b7dd1e90-a31f-4048-914a-8f89cfa14b58",
                   "label": "2007-GOVERNOR’S-UPPER-PENINSULA-INAUGURAL.pptx",
                   "format": "Powerpoint for Windows 2007+",
                   "puid": "fmt/215",
-                  "extension": ".pptx"
+                  "extension": ".pptx",
+                  "size": 36.08389949798584
                 },
                 {
                   "id": "7f973d7e-5326-4790-bdd7-f0cf49e5c2a2",
                   "label": "20070620-PC-auto.pdf",
                   "format": "Acrobat PDF 1.3",
-                  "puid": "fmt/17"
+                  "puid": "fmt/17",
+                  "size": 0.058150291442871094
                 },
                 {
                   "id": "1c1b906c-d774-4f61-b42f-ea66b0fcac7e",
                   "label": "2007ConsentDecree-pressavail9-26-07.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 6.87353515625
                 },
                 {
                   "id": "2652b603-226c-49b0-8ca3-0b4325156f2a",
                   "label": "2008Hiring-Process-Flow-Chart-1.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.037109375
                 },
                 {
                   "id": "72139d86-8d5c-4288-936d-77916d56e2fd",
                   "label": "A-Carbon-Offset-Cost-Benefit-Analysis-Test-Case-version-2-CCX.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 3.18896484375
                 },
                 {
                   "id": "bdd54650-671b-455d-a913-083de75614e9",
                   "label": "AFFIRMATIVE-ACTION-3-Final.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.064453125
                 },
                 {
                   "id": "e6da8025-83db-4c4a-848d-98e9d42a0b27",
                   "label": "American-Legion-Roast.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.02490234375
                 },
                 {
                   "id": "77b83820-4efc-4372-a496-8188e8d083c1",
                   "label": "AppropSub-on-Nat-Res-12-11-07.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 8.68115234375
                 },
                 {
                   "id": "bdaac43e-0680-4f30-999a-a8dece1dab8d",
                   "label": "BioDiesel-2-08-flat.JPG",
                   "format": "JPEG 1.01",
-                  "puid": "fmt/43"
+                  "puid": "fmt/43",
+                  "size": 0.528172492980957
                 },
                 {
                   "id": "1c0dc438-27ff-499e-a217-da41542bb3be",
                   "label": "Book1.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.01513671875
                 },
                 {
                   "id": "2ac46918-cc89-496c-abc6-f415a6f235c2",
                   "label": "CREDIBILITY.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 2.91552734375
                 },
                 {
                   "id": "432c49a8-44c9-40e2-b146-db6ed682d455",
                   "label": "CUPPAD.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 12.71728515625
                 },
                 {
                   "id": "1ce24e87-1c60-4e0a-b1ec-c0d324686ce6",
                   "label": "Can-You-Budget-Personnel.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.00927734375
                 },
                 {
                   "id": "cd26e0c2-fc2a-4541-b2a3-2e3363c17f4c",
                   "label": "Career-Day.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 6.9580078125
                 },
                 {
                   "id": "a92aef42-d629-4419-be18-0c9bf135a86b",
                   "label": "Charts-for-Budget-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.974609375
                 },
                 {
                   "id": "a6b4a784-38c8-4f5a-b6f4-4be769a9fedb",
                   "label": "Cherry-Comm-Hearing.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.017578125
                 },
                 {
                   "id": "718a5a4f-4755-4da9-8632-b4254883fa54",
                   "label": "Christian-Demorcracy.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 9.3583984375
                 },
                 {
                   "id": "f7a31308-f7f1-465f-a599-c251b61bcc94",
                   "label": "Community-Partnership.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 4.2080078125
                 },
                 {
                   "id": "79b09046-4203-465a-abc3-2f2c24686117",
                   "label": "Community-partnership-pre-show-slides.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.08349609375
                 },
                 {
                   "id": "5f71d23c-ee52-4ab4-a32a-79670456cdb7",
                   "label": "Cool-Attendees.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.0537109375
                 },
                 {
                   "id": "03bb6577-7860-424e-9ddf-f104dfaf19cd",
                   "label": "Corn-based-Ethanol-ppt-BB-2-08.JPG",
                   "format": "JPEG 1.01",
-                  "puid": "fmt/43"
+                  "puid": "fmt/43",
+                  "size": 0.9645919799804688
                 },
                 {
                   "id": "677d7bb9-a948-4e1a-b9fc-feb0c2a18065",
                   "label": "County-Commission-Meeting-10-12.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 10.7734375
                 },
                 {
                   "id": "14866b9f-6b5c-4909-a46a-8b39247e48f5",
                   "label": "Criminal-Justice-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 4.22119140625
                 },
                 {
                   "id": "cf00c7ea-a6c0-40b6-b2b7-215bafaa53f4",
                   "label": "Delta-County-Township-Association.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 18.5
                 },
                 {
                   "id": "006a5b70-8c97-4c9c-9507-77018db0aaa5",
                   "label": "EOY-Prison-Population-1995-2006.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.07421875
                 },
                 {
                   "id": "c076d0d6-0e9a-4a5f-b472-b4007605ec3b",
                   "label": "Executive-Budget-Presentation-2-8-07.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.10888671875
                 },
                 {
                   "id": "139d3054-3cf9-45fd-8afe-840e1201bc34",
-                  "label": "Fair-Registration.xls"
+                  "label": "Fair-Registration.xls",
+                  "size": 0.0361328125
                 },
                 {
                   "id": "5157e070-d5bd-45b5-9f8a-4ad8165fe20e",
                   "label": "Final-Leadership-Michigan-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 14.638671875
                 },
                 {
                   "id": "b95af23e-b5de-4fed-8fc5-a8bbf9ebaeaa",
                   "label": "Final-leadership-michigan.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 3.47998046875
                 },
                 {
                   "id": "87650036-e9ed-4132-ae97-2940ac2efa34",
                   "label": "Forest-Finance-Authority.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.0458984375
                 },
                 {
                   "id": "6a6ed72c-832f-4bb3-9bc8-17123fb8418d",
                   "label": "Forest-lands.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.439453125
                 },
                 {
                   "id": "d59dca0d-b954-46a4-b70a-d92969a2b1b7",
                   "label": "Fuels-From-The-Forest.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 2.44775390625
                 },
                 {
                   "id": "1977ea9c-9d23-40b7-bdd3-1b4ba7b3e33f",
                   "label": "Gogebic-Conservation-District.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 16.63623046875
                 },
                 {
                   "id": "fc0cc04b-73a5-4f79-ba5b-0de72ad92698",
                   "label": "Gogebic-Leadership.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 4.9072265625
                 },
                 {
                   "id": "23bcd60a-b9cd-42a1-a86e-5ce2a41dc5dd",
                   "label": "Governors-economic-plan.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 1.35595703125
                 },
                 {
                   "id": "caab6851-04a2-459f-ade3-5abf8476667a",
                   "label": "Khoury-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 11.96728515625
                 },
                 {
                   "id": "5e7d5e1c-1af2-45fd-9587-8c6337198eb9",
                   "label": "Khoury-Presentation2.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 11.58447265625
                 },
                 {
                   "id": "0908668b-80ff-4b26-abd5-a720b5fbf613",
                   "label": "Khoury-Presentation3.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 13.8837890625
                 },
                 {
                   "id": "c87d42d9-d05f-42d4-a3d7-15cdd0f8b63f",
                   "label": "Kiwanis.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.9775390625
                 },
                 {
                   "id": "d1e83d0a-da80-4c99-aecf-e291ee49d9ee",
                   "label": "LSCP-March-29.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 1.39599609375
                 },
                 {
                   "id": "66eff2e7-e6a3-4a32-ae4c-f72782e6c3a8",
                   "label": "Lake-Superior-Leadership-Academy.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 15.2744140625
                 },
                 {
                   "id": "f1be4cc3-6420-4917-ab63-9167427d6e2e",
                   "label": "LeadAcadJan6.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 3.4033203125
                 },
                 {
                   "id": "00c3a866-c9ab-480f-8165-b917ddacc649",
                   "label": "Leadership-Michigan-2007-final.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 15.572265625
                 },
                 {
                   "id": "58fd359c-b4b7-4ea2-a54f-5c79fcb5a0d5",
                   "label": "Leadership-Michigan-2007.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 15.56787109375
                 },
                 {
                   "id": "ab22a393-c38e-46f1-acfe-76a4b7c7dcf7",
                   "label": "Leadership-West-Michigan.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 16.1064453125
                 },
                 {
                   "id": "53ca6598-82c1-4480-af56-5fa5c7d5e7aa",
                   "label": "Loc-Mackinac-GovernorsOffice.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.43798828125
                 },
                 {
                   "id": "47c3d83a-ce92-43f3-abd0-9f87ee493508",
                   "label": "Loc-Schoolcraft-GovernorsOffice.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.30322265625
                 },
                 {
                   "id": "72d6153f-575e-4e2f-be5c-6127d8752eed",
                   "label": "MBT-Short.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 1.3486328125
                 },
                 {
                   "id": "06bb5964-6b5e-43fd-863c-882771c44d02",
                   "label": "MCTA-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.3564453125
                 },
                 {
                   "id": "2cce5c73-8d4c-4788-a38f-d2e6ab6b664b",
                   "label": "MIFFA-Forest-Carbon-Presentation-24-August-2006.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 2.31201171875
                 },
                 {
                   "id": "2a6efd79-46fb-4276-9456-242315c2ad35",
                   "label": "MPRI-Model-101.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 1.11328125
                 },
                 {
                   "id": "568967d0-7761-4f22-91df-657e1f9c61c0",
                   "label": "MSEA1.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 5.9345703125
                 },
                 {
                   "id": "6035924a-4831-4b9f-b2bf-ea62328cbd12",
                   "label": "Manistique-High-School.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 8.70263671875
                 },
                 {
                   "id": "e333b88e-5f65-4e6a-8363-e672feab53c0",
                   "label": "Marquette-County-Township-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 15.89501953125
                 },
                 {
                   "id": "23bec771-e9c8-463a-9fa0-19dbda0c00b8",
                   "label": "MedCaseload.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.05224609375
                 },
                 {
                   "id": "a44eac70-99f7-48f6-8faa-a6f36cdc2542",
                   "label": "Mqt-Higher-Ed-Speakers.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.017578125
                 },
                 {
                   "id": "d7c7ec19-1495-4842-b4d8-84194476d6b4",
                   "label": "Municpal-Management.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 6.47509765625
                 },
                 {
                   "id": "0ea655da-323e-4dc3-9db2-0064c637de02",
                   "label": "NMPSA2005.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 3.89013671875
                 },
                 {
                   "id": "0bea6b83-e580-4809-b63b-ec77eb78d8c9",
                   "label": "NMU-Budget-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 10.88134765625
                 },
                 {
                   "id": "bcc81641-bf74-46a3-9e59-dd1061e52b17",
                   "label": "Nursing-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 2.1484375
                 },
                 {
                   "id": "da934e38-be1a-48a8-8879-bcd2321eb972",
                   "label": "Office-of-Community-Corrections.PPT",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.11279296875
                 },
                 {
                   "id": "c816bd40-ad02-45e6-83ea-2d4527ebae5f",
                   "label": "Oscoda-County-Conservation-District.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 16.72216796875
                 },
                 {
                   "id": "a16e7efa-33d0-4c2a-82a5-42df154f9027",
                   "label": "Overall-Budget-Picture.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 10.5029296875
                 },
                 {
                   "id": "e2739449-afc2-4b87-ac0c-afebd4da0f89",
                   "label": "PARKVIEW-1.JPG",
                   "format": "JPEG 1.01",
-                  "puid": "fmt/43"
+                  "puid": "fmt/43",
+                  "size": 0.19284820556640625
                 },
                 {
                   "id": "8d3463b3-7c92-4b2f-a139-f02ab9168da8",
                   "label": "PPT-CRC-FINAL-10-5-07.ppt",
                   "format": "Generic AIFF",
-                  "extension": ".aif"
+                  "extension": ".aif",
+                  "size": 0.04685211181640625
                 },
                 {
                   "id": "cb761ad4-7301-421e-b5d0-8ed33896b328",
                   "label": "PPT-Surrogate-31506.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.1728515625
                 },
                 {
                   "id": "7dc10281-d850-4eec-8cf9-31885fe1031e",
                   "label": "PS-528-Final-Power-Point.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 1.26220703125
                 },
                 {
                   "id": "91e2f2b0-29a6-4e4d-bbfd-2db8e4479506",
                   "label": "Pavement-Condition-1.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.1162109375
                 },
                 {
                   "id": "49cb638f-28c9-4413-b596-983d2caf4e64",
                   "label": "Politics-of-Media.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 1.373046875
                 },
                 {
                   "id": "07b97d74-ed87-420a-bacf-69a3cb7d27a6",
                   "label": "Powers-Class.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 3.91259765625
                 },
                 {
                   "id": "5599b16c-2c67-41bc-8819-cdff1fcc7786",
                   "label": "Powers-class-2-25.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 4.02294921875
                 },
                 {
                   "id": "3844471b-b7ed-4aab-bee2-064e2e40dae4",
                   "label": "Presentation-Slides.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.4638671875
                 },
                 {
                   "id": "003253d2-3ad2-4110-9ef2-1f731fd9fca7",
                   "label": "Rotary-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 3.0341796875
                 },
                 {
                   "id": "721214c2-f7c7-4165-9d90-f424e270fdf1",
                   "label": "SBT-presentation.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.125
                 },
                 {
                   "id": "e68f3e8c-38c6-420c-9dc0-fc6b63a5132a",
                   "label": "SERA.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 1.82958984375
                 },
                 {
                   "id": "1bb57ef3-0b52-4e0b-ad90-8a9eff20d038",
                   "label": "SHARED-SERVICES-1.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 1.59423828125
                 },
                 {
                   "id": "bd3800fc-ff2e-4358-ba4a-12d03f4ce201",
                   "label": "SHARED-SERVICES.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 1.73193359375
                 },
                 {
                   "id": "2be09d3e-1efe-4b42-b474-f63f05fb0e2a",
                   "label": "Schoolcraft-Township-Association.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 20.294921875
                 },
                 {
                   "id": "c9e3614c-0fbc-4937-9258-097089ab6d82",
                   "label": "Sled-Dog-Fundraiser.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.0224609375
                 },
                 {
                   "id": "0d87206e-d5ce-4df7-97a7-957a867b4090",
                   "label": "Social-Welfare-Policy.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 4.03515625
                 },
                 {
                   "id": "789a5650-df44-41da-955d-01f07f807447",
                   "label": "Social-Welfare-Policy2.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 4.1181640625
                 },
                 {
                   "id": "ec73e7d5-df56-480d-a70e-45e37e5f72e1",
                   "label": "State-and-Local-Govts.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 3.25439453125
                 },
                 {
                   "id": "0bb41e14-62dc-45b1-9eac-585ab25e2c30",
                   "label": "SummitNMU.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 1.51513671875
                 },
                 {
                   "id": "7628249b-9847-48a8-9da1-3ab6ed0b82b4",
                   "label": "Surrogate-6-9-06-161851-7.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 1.67333984375
                 },
                 {
                   "id": "fd8c981c-1c90-4da1-a3bf-9944b3753b44",
                   "label": "TC-Slides-2.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.06298828125
                 },
                 {
                   "id": "e1af0433-4248-43de-ab60-da0c3fd47d07",
                   "label": "UPEDA.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 1.029296875
                 },
                 {
                   "id": "854c9ac3-1fd8-4df9-b47c-c4ccdc16d1e7",
                   "label": "Video-Franchising-Powerpoint.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.06201171875
                 },
                 {
                   "id": "4d98a0e1-c53b-4bb9-9c13-893d21873787",
                   "label": "Video-Franchising-Presentation-NMPSA.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 1.3466796875
                 },
                 {
                   "id": "4d80ba4c-3e44-4107-9f85-8b940058d344",
                   "label": "Website-Electronic-Monitoring-of-Offenders-in-the-Community-2.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.06396484375
                 },
                 {
                   "id": "4c769be6-8691-428a-b265-8e98ca8cf3fb",
                   "label": "budget-new-taxes.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 1.62744140625
                 },
                 {
                   "id": "5dfc17ba-bc9e-464f-95d6-d613290a05f0",
                   "label": "china-slides.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.03515625
                 },
                 {
                   "id": "c3100b39-3be2-476d-8882-3214b9cb1f63",
                   "label": "corrections-reform.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 11.04248046875
                 },
                 {
                   "id": "c54bd138-115e-4b6d-a1e3-679868419b7f",
                   "label": "emp-Final-Techinvite2004.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.15673828125
                 },
                 {
                   "id": "3f3ce1cb-7cd0-4872-b18f-8c4d3f29d598",
                   "label": "end-of-line.JPG",
                   "format": "JPEG 1.01",
-                  "puid": "fmt/43"
+                  "puid": "fmt/43",
+                  "size": 1.7736444473266602
                 },
                 {
                   "id": "6c6412e0-e646-4b87-8298-37142d43fc0a",
                   "label": "environmental-policy.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 19.42333984375
                 },
                 {
                   "id": "10fbf7ba-252e-48bb-b35b-ab365d7ddc9f",
                   "label": "fundraisersledog.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.021484375
                 },
                 {
                   "id": "f07f481f-e354-40e7-b84b-4be225bfe329",
                   "label": "kiwanis-menominee.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 6.4892578125
                 },
                 {
                   "id": "2ec91ebb-b77e-491f-b33c-317225967700",
                   "label": "leadership-michigan-powerpoint.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.61279296875
                 },
                 {
                   "id": "82ddeed9-ec25-4db7-874d-332acbc397f9",
                   "label": "leadership-michigan-powerpointfinaldraft.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 3.07958984375
                 },
                 {
                   "id": "7413eebd-ee3c-4e86-bea9-045f680c223d",
                   "label": "logs-rolling-off-debarker.JPG",
                   "format": "JPEG 1.01",
-                  "puid": "fmt/43"
+                  "puid": "fmt/43",
+                  "size": 1.1215858459472656
                 },
                 {
                   "id": "bfca29d1-5d17-4aa2-b326-d630b756a966",
                   "label": "mbt.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.07080078125
                 },
                 {
                   "id": "09cffaf4-6ddb-43fd-a066-715b96acc94a",
                   "label": "mml-Oct-2006-1.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.85595703125
                 },
                 {
                   "id": "6894ca16-5189-4333-8b9a-c3ba17c671de",
                   "label": "outcome-measurement-framework.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.01318359375
                 },
                 {
                   "id": "4598e44b-0db9-44b4-91d5-d7122a472796",
                   "label": "pp-react-usa.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 1.26611328125
                 },
                 {
                   "id": "2ed0e440-916c-4315-8194-70f9863d0923",
                   "label": "ps-528-power-point.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.0693359375
                 },
                 {
                   "id": "2063bc88-23ba-460c-ac41-d2395cdcad0a",
                   "label": "regional-colaboration.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 4.673828125
                 },
                 {
                   "id": "075a0ba6-471a-4dc4-abc6-d82fb13bb1ac",
                   "label": "smoking-rates-success.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.0400390625
                 },
                 {
                   "id": "5d9e39af-ee3e-4b68-bcef-26c06155097a",
                   "label": "state-and-local-short.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 7.51708984375
                 },
                 {
                   "id": "22aa0644-7a59-4f75-ad67-98edf180e46e",
                   "label": "state-and-local.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 10.6787109375
                 },
                 {
                   "id": "dbb0eb8d-0028-4346-ae2c-f979577d9cfe",
                   "label": "tilden-township.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 0.3095703125
                 },
                 {
                   "id": "c1a9b55c-4011-4281-a9b2-11c39a0a6b90",
                   "label": "up-STAFF1.ppt",
                   "format": "Powerpoint 97-2002",
-                  "puid": "fmt/126"
+                  "puid": "fmt/126",
+                  "size": 4.5419921875
                 }
               ]
             },
@@ -4248,227 +4840,265 @@
                       "id": "508779d9-8ac7-4d93-993c-e3785bdf7dc7",
                       "label": "2004-Master-Calendar.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.01904296875
                     },
                     {
                       "id": "777c31be-466d-45e1-a556-fb05abbfbf0d",
                       "label": "Description-of-internship-for-Governor-Jennifer-Granholm1.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02392578125
                     },
                     {
                       "id": "3f08d205-63c1-4ffc-ba51-93d71c29e56b",
                       "label": "Engineered-Manufactured-Products.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02392578125
                     },
                     {
                       "id": "58e2fb84-4923-4a4b-a65f-b11199345a04",
                       "label": "Fax-Wizard.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0322265625
                     },
                     {
                       "id": "431d13c9-b60e-47d7-8648-4cee0471896b",
                       "label": "Final-leadership-michigan.ppt",
                       "format": "Powerpoint 97-2002",
-                      "puid": "fmt/126"
+                      "puid": "fmt/126",
+                      "size": 3.8642578125
                     },
                     {
                       "id": "b124c0d7-2d87-4d08-bd46-87d30eda09fc",
                       "label": "INTERN.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02294921875
                     },
                     {
                       "id": "5a436c06-b4c7-4c63-af45-3da6c727cd66",
                       "label": "Logging-Truck-Safety-Survey-CODEBOOK-COMBINED.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.10498046875
                     },
                     {
                       "id": "2102f43a-78bb-460e-93ed-ae05f661a3b9",
                       "label": "Logging-Truck-Safety-Survey-COMBINED-CODEBOOK.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.16796875
                     },
                     {
                       "id": "d81d4a3a-e589-422c-bf10-e30f85b7b82b",
                       "label": "Logging-Truck-Safety-Survey-LANSE-CODEBOOK.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.107421875
                     },
                     {
                       "id": "86d23952-106c-41aa-97e9-8b8ecee82698",
                       "label": "MI-watershed-alliance.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0234375
                     },
                     {
                       "id": "b4d4e5aa-4ac6-4b6c-939c-8359c5e59143",
                       "label": "Marquette-Budget-Forum.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.037109375
                     },
                     {
                       "id": "2ffee209-7bcc-4330-9590-8a46582d67a7",
                       "label": "Memo-Dans-visit.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.021484375
                     },
                     {
                       "id": "6f0274fe-af95-416e-b4c6-6e89524acf67",
                       "label": "Mentor-Conference.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02294921875
                     },
                     {
                       "id": "1ca81e00-cd8c-4678-8b78-ae3c0a364441",
                       "label": "Michigan-Broadband-Authority.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0234375
                     },
                     {
                       "id": "f512bc9c-ddf0-46e5-b078-d901768a0c12",
                       "label": "Michigan-Sample-Slides.ppt",
                       "format": "Powerpoint 97-2002",
-                      "puid": "fmt/126"
+                      "puid": "fmt/126",
+                      "size": 0.0859375
                     },
                     {
                       "id": "7c2de80d-c45f-449e-971e-1f81cdfabc04",
-                      "label": "New-Microsoft-Access-Application.mdb"
+                      "label": "New-Microsoft-Access-Application.mdb",
+                      "size": 0.09375
                     },
                     {
                       "id": "fb9c7a39-c251-41fa-9438-a27cdfa234c9",
                       "label": "New-Microsoft-Word-Document.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.01025390625
                     },
                     {
                       "id": "470d1831-3543-405a-afee-ed7dfde9cf95",
                       "label": "Ontonagon-notes.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02685546875
                     },
                     {
                       "id": "871a3295-b293-4804-a559-00e53db22a6e",
                       "label": "PILT-spreadsheet.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.0390625
                     },
                     {
                       "id": "2c16d1ce-3241-4bfd-b85c-719b0c77eb55",
                       "label": "SERVICE-SHARING-MEETINGS-SUMMARY.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.05126953125
                     },
                     {
                       "id": "6878efa1-d7d0-47f8-b11d-89e8d53a5f9b",
                       "label": "Shared-Services-Metting-Notes.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02490234375
                     },
                     {
                       "id": "ec353763-9962-4c83-a2e0-5c80ddd604bc",
                       "label": "Student-List-for-2-18-05.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.01708984375
                     },
                     {
                       "id": "5c8cb018-9a53-4e87-9f18-dd4229846032",
                       "label": "UP-Events.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.017578125
                     },
                     {
                       "id": "7f33d40e-4078-43cf-b21d-1f4478c181fb",
                       "label": "UP-Shared-Service-Examples.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0341796875
                     },
                     {
                       "id": "b4d159a9-3461-4bd4-abb8-ecd8dbc51ed4",
                       "label": "UPPER-PENINSULA1.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0517578125
                     },
                     {
                       "id": "e95dc4a0-43f1-4abe-b3f8-b493c7082934",
                       "label": "UPandlowpenn1.jpg",
                       "format": "JPEG 1.01",
-                      "puid": "fmt/43"
+                      "puid": "fmt/43",
+                      "size": 0.03262042999267578
                     },
                     {
                       "id": "03452c9c-8b98-4870-9184-9d4f8df90a46",
                       "label": "UPonly1.jpg",
                       "format": "JPEG 1.01",
-                      "puid": "fmt/43"
+                      "puid": "fmt/43",
+                      "size": 0.028840065002441406
                     },
                     {
                       "id": "899683d5-796f-41da-81f6-69bc7f7e9d77",
                       "label": "Volume-Purchasing.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02392578125
                     },
                     {
                       "id": "dad0094c-6813-4bb7-8fcb-f40b3a0f9976",
                       "label": "bridge-walk.jpg",
                       "format": "JPEG 1.01",
-                      "puid": "fmt/43"
+                      "puid": "fmt/43",
+                      "size": 0.03153800964355469
                     },
                     {
                       "id": "c77a7f9c-f8c1-4868-9566-80d547efd1bf",
                       "label": "lansing-schedule.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02392578125
                     },
                     {
                       "id": "512f0cef-dcf9-463c-82d6-e148aebd3e07",
                       "label": "leadership-michigan-powerpoint.ppt",
                       "format": "Powerpoint 97-2002",
-                      "puid": "fmt/126"
+                      "puid": "fmt/126",
+                      "size": 0.6708984375
                     },
                     {
                       "id": "047efa98-8a46-4459-aa2b-e5a3e2c1c62b",
                       "label": "lp-ma.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.03173828125
                     },
                     {
                       "id": "9d966a3f-c034-46d0-9c2d-6ce2ef9c0739",
                       "label": "map.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0244140625
                     },
                     {
                       "id": "b8067234-b6dc-43c9-97fc-1a546e5c6a25",
                       "label": "memo-from-kennecott-presentation.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.04052734375
                     },
                     {
                       "id": "a098f84a-4ce6-4d8d-9e24-d1f2024a135d",
                       "label": "memo-on-service-sharing-in-hospitals.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0400390625
                     },
                     {
                       "id": "d2134aee-87a5-4f8f-95d2-621656e2df09",
                       "label": "memo-on-wind-turbines.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0380859375
                     },
                     {
                       "id": "80a555b2-b330-4808-aadb-66e6153e3334",
                       "label": "school-numbers.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02294921875
                     },
                     {
                       "id": "88d90134-53fe-4887-ba73-7b5de7f60141",
                       "label": "tilden-township.ppt",
                       "format": "Powerpoint 97-2002",
-                      "puid": "fmt/126"
+                      "puid": "fmt/126",
+                      "size": 0.30322265625
                     }
                   ]
                 },
@@ -4486,7 +5116,8 @@
                       "id": "4a0b65f0-fbd3-422d-9246-ce8db2739f80",
                       "label": "Truck-study-Raw-comments-Lanse.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.05419921875
                     }
                   ]
                 },
@@ -4527,49 +5158,57 @@
                           "id": "cc57d59a-c83c-46fb-bca8-bd94bc6312a1",
                           "label": "Briefing-2-17-05-Hockey-NMU-vs-MTU.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.02197265625
                         },
                         {
                           "id": "0082f86b-163c-4601-9f51-7dda34760993",
                           "label": "Briefing-2-17-05-UP-Road-Builders-Conference.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.02197265625
                         },
                         {
                           "id": "57623ea4-3415-47cc-a19e-c42b9d671890",
                           "label": "Briefing-2-17-05-WNMU.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.021484375
                         },
                         {
                           "id": "3fd8157c-2ef8-4e66-a6d5-2b9f606f5105",
                           "label": "Briefing-Format.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.021484375
                         },
                         {
                           "id": "8a98f1f1-f1a1-41d5-a3be-487b06499eb4",
                           "label": "Duty-Logf.xls",
                           "format": "Excel 97 Workbook",
-                          "puid": "fmt/61"
+                          "puid": "fmt/61",
+                          "size": 0.0146484375
                         },
                         {
                           "id": "acd7d9b4-6dfb-4045-bcf3-b70a66b43b86",
                           "label": "INTERNLOG.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.02490234375
                         },
                         {
                           "id": "c29ee111-db51-47a6-b3aa-d8d0b3841ff0",
                           "label": "June-Log.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.0224609375
                         },
                         {
                           "id": "e774dee5-d70c-460f-9fcb-fbc33ebc1542",
                           "label": "Student-Work-Log-Sample.xls",
                           "format": "Excel 97 Workbook",
-                          "puid": "fmt/61"
+                          "puid": "fmt/61",
+                          "size": 0.013671875
                         }
                       ]
                     },
@@ -4595,7 +5234,8 @@
                           "id": "5f04b079-0a90-4973-97d6-74f913eca4e7",
                           "label": "upper-peninsula-map.htm",
                           "format": "Hypertext Markup Language 4.0",
-                          "puid": "fmt/99"
+                          "puid": "fmt/99",
+                          "size": 0.0017805099487304688
                         },
                         {
                           "id": "0ff81300-dc48-4aea-b81e-486fb1e699fc",
@@ -4616,53 +5256,62 @@
                               "id": "d0aa422c-8eda-43d4-8a4d-d4309fcb4aeb",
                               "label": "Bridge-Walk-Overview-2.jpg",
                               "format": "JPEG 1.01",
-                              "puid": "fmt/43"
+                              "puid": "fmt/43",
+                              "size": 0.09985733032226562
                             },
                             {
                               "id": "9722d84a-54d8-4ec6-ad01-c1ea99a6af58",
                               "label": "Bridge-Walk-Overview.jpg",
                               "format": "JPEG 1.01",
-                              "puid": "fmt/43"
+                              "puid": "fmt/43",
+                              "size": 0.0044155120849609375
                             },
                             {
                               "id": "c5220716-d35c-4f10-8b31-90de7cb4363f",
                               "label": "Chinese-Glass-Dome.jpg",
                               "format": "JPEG 1.01",
-                              "puid": "fmt/43"
+                              "puid": "fmt/43",
+                              "size": 0.026022911071777344
                             },
                             {
                               "id": "4f2c148b-b1fb-40e8-9ee7-0a4048ffc4eb",
-                              "label": "Desktop.ini"
+                              "label": "Desktop.ini",
+                              "size": 0.00010204315185546875
                             },
                             {
                               "id": "e97a1519-6e6d-404d-941a-50b31baf38ac",
                               "label": "Empire-Mine.jpg",
                               "format": "JPEG 1.01",
-                              "puid": "fmt/43"
+                              "puid": "fmt/43",
+                              "size": 0.006748199462890625
                             },
                             {
                               "id": "6020af21-7b2d-46ab-93fb-576a255f766d",
                               "label": "UP-picture.rtf",
                               "format": "RTF 1.5-1.6",
-                              "puid": "fmt/50"
+                              "puid": "fmt/50",
+                              "size": 0.7602930068969727
                             },
                             {
                               "id": "739a6eef-0df1-4390-a446-3e01b070aaad",
                               "label": "Upper-Peninsula-County-Map.jpg",
                               "format": "JPEG 1.02",
-                              "puid": "fmt/44"
+                              "puid": "fmt/44",
+                              "size": 0.04015159606933594
                             },
                             {
                               "id": "4dae7d2d-80bd-44dc-8cc7-c8a0560b1581",
                               "label": "leadership.gif",
                               "format": "1989a",
-                              "puid": "fmt/4"
+                              "puid": "fmt/4",
+                              "size": 0.004961967468261719
                             },
                             {
                               "id": "700af938-facb-4933-b177-60aefd6e9996",
                               "label": "tilden-mine.jpg",
                               "format": "JPEG 1.01",
-                              "puid": "fmt/43"
+                              "puid": "fmt/43",
+                              "size": 0.012227058410644531
                             }
                           ]
                         },
@@ -4680,7 +5329,8 @@
                               "id": "5ada198e-75a9-4084-ac78-b23a281675d9",
                               "label": "college-stats.gif",
                               "format": "1989a",
-                              "puid": "fmt/4"
+                              "puid": "fmt/4",
+                              "size": 0.02887439727783203
                             }
                           ]
                         },
@@ -4701,62 +5351,72 @@
                               "id": "c84c453d-7fb5-4fa6-9d50-bcad30bb43ac",
                               "label": "030718deer.jpg",
                               "format": "JPEG 1.02",
-                              "puid": "fmt/44"
+                              "puid": "fmt/44",
+                              "size": 0.007403373718261719
                             },
                             {
                               "id": "cbb5f202-b03b-4d57-89fa-980a59fd830a",
                               "label": "Empire20aerial202.jpg",
                               "format": "JPEG 1.01",
-                              "puid": "fmt/43"
+                              "puid": "fmt/43",
+                              "size": 0.013245582580566406
                             },
                             {
                               "id": "90cac1b5-95d0-4280-8dab-c48defe2ced5",
                               "label": "Tilden20aerial20220web.jpg",
                               "format": "JPEG 1.02",
-                              "puid": "fmt/44"
+                              "puid": "fmt/44",
+                              "size": 0.005615234375
                             },
                             {
                               "id": "e85a95b5-2cea-415e-ade8-5e0c0ff979d8",
                               "label": "artwork03.jpg",
                               "format": "JPEG 1.02",
-                              "puid": "fmt/44"
+                              "puid": "fmt/44",
+                              "size": 0.05019664764404297
                             },
                             {
                               "id": "08fa0000-2332-41a0-a6ab-fa968615d940",
                               "label": "artwork04.jpg",
                               "format": "JPEG 1.02",
-                              "puid": "fmt/44"
+                              "puid": "fmt/44",
+                              "size": 0.05620861053466797
                             },
                             {
                               "id": "a26d413f-7171-43c6-bbf8-77ee12052ea6",
                               "label": "artwork06.jpg",
                               "format": "JPEG 1.02",
-                              "puid": "fmt/44"
+                              "puid": "fmt/44",
+                              "size": 0.059363365173339844
                             },
                             {
                               "id": "e32c8ad5-06b6-4574-9e88-dfa71e53d114",
                               "label": "fall-colors.jpg",
                               "format": "JPEG 1.02",
-                              "puid": "fmt/44"
+                              "puid": "fmt/44",
+                              "size": 0.009907722473144531
                             },
                             {
                               "id": "9a161ece-0c41-4b59-a4da-58fbf83c317f",
                               "label": "gov-hs-54993-7.tif",
                               "format": "TIFF",
                               "puid": "fmt/353",
-                              "extension": ".tif"
+                              "extension": ".tif",
+                              "size": 4.756345748901367
                             },
                             {
                               "id": "01f4cf81-ce8d-485c-97fa-7aa60b0c731c",
                               "label": "upmap4.jpg",
                               "format": "JPEG 1.01",
-                              "puid": "fmt/43"
+                              "puid": "fmt/43",
+                              "size": 0.020229339599609375
                             },
                             {
                               "id": "3c5f01cd-8c1f-4ff5-a56a-8dba5e1c9b88",
                               "label": "welcomup.gif",
                               "format": "1989a",
-                              "puid": "fmt/4"
+                              "puid": "fmt/4",
+                              "size": 0.0064105987548828125
                             }
                           ]
                         }
@@ -4794,151 +5454,176 @@
                       "id": "b083ebc2-6653-4b23-851d-d0f81b6753ae",
                       "label": "8-14-08-Mascoma-Gov-Brief.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0302734375
                     },
                     {
                       "id": "42ca5547-9289-431f-8f7c-e07616072f98",
                       "label": "DNR-Pocket-Park-Ribbon-Cutting.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.03515625
                     },
                     {
                       "id": "43a58620-25c2-4a98-98ca-f25157a92f88",
                       "label": "Delta-County.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.01953125
                     },
                     {
                       "id": "fe95bf37-aa7e-45ff-aaec-380c2f932fea",
                       "label": "Ed-Board-Daily-Press.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0283203125
                     },
                     {
                       "id": "e1a42695-2c6a-4b90-8d65-7c869ceec5a2",
                       "label": "Governor-UP-August-2008.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.03173828125
                     },
                     {
                       "id": "6f8c1413-45b2-410b-b3e3-9ccb0ae1f0df",
                       "label": "Lofts-on-Ludington.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.03173828125
                     },
                     {
                       "id": "576d11e9-1a66-40ed-9450-a69469d988c4",
                       "label": "LunchwGovAd2008.pdf",
                       "format": "Acrobat PDF 1.3",
-                      "puid": "fmt/17"
+                      "puid": "fmt/17",
+                      "size": 0.0376129150390625
                     },
                     {
                       "id": "c791010d-493a-4e16-9a66-235b97b0db0e",
                       "label": "Marquette-County.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.021484375
                     },
                     {
                       "id": "2483f88e-d62d-43f2-9095-65ced01c4728",
                       "label": "Mascoma-Meeting.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02783203125
                     },
                     {
                       "id": "fcea0bfa-8e67-4606-8c43-75b1f81d9088",
                       "label": "Media-Meet-brief.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0302734375
                     },
                     {
                       "id": "58b9896c-70be-432d-b804-69dab53eedd4",
                       "label": "Mining-Journal-Ed-Board-Visit.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0283203125
                     },
                     {
                       "id": "c4264495-b595-41c1-8b4b-b9c12f288b45",
                       "label": "NWLB-Press-Conference.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02685546875
                     },
                     {
                       "id": "c02f719b-e349-489a-8302-65e6fb46a33e",
                       "label": "State-Bird-Carving-Presentation.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.03173828125
                     },
                     {
                       "id": "77933055-9bad-4f1a-9737-729a02f5c54a",
                       "label": "Stupak-FR-Hot-Issues.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0234375
                     },
                     {
                       "id": "dff2880c-705f-43cf-92e5-0a2e65a2186c",
                       "label": "Stupak-Fundraiser.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0302734375
                     },
                     {
                       "id": "fc8ab3fc-63e9-4035-9a5f-ad776ea4b7f0",
                       "label": "Tim-Kobasic-WYKK-Interview-brief.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02978515625
                     },
                     {
                       "id": "1d787f99-42c9-4911-8c0c-67840fe13459",
                       "label": "UP-HOT-TOPICS-2007.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.1455078125
                     },
                     {
                       "id": "36ec1b1c-8685-4d4e-8c9e-85edf7cc75eb",
                       "label": "UP-HOT-TOPICS-2008.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.13623046875
                     },
                     {
                       "id": "3c18c1bd-d1de-497f-8eb8-cc898d96adb2",
                       "label": "UP-State-Fair-Governors-Luncheon-2008.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.44873046875
                     },
                     {
                       "id": "181a3b0c-6a8a-442b-8496-7fcbee857e47",
                       "label": "Upper-Peninsula-Hot-Topics.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.064453125
                     },
                     {
                       "id": "6fadf2ae-99cd-44cb-805c-772d63a48320",
                       "label": "Vet-of-the-Year-Brief.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.033203125
                     },
                     {
                       "id": "9f497db0-3ae6-4a88-992b-15f1dae7d5c4",
                       "label": "Veteran-Background.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02490234375
                     },
                     {
                       "id": "8572787f-bcf5-41df-b720-42b3751e37d0",
                       "label": "WCHT-Radio-Interview.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0283203125
                     },
                     {
                       "id": "50674d8a-daa6-4783-8146-9d98fe998d76",
                       "label": "WMXG-FM-radio-interview-brief.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0283203125
                     },
                     {
                       "id": "15dc2741-c74b-4703-b2df-8a518b7a39ac",
                       "label": "Walt-Lindala.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.029296875
                     }
                   ]
                 },
@@ -4956,67 +5641,78 @@
                       "id": "ec586689-675f-4203-a086-e2098a6c73f0",
                       "label": "Bay-College-Tour.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0322265625
                     },
                     {
                       "id": "63746990-43b0-4d5a-a4fe-30c1f01e5247",
                       "label": "Governors-Luncheon-Summer-Youth-Initiative.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.03173828125
                     },
                     {
                       "id": "90f6a55c-d0e9-47d7-bd13-a38dd7626581",
                       "label": "IM-Schools-Meeting.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.033203125
                     },
                     {
                       "id": "54b1bb93-fa96-4d1c-a3a6-19fcabb5537c",
                       "label": "Lofts-on-Ludington-Tour.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02783203125
                     },
                     {
                       "id": "96f719f8-e76e-4c94-9484-ae85740693c4",
                       "label": "Lunch-with-Bay-College-Bd-of-Trustees.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.03076171875
                     },
                     {
                       "id": "602df535-034a-4dc4-9f9a-c5952ec03140",
                       "label": "Luncheon.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.08984375
                     },
                     {
                       "id": "32f6cae5-c60c-4328-a7ba-41a160714f1a",
                       "label": "No-Worker-Left-Behind-Event.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0322265625
                     },
                     {
                       "id": "142ef483-1117-4217-8544-25c0d3ad0028",
                       "label": "Photo-Op-with-Orrin-Bailey.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0302734375
                     },
                     {
                       "id": "888326bc-afc7-4236-897e-99ec6bb3d1ae",
                       "label": "St-John-Forest-Products-Tour.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.03173828125
                     },
                     {
                       "id": "8dd14878-8aa1-4dca-9bd5-4c93bcc134ac",
                       "label": "State-Bird-Carving-Presentation.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0322265625
                     },
                     {
                       "id": "f412d8ac-ffbf-4f05-ba4f-cfbc5998e2a8",
                       "label": "Vet-of-the-Year-Brief-2009.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.083984375
                     },
                     {
                       "id": "344a8de5-fa9c-4f2e-8e98-a0719c4fe8e2",
@@ -5032,37 +5728,43 @@
                           "id": "fa2bf455-20c7-4853-93e3-f9f65cb2bce0",
                           "label": "Lofts-on-Ludington-Tour.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.03173828125
                         },
                         {
                           "id": "b9d7b8ef-5b53-4de5-94f7-cbab34e2493e",
                           "label": "Lunch-with-Bay-College-Bd-of-Trustees.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.03076171875
                         },
                         {
                           "id": "c70aaabb-b48e-490d-9c95-bb8530ee3840",
                           "label": "Photo-Op-with-Orrin-Bailey.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.0302734375
                         },
                         {
                           "id": "5286d20f-32e3-49e8-b696-3a4a9138964a",
                           "label": "St-John-Forest-Products-Tour.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.03173828125
                         },
                         {
                           "id": "db3cf8f1-d42f-4b43-a398-d7de26cf7c8b",
                           "label": "State-Bird-Carving-Presentation.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.03173828125
                         },
                         {
                           "id": "642899f9-0f6d-49c9-adde-0977ca2fc113",
                           "label": "Vet-of-the-Year-Brief-2009.doc",
                           "format": "Microsoft Word Document 97-2003",
-                          "puid": "fmt/40"
+                          "puid": "fmt/40",
+                          "size": 0.083984375
                         }
                       ]
                     }
@@ -5102,175 +5804,204 @@
                       "id": "d6665e1f-36fb-4ad2-87de-57891fcb5425",
                       "label": "Background-Info-Western-Lime-3.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0224609375
                     },
                     {
                       "id": "ac9340b2-5629-4ede-bb63-d1953698b69d",
                       "label": "Bonifas-Arts-Center-Brief.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0322265625
                     },
                     {
                       "id": "3b21f7ce-b61f-4176-a167-4d312b9fb11d",
                       "label": "CCI-Announcement-brief.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.04052734375
                     },
                     {
                       "id": "c3b8e1ec-356c-4293-8a79-1db21ab873a5",
                       "label": "Cleveland-Cliffs-Announcement.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.138671875
                     },
                     {
                       "id": "b1a8db6d-317c-48fa-8a81-b1313a152a14",
                       "label": "Cliffs-Dignitary-Reception-brief.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.03125
                     },
                     {
                       "id": "23e802c7-6947-4948-819d-ebc9949f5144",
                       "label": "DJG-Remarks-8-16-07-draft8-2.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0302734375
                     },
                     {
                       "id": "b710bc07-b896-483a-988c-3b8d8d85b6cb",
                       "label": "Delta-County.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.01953125
                     },
                     {
                       "id": "2c594d09-a5eb-472d-8f1b-4640a9caf65c",
                       "label": "Detailed-Western-Lime-Agenda-2.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02001953125
                     },
                     {
                       "id": "11d34b64-c213-4659-b9ad-a812934cdded",
                       "label": "Dick-Storm-Radio-Interview-Brief.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0283203125
                     },
                     {
                       "id": "89ac8941-59d9-4f17-a70a-fba0da15f899",
                       "label": "Governor-s-UP-FINAL-Schedule.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.04541015625
                     },
                     {
                       "id": "c7a48ba8-8949-4962-8e99-734598e472a7",
                       "label": "Govs-luncheon-Attendees.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.63134765625
                     },
                     {
                       "id": "b708aaac-165d-4d4b-b88c-db6116405fbe",
                       "label": "Guinness-book-of-records.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0869140625
                     },
                     {
                       "id": "c721512e-b340-40bf-9ce1-b30479d97d0a",
                       "label": "GuinnessWorldRecords-for-skateboard.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02734375
                     },
                     {
                       "id": "c9039a57-22ec-4716-a4ac-998dcd687d64",
                       "label": "Les-Wong-meeting-brief.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.03076171875
                     },
                     {
                       "id": "e041382f-1c40-4477-b684-226feb410590",
                       "label": "Manistique-Officials-Meeting-Brief.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02978515625
                     },
                     {
                       "id": "6be703aa-c193-4ea6-8241-de7c781c8515",
                       "label": "Marquette-County.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.021484375
                     },
                     {
                       "id": "b1774bcd-71c0-4740-8668-270f39a15e55",
                       "label": "Media-Meet-brief.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.03125
                     },
                     {
                       "id": "4735b376-694c-4067-8cf7-196b69e5a110",
                       "label": "Never-mistake-a-clear-vision-for-a-short-journey-3.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02587890625
                     },
                     {
                       "id": "3db2e66a-fb8d-420b-88b2-6d5dee296395",
                       "label": "Open-House-Invitations.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.0302734375
                     },
                     {
                       "id": "5b59f123-da48-4e42-b946-6643c85b1fa8",
                       "label": "Schoolcraft-County.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02099609375
                     },
                     {
                       "id": "c46e1af0-b258-4c90-a6cd-cc33ab74120e",
                       "label": "Tim-Kobasic-WYKK-Interview-brief.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02978515625
                     },
                     {
                       "id": "f6ce22bb-0afc-4df0-a729-e9920abf0469",
                       "label": "UP-State-Fair-Governors-Luncheon-2007.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.650390625
                     },
                     {
                       "id": "a586640f-b47a-494e-a3e0-c2fa29de4a01",
                       "label": "UP-State-Fair-Luncheon-SPEECH-Info.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02001953125
                     },
                     {
                       "id": "f4b770d6-6c4e-49eb-b358-554e4c3f53e4",
                       "label": "Vet-of-the-Year-Background-2007.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0224609375
                     },
                     {
                       "id": "37b6a833-efea-4f00-a350-709ae580560e",
                       "label": "Vet-of-the-Year-Event-Brief.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.08203125
                     },
                     {
                       "id": "02f4fafa-60b8-421e-b288-7d16abe9691a",
                       "label": "WMXG-FM-radio-interview-brief.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0244140625
                     },
                     {
                       "id": "fc445b29-e398-477b-8515-9cf1f15282a5",
                       "label": "Western-Lime-Brief-1.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.05224609375
                     },
                     {
                       "id": "db2bf5d2-8c91-484c-9b6c-f97e0b56beda",
                       "label": "Western-Lime-Brief.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0322265625
                     },
                     {
                       "id": "206a7f82-0590-44ae-add7-4c449c02553f",
                       "label": "Western-Lime-Info.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02197265625
                     }
                   ]
                 },
@@ -5294,103 +6025,120 @@
                       "id": "1391f5e1-bfa7-41b6-96af-c59bf3681965",
                       "label": "8-18-Media-2.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.033203125
                     },
                     {
                       "id": "bfb771b8-e7d7-47eb-bd89-2f1079f2e9a7",
                       "label": "Briefing-Memo-ATV-OHV-Practical-Skills-Track-Dedication.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0322265625
                     },
                     {
                       "id": "17497749-0ccc-4dcb-a2cd-410857c055b1",
                       "label": "Briefing-Memo-H-for-H-Home-Dedication.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02490234375
                     },
                     {
                       "id": "ab81254b-45f0-4de2-8118-d30e670693b1",
                       "label": "Briefing-Memo-H-for-H-Manistique.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02392578125
                     },
                     {
                       "id": "3625e2d2-0e27-4ffe-9d51-db07bfdcc259",
                       "label": "Briefing-Memo-Manistique-Memorial-Fountain.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02783203125
                     },
                     {
                       "id": "3d7a9ea6-c626-49f8-a169-e42dae990d5b",
                       "label": "Briefing-Memo-UPSF-Luncheon.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02783203125
                     },
                     {
                       "id": "886d1d5b-f228-4566-be95-398dc1b83fd4",
                       "label": "Briefing-Memo-War-Memorial-Hospital-Medical-Building.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0234375
                     },
                     {
                       "id": "467f9b0f-12db-461d-8bb4-894c6cd55fc6",
                       "label": "CONTACTS-August-19-20-2010.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.0205078125
                     },
                     {
                       "id": "db9b741d-d7ae-49ef-b3da-21d59a50fb8f",
                       "label": "Fw-Moyle-Ribbon-Cutting-List-Moyle-Investment-as-it-relates-to-War-Memorial-Hospital.htm",
                       "format": "Hypertext Markup Language 4.0",
-                      "puid": "fmt/99"
+                      "puid": "fmt/99",
+                      "size": 0.04069709777832031
                     },
                     {
                       "id": "cd19f388-0a33-4f9c-806c-600afaea09cf",
                       "label": "Fw-tentative-groundbreaking-agenda-2-GFWC.htm",
                       "format": "Hypertext Markup Language 4.0",
-                      "puid": "fmt/99"
+                      "puid": "fmt/99",
+                      "size": 0.017065048217773438
                     },
                     {
                       "id": "3937a42f-2f40-46c2-87b0-9adc62e8e27f",
                       "label": "GFWC.pdf",
                       "format": "Acrobat PDF 1.6",
-                      "puid": "fmt/20"
+                      "puid": "fmt/20",
+                      "size": 0.15174293518066406
                     },
                     {
                       "id": "9bcd1dcd-d451-4ee8-9ba1-de29c17372be",
                       "label": "HforH-2.pdf",
                       "format": "Acrobat PDF 1.6",
-                      "puid": "fmt/20"
+                      "puid": "fmt/20",
+                      "size": 0.6819515228271484
                     },
                     {
                       "id": "528a7571-86dd-4a81-b03a-16aed00bf89f",
                       "label": "MOB-Mailing-List.xls",
                       "format": "Excel 97 Workbook",
-                      "puid": "fmt/61"
+                      "puid": "fmt/61",
+                      "size": 0.02197265625
                     },
                     {
                       "id": "16312664-8946-4e0d-94cc-2f04b4a4cdf2",
                       "label": "UPSF-2010-UPDATE.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.0283203125
                     },
                     {
                       "id": "b6cfe345-fae1-4676-a1b2-1668267634ed",
                       "label": "UPSF.pdf",
                       "format": "Acrobat PDF 1.6",
-                      "puid": "fmt/20"
+                      "puid": "fmt/20",
+                      "size": 0.07654857635498047
                     },
                     {
                       "id": "9cdb5bb9-a3be-4d35-9274-72ac1e003d8e",
                       "label": "invitation.htm",
                       "format": "Hypertext Markup Language 4.0",
-                      "puid": "fmt/99"
+                      "puid": "fmt/99",
+                      "size": 0.019969940185546875
                     },
                     {
                       "id": "5115ebdd-50a4-4d2f-ada8-9eea06d4da40",
                       "label": "mob-2.doc",
                       "format": "Microsoft Word Document 97-2003",
-                      "puid": "fmt/40"
+                      "puid": "fmt/40",
+                      "size": 0.02587890625
                     }
                   ]
                 }
@@ -5412,235 +6160,274 @@
                   "id": "6715c620-3da0-488f-b789-c6931dbef6a8",
                   "label": "August-2005-list-of-events-part-1.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.02734375
                 },
                 {
                   "id": "81d38289-5dd7-4b30-b317-0f140a10e347",
                   "label": "Baraga-County.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.0283203125
                 },
                 {
                   "id": "251d1018-4e3f-4a76-ba8e-469040ec2fee",
                   "label": "Coffee-with-the-Governor-Baraga.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.04052734375
                 },
                 {
                   "id": "0be77823-4276-41b3-9032-c58747c848b2",
                   "label": "Copy-of-phone-numbers.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.017578125
                 },
                 {
                   "id": "c86c9da9-c96a-4667-86fb-4ed7d1e459f5",
                   "label": "Delta-County.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.0263671875
                 },
                 {
                   "id": "984b03ba-4b49-4788-9c0d-3e947e1a706e",
                   "label": "Eagle-Herald-Newspaper-bio.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.02392578125
                 },
                 {
                   "id": "a14c9037-48e4-42f7-b8cc-b982c95cdbe9",
                   "label": "Eagle-River-Community-BBQ.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.02978515625
                 },
                 {
                   "id": "7a146662-32e0-4f47-99ab-db45a52ad41f",
                   "label": "Firefighter-Recognition.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.0361328125
                 },
                 {
                   "id": "9a055d83-0d18-4f4b-9dfb-b4c30d58bba7",
                   "label": "Interview-with-Iron-River-County-Reporter.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.04248046875
                 },
                 {
                   "id": "34cb6798-9e1c-48b9-a9fa-44804c7ac05b",
                   "label": "Interview-with-WDBC-Escanaba.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.03076171875
                 },
                 {
                   "id": "e566a1a5-f8a7-4c46-9769-026e391c56fb",
                   "label": "Interview-with-editorial-board-lanse-sentinel.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.02587890625
                 },
                 {
                   "id": "1358e5f6-312e-4875-a5bb-9cc4cfb6a430",
                   "label": "Interview-witht-the-Escanaba-Daily-Press.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.0302734375
                 },
                 {
                   "id": "934cf71f-b74f-417c-bbf1-b6d835589e81",
                   "label": "Iron-Mnt-out-to-lunch.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.0302734375
                 },
                 {
                   "id": "02a9a091-a16b-4f12-9168-72a4fc4063d9",
                   "label": "Iron-River-Roundtable.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.03466796875
                 },
                 {
                   "id": "9511cd47-3de6-4bca-92b3-291648597f3e",
                   "label": "Menominee-County.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.02734375
                 },
                 {
                   "id": "2a59646a-510f-43d8-9cbb-3811dbc07028",
                   "label": "Pinecrest-Nursing-Home-visit.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.04541015625
                 },
                 {
                   "id": "4077f08e-7759-4dc4-99e7-129981e1eb88",
                   "label": "Reception-for-Mitch-Irwin.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.033203125
                 },
                 {
                   "id": "cf0826bb-02db-4bd7-958f-12bbe7acd143",
                   "label": "Skeleton-Schedule.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.0302734375
                 },
                 {
                   "id": "98d8a818-04eb-4ea4-a596-8cf0a37f3483",
                   "label": "Thank-you-2005.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.0390625
                 },
                 {
                   "id": "6fe69727-81b6-45c0-aa23-47c6f8e7e8d8",
                   "label": "Thank-you-note-list.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.03759765625
                 },
                 {
                   "id": "bb42cba2-a016-463d-8165-72162a856f36",
                   "label": "Township-Supervisors-and-City-Managers-for-U.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.02294921875
                 },
                 {
                   "id": "0bc1d393-32ab-49fc-86e8-13379eabcc9a",
                   "label": "UP-State-Fair-4-H-dedication.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.0361328125
                 },
                 {
                   "id": "9a3d1321-3a5e-41b2-8b92-90bf28a64a9f",
                   "label": "UP-State-Fair-Veterans-Ceremony2.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.03173828125
                 },
                 {
                   "id": "c691969e-4aab-4b95-b7b8-ce0b0df934c5",
                   "label": "UP-State-Fair.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.0361328125
                 },
                 {
                   "id": "03ee42c2-a9b8-4f71-b44d-ee769ad3091c",
                   "label": "UP-Swing-Follow-Up.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.02294921875
                 },
                 {
                   "id": "728b9ec5-8313-42e0-9c76-c80433b5bad2",
                   "label": "Upper-Peninsula-Hot-Topics.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.064453125
                 },
                 {
                   "id": "8e70c704-ab40-40e9-9995-6c9ba478315d",
                   "label": "art-project-bd.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.037109375
                 },
                 {
                   "id": "f76295ff-f2fd-49b4-8fc0-06e5b41a0e21",
                   "label": "august-2005-list-of-events-part-2.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.1318359375
                 },
                 {
                   "id": "e6c8545b-093e-44eb-8ade-4cc79ee3df98",
                   "label": "fundraiser-for-Senator-Mike-Prusi.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.02880859375
                 },
                 {
                   "id": "a998a205-34e8-4848-945d-837c8803b543",
                   "label": "international-paper-bd.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.044921875
                 },
                 {
                   "id": "670c716b-f6ca-47cd-9590-e4f17e355158",
                   "label": "international-paper-bd2.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.03662109375
                 },
                 {
                   "id": "a8499275-22bc-418a-9021-7e29d52e85e2",
                   "label": "newpage.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.03173828125
                 },
                 {
                   "id": "40769334-200a-45ac-b226-d063f17931f1",
                   "label": "numbers-and-addresses-for-august-2005-visit.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.0595703125
                 },
                 {
                   "id": "c4d8ed8f-2bf1-4b05-a82c-f4f57d725f8e",
                   "label": "phone-numbers.xls",
                   "format": "Excel 97 Workbook",
-                  "puid": "fmt/61"
+                  "puid": "fmt/61",
+                  "size": 0.01806640625
                 },
                 {
                   "id": "8ead7e2e-ba40-4aba-9781-0e984e2037de",
                   "label": "up-fair-reading-program-event.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.0322265625
                 },
                 {
                   "id": "879328d6-ec06-4447-b3c4-611204ec71e6",
                   "label": "up-state-dnr-pocket-park.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.03076171875
                 },
                 {
                   "id": "c3f1f342-873b-46d2-ba35-b207249a0ec2",
                   "label": "up-state-fair-animal-barn.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.02880859375
                 },
                 {
                   "id": "7b511d12-7889-4294-b3e5-c84d5f340156",
                   "label": "up-state-fair-governor-luncheon-and-tour.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.02734375
                 },
                 {
                   "id": "09a81af7-804c-4008-9e73-8040ebe5cd58",
                   "label": "up-state-fairgrounds-map.doc",
                   "format": "Microsoft Word Document 97-2003",
-                  "puid": "fmt/40"
+                  "puid": "fmt/40",
+                  "size": 0.068359375
                 }
               ]
             }
@@ -5703,79 +6490,96 @@
               "label": "2009 class.docx",
               "format": "Microsoft Word for Windows 2007+",
               "puid": "fmt/412",
-              "extension": ".docx"
+              "extension": ".docx",
+              "size": 0.010906219482421875
             },
             {
               "id": "c93564d6-306c-400f-9bfe-73508ef1addf",
               "label": "Contacts.pptx",
               "format": "Powerpoint for Windows 2007+",
               "puid": "fmt/215",
-              "extension": ".pptx"
+              "extension": ".pptx",
+              "size": 0.04548835754394531,
+              "bulk_extractor": "fixtures/transferdata/bulk-c93564d6-306c-400f-9bfe-73508ef1addf.zip"
             },
             {
               "id": "7fc27b8f-fd4e-4220-bd6d-9db98fb14c9d",
               "label": "Credit Report.pdf",
               "format": "Acrobat PDF 1.5",
-              "puid": "fmt/19"
+              "puid": "fmt/19",
+              "size": 0.037242889404296875
             },
             {
               "id": "8ca89491-5b9a-45e0-8202-3e1a1357eab4",
               "label": "Department.csv",
               "format": "Comma Separated Values",
               "puid": "x-fmt/18",
-              "extension": ".csv"
+              "extension": ".csv",
+              "size": 0.0016050338745117188
             },
             {
               "id": "d2523802-203b-43e5-b5a9-c719985f726b",
-              "label": "Employee Database.accdb"
+              "label": "Employee Database.accdb",
+              "size": 0.37109375
             },
             {
               "id": "2927af84-d519-41f6-8bda-5c1caec67d0c",
-              "label": "Employee Database.mdb"
+              "label": "Employee Database.mdb",
+              "size": 0.21875
             },
             {
               "id": "e198fa44-5958-4039-9273-7239e5c7e571",
               "label": "Hidden Column.xls",
               "format": "Excel 97 Workbook",
-              "puid": "fmt/61"
+              "puid": "fmt/61",
+              "size": 0.01953125
             },
             {
               "id": "7fce5968-013c-46f5-9e9b-3774b2aa5cb0",
               "label": "Tax Return 2008.pdf",
               "format": "Acrobat PDF 1.5",
-              "puid": "fmt/19"
+              "puid": "fmt/19",
+              "size": 0.020104408264160156,
+              "bulk_extractor": "fixtures/transferdata/bulk-7fce5968-013c-46f5-9e9b-3774b2aa5cb0.zip"
             },
             {
               "id": "a7bf717f-c0bd-4161-9a02-a7cb1674c634",
               "label": "application.pdf",
               "format": "Acrobat PDF 1.5",
-              "puid": "fmt/19"
+              "puid": "fmt/19",
+              "size": 0.08741188049316406,
+              "bulk_extractor": "fixtures/transferdata/bulk-a7bf717f-c0bd-4161-9a02-a7cb1674c634.zip"
             },
             {
               "id": "875d8e59-2ff3-4e9e-a4dd-90edd4152305",
               "label": "college essay w footer.doc",
               "format": "Microsoft Word Document 97-2003",
-              "puid": "fmt/40"
+              "puid": "fmt/40",
+              "size": 0.02978515625
             },
             {
               "id": "c233ba1e-014b-4d74-958a-fb05dabc7932",
               "label": "loans.xlsx",
               "format": "Excel for Windows 2007+",
               "puid": "fmt/214",
-              "extension": ".xlsx"
+              "extension": ".xlsx",
+              "size": 0.011753082275390625
             },
             {
               "id": "8f5abbd7-046f-40bd-bae6-6646463c2a41",
               "label": "request.zip",
               "format": "ZIP file",
               "puid": "x-fmt/263",
-              "extension": ".zip"
+              "extension": ".zip",
+              "size": 0.00031948089599609375,
+              "bulk_extractor": "fixtures/transferdata/bulk-8f5abbd7-046f-40bd-bae6-6646463c2a41.zip"
             },
             {
               "id": "61f32c21-46b8-442f-9d55-e1828ea788b5",
               "label": "students.ppt",
               "format": "Powerpoint 97-2002",
-              "puid": "fmt/126"
+              "puid": "fmt/126",
+              "size": 0.1494140625
             },
             {
               "id": "d12aaf8b-1265-47a4-97c3-64ab03fb2c20",
@@ -5792,7 +6596,8 @@
                   "label": "Fake SSNs/fake_ssn.txt",
                   "format": "Generic TXT",
                   "puid": "x-fmt/111",
-                  "extension": ".txt"
+                  "extension": ".txt",
+                  "size": 0.05178642272949219
                 }
               ]
             },
@@ -5811,14 +6616,17 @@
                   "label": "SSN.txt",
                   "format": "Generic TXT",
                   "puid": "x-fmt/111",
-                  "extension": ".txt"
+                  "extension": ".txt",
+                  "size": 0.00034046173095703125
                 },
                 {
                   "id": "97331076-6932-4e19-ad9a-7c31115493e8",
                   "label": "Sample Real CCN.txt",
                   "format": "Generic TXT",
                   "puid": "x-fmt/111",
-                  "extension": ".txt"
+                  "extension": ".txt",
+                  "size": 0.008740425109863281,
+                  "bulk_extractor": "fixtures/transferdata/bulk-97331076-6932-4e19-ad9a-7c31115493e8.zip"
                 }
               ]
             },
@@ -5837,7 +6645,9 @@
                   "label": "request.txt",
                   "format": "Generic TXT",
                   "puid": "x-fmt/111",
-                  "extension": ".txt"
+                  "extension": ".txt",
+                  "size": 0.00025177001953125,
+                  "bulk_extractor": "fixtures/transferdata/bulk-2812a935-017d-4a9c-ab68-6938a9f50f6b.zip"
                 }
               ]
             }

--- a/app/fixtures/transfers.json
+++ b/app/fixtures/transfers.json
@@ -195,106 +195,154 @@
                   "label": "ASL-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 34.27294921875
+                  "size": 34.27294921875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "fba05cf5-5eb2-4051-b7ce-4db43c97f9fc",
                   "label": "Ore-Dock-1.bmp",
                   "format": "Windows BItmap 3.0",
                   "puid": "fmt/116",
-                  "size": 8.077878952026367
+                  "size": 8.077878952026367,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "fd54a7dd-6d40-4257-9be5-13df0b3e9a09",
                   "label": "Ore-Dock-1j.JPG",
                   "format": "JPEG 1.01",
                   "puid": "fmt/43",
-                  "size": 0.32271575927734375
+                  "size": 0.32271575927734375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "b1ed33b9-ba6b-41e0-9063-00099f809d57",
                   "label": "Ore-Dock-2.bmp",
                   "format": "Windows BItmap 3.0",
                   "puid": "fmt/116",
-                  "size": 4.162527084350586
+                  "size": 4.162527084350586,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "7c7af5e8-0b61-4490-a30d-cb414d1b7303",
                   "label": "Ore-Dock-2j.JPG",
                   "format": "JPEG 1.01",
                   "puid": "fmt/43",
-                  "size": 0.15170955657958984
+                  "size": 0.15170955657958984,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "e2f8e0fe-8620-4814-abc0-e50dfd7872de",
                   "label": "Ore-Dock-3.bmp",
                   "format": "Windows BItmap 3.0",
                   "puid": "fmt/116",
-                  "size": 8.459562301635742
+                  "size": 8.459562301635742,
+                  "bulk_extractor_reports": [
+                    "ccn"
+                  ]
                 },
                 {
                   "id": "980c54d1-b4f2-41c9-b0f2-5556512f26ed",
                   "label": "Ore-Dock-3j.JPG",
                   "format": "JPEG 1.01",
                   "puid": "fmt/43",
-                  "size": 0.3149404525756836
+                  "size": 0.3149404525756836,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "cb5ab84e-52d0-473c-896b-c380cc41fb05",
                   "label": "Ore-Dock-4.bmp",
                   "format": "Windows BItmap 3.0",
                   "puid": "fmt/116",
-                  "size": 5.125577926635742
+                  "size": 5.125577926635742,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "3b80e783-3ad3-4fca-9c66-d5cae4b649bd",
                   "label": "Ore-Dock-4j.bmp",
                   "format": "Windows BItmap 3.0",
                   "puid": "fmt/116",
-                  "size": 5.125577926635742
+                  "size": 5.125577926635742,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "404a4e1f-abb5-4d14-86cd-6f2f9ea72189",
                   "label": "Ore-Dock-5.bmp",
                   "format": "Windows BItmap 3.0",
                   "puid": "fmt/116",
-                  "size": 8.580511093139648
+                  "size": 8.580511093139648,
+                  "bulk_extractor_reports": [
+                    "ccn"
+                  ]
                 },
                 {
                   "id": "0d09569d-e6e3-4207-94dd-3c9cbd5a153f",
                   "label": "Ore-Dock-5j.JPG",
                   "format": "JPEG 1.01",
                   "puid": "fmt/43",
-                  "size": 0.3166322708129883
+                  "size": 0.3166322708129883,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "939a1545-91ee-484b-9d87-af3b61b13758",
                   "label": "Ore-Dock-6.bmp",
                   "format": "Windows BItmap 3.0",
                   "puid": "fmt/116",
-                  "size": 1.299734115600586
+                  "size": 1.299734115600586,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "594719c0-b8d6-4dc6-9fa9-3e03154d5e90",
                   "label": "Scrap.shs",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 1.625
+                  "size": 1.625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "e72a068d-c634-4194-8910-ba474d001427",
                   "label": "pptBA.tmp",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 34.27294921875
+                  "size": 34.27294921875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "dc08bcee-c4b9-490e-a98e-a884c4a9973c",
                   "label": "pptC1.tmp",
                   "format": "Generic AIFF",
                   "extension": ".aif",
-                  "size": 34.27294921875
+                  "size": 34.27294921875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 }
+              ],
+              "bulk_extractor_reports": [
+
               ]
             },
             {
@@ -312,8 +360,14 @@
                   "label": "UPDON-2-12-09.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 2.423828125
+                  "size": 2.423828125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 }
+              ],
+              "bulk_extractor_reports": [
+
               ]
             },
             {
@@ -343,612 +397,879 @@
                       "label": "Governor-on-porch.jpg",
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
-                      "size": 0.08105278015136719
+                      "size": 0.08105278015136719,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "497d3903-a7d2-4645-8033-14842ff7725f",
                       "label": "P1000523.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8009662628173828
+                      "size": 0.8009662628173828,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "be9f817f-c17d-4475-b735-2bd898bce100",
                       "label": "P1000524.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.814112663269043
+                      "size": 0.814112663269043,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "7ff32b8d-bd5e-4aaf-83bb-42d86a0feafd",
                       "label": "P1000525.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7834558486938477
+                      "size": 0.7834558486938477,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "132c18e8-a1fa-4f01-b1ca-469e037d06f5",
                       "label": "P1000526.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.781224250793457
+                      "size": 0.781224250793457,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "f7985dea-9e3f-428e-933a-0f410bc70c06",
                       "label": "P1000527.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7889175415039062
+                      "size": 0.7889175415039062,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "e3407b7a-9fdc-4e2f-b976-2a0140a7df62",
                       "label": "P1000528.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7830429077148438
+                      "size": 0.7830429077148438,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "761d4f12-6cee-4c99-b8c8-49ba5728357e",
                       "label": "P1000529.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7952718734741211
+                      "size": 0.7952718734741211,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "3eb7a763-a55c-4149-af48-84d8ad0755d0",
                       "label": "P1000530.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8044652938842773
+                      "size": 0.8044652938842773,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "05e38971-f835-4828-b643-f74396a073b7",
                       "label": "P1000531.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8060264587402344
+                      "size": 0.8060264587402344,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "20961c83-a976-4bed-909d-41fe82938325",
                       "label": "P1000532.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8330612182617188
+                      "size": 0.8330612182617188,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "50928d0f-7855-4775-82d7-f5b9db3654cc",
                       "label": "P1000533.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7969169616699219
+                      "size": 0.7969169616699219,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "ebb8345f-80e8-45d3-8470-338c66931f5c",
                       "label": "P1000534.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7953319549560547
+                      "size": 0.7953319549560547,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "5c14dc3f-93ed-4bd7-b234-ec4e8299cd1c",
                       "label": "P1000535.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7913856506347656
+                      "size": 0.7913856506347656,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "7cbd68c0-a33c-4987-aedd-2af406fd69c3",
                       "label": "P1000536.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7980022430419922
+                      "size": 0.7980022430419922,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "e56b9643-24db-4adf-85ca-cdde977abfb0",
                       "label": "P1000537.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.755314826965332
+                      "size": 0.755314826965332,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "2e31051c-965c-4b91-b882-0cc23d939d17",
                       "label": "P1000538.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7527074813842773
+                      "size": 0.7527074813842773,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "d476f3a5-1071-44c3-87ba-eb2bed302492",
                       "label": "P1000539.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7618980407714844
+                      "size": 0.7618980407714844,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "22397de5-7ff3-4c65-8e00-d02123df2cdc",
                       "label": "P1000540.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7491569519042969
+                      "size": 0.7491569519042969,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "de8c868d-9f68-43f6-a104-31b225095714",
                       "label": "P1000541.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8187351226806641
+                      "size": 0.8187351226806641,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "a9dea238-a58c-4e47-bb4d-20cd4e968daf",
                       "label": "P1000542.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7689790725708008
+                      "size": 0.7689790725708008,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "d7822633-b99e-40c2-a789-f9ff4bed50b4",
                       "label": "P1000543.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.747706413269043
+                      "size": 0.747706413269043,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "76b49be6-2ef0-40a6-afcd-55e037324ffd",
                       "label": "P1000544.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8688259124755859
+                      "size": 0.8688259124755859,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "e3abf244-378b-42f5-9bb0-52de529aadb6",
                       "label": "P1000545.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7807531356811523
+                      "size": 0.7807531356811523,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "5596a7cc-1152-4c4e-9242-6af68f959970",
                       "label": "P1000546.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7750053405761719
+                      "size": 0.7750053405761719,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "8483d5f9-d52f-453f-a728-fd4532f1124f",
                       "label": "P1000547.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7576465606689453
+                      "size": 0.7576465606689453,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "a5c6d5ff-1a07-497a-b1e2-cb3818a191aa",
                       "label": "P1000548.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8059453964233398
+                      "size": 0.8059453964233398,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "65fecb74-0db3-425b-81be-756a28b65333",
                       "label": "P1000549.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7613468170166016
+                      "size": 0.7613468170166016,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "c04d9251-771a-49ee-8f81-4da082779d34",
                       "label": "P1000550.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.782597541809082
+                      "size": 0.782597541809082,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "dc76634e-8f65-4f32-9002-7877b2e7bc82",
                       "label": "P1000551.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8213558197021484
+                      "size": 0.8213558197021484,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "5b6e53ac-cf5c-4317-869e-f2e5d53b15df",
                       "label": "P1000552.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7818355560302734
+                      "size": 0.7818355560302734,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "84e9b639-4e73-4251-a199-eba0e0175b70",
                       "label": "P1000553.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.763340950012207
+                      "size": 0.763340950012207,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "785efffc-ab11-43b3-84ae-f529e6a5bc0e",
                       "label": "P1000554.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8000144958496094
+                      "size": 0.8000144958496094,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "f79b20ae-8afe-4a97-b5cd-7f3fc44e917a",
                       "label": "P1000555.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.772007942199707
+                      "size": 0.772007942199707,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "cc87baf1-ca3c-4ec5-890f-f8d78b300b9f",
                       "label": "P1000556.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.793736457824707
+                      "size": 0.793736457824707,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "157988d8-da8b-42e3-b27b-da3cd84c5036",
                       "label": "P1000557.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7690486907958984
+                      "size": 0.7690486907958984,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "0142ab23-7ad4-4e4d-a40a-f727f2e8b9c1",
                       "label": "P1000558.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7751045227050781
+                      "size": 0.7751045227050781,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "f3501517-d363-435f-a5de-b2d6374ce4f3",
                       "label": "P1000559.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7689371109008789
+                      "size": 0.7689371109008789,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "88192250-59c0-4f9d-b21f-05102e8b36b1",
                       "label": "P1000560.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7914190292358398
+                      "size": 0.7914190292358398,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "0793f544-83b5-49cc-8862-3d0b8fcde3d8",
                       "label": "P1000561.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7871770858764648
+                      "size": 0.7871770858764648,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "1f63a706-cf3e-4a8d-8569-5092e6edc2c4",
                       "label": "P1000562.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8139705657958984
+                      "size": 0.8139705657958984,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "f5bed50d-ec8b-4bc5-8f78-08bd81db830f",
                       "label": "P1000563.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7992067337036133
+                      "size": 0.7992067337036133,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "0d650bbc-c323-429c-9720-74262580d356",
                       "label": "P1000564.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7871217727661133
+                      "size": 0.7871217727661133,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "9d970656-204e-4536-85c5-e6fbbc859082",
                       "label": "P1000565.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7658786773681641
+                      "size": 0.7658786773681641,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "461668df-7cab-44ca-a530-dbc82216b478",
                       "label": "P1000566.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7848920822143555
+                      "size": 0.7848920822143555,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "f756d45f-c4fe-4181-b7d4-932edb79c0b0",
                       "label": "P1000567.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7803659439086914
+                      "size": 0.7803659439086914,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "a0cf623f-11b8-43c0-bc55-8039fed63465",
                       "label": "P1000568.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7725648880004883
+                      "size": 0.7725648880004883,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "24e38fd3-4e53-48c1-84cc-a4c36cc1fa53",
                       "label": "P1000569.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8094930648803711
+                      "size": 0.8094930648803711,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "d40562b8-160e-45b2-a722-4c0a66b6757d",
                       "label": "P1000570.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7844257354736328
+                      "size": 0.7844257354736328,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "88a5bb2e-f97e-4ab5-aed5-cebbdd8a956e",
                       "label": "P1000571.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7758417129516602
+                      "size": 0.7758417129516602,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "9b77a50f-21bd-4b1e-9bc8-bc7401efb524",
                       "label": "P1000572.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8068809509277344
+                      "size": 0.8068809509277344,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "faaae401-3b69-4529-bf01-ead46223e9da",
                       "label": "P1000573.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8430023193359375
+                      "size": 0.8430023193359375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "7197e739-68ef-4475-b4ff-b0b380da4f83",
                       "label": "P1000574.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7767734527587891
+                      "size": 0.7767734527587891,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "cb5503b7-b8e7-422f-bd71-b8a18cc87908",
                       "label": "P1000575.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8145170211791992
+                      "size": 0.8145170211791992,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "f43e7a56-c3a0-4d75-9ccb-68884d226b5c",
                       "label": "P1000576.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7862424850463867
+                      "size": 0.7862424850463867,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "68083f0f-b8a6-4f42-9511-bc56d6bb82fb",
                       "label": "P1000577.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7979192733764648
+                      "size": 0.7979192733764648,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "f97697b1-4f9f-4ff9-a458-56467c85f884",
                       "label": "P1000578.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7981901168823242
+                      "size": 0.7981901168823242,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "30c43413-e0aa-418c-b0c4-42a7c86afda2",
                       "label": "P1000579.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7796869277954102
+                      "size": 0.7796869277954102,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "dd34d12d-b14b-417c-977d-7b136f1e755e",
                       "label": "P1000580.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.765960693359375
+                      "size": 0.765960693359375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "8397474d-5c4b-440f-9121-2c5650003aec",
                       "label": "P1000581.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8168249130249023
+                      "size": 0.8168249130249023,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "48c5e31d-8c51-4708-a6ef-cd6e4c78d609",
                       "label": "P1000582.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8315887451171875
+                      "size": 0.8315887451171875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "501f0542-c4e1-48c2-b2ed-1fe8a1da198a",
                       "label": "P1000583.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7961263656616211
+                      "size": 0.7961263656616211,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "3672bbea-ac24-464a-849f-3fcc2ba167dd",
                       "label": "P1000584.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8884744644165039
+                      "size": 0.8884744644165039,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "99de286e-324c-4e88-964f-75c6c8c84d60",
                       "label": "P1000585.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8134365081787109
+                      "size": 0.8134365081787109,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "2eb3b488-b691-4f99-bf96-97d4acaa054f",
                       "label": "P1000586.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7922048568725586
+                      "size": 0.7922048568725586,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "efc67149-fbad-440a-b2fe-4319feec5d55",
                       "label": "P1000587.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7921237945556641
+                      "size": 0.7921237945556641,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "c6d3e75b-a371-4d2f-a79f-1e79c592a140",
                       "label": "P1000588.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7933330535888672
+                      "size": 0.7933330535888672,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "70f65deb-9e7a-4f92-a99c-0fdf294f7fdd",
                       "label": "P1000589.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8035268783569336
+                      "size": 0.8035268783569336,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "f54243ae-a4f5-4ac6-8202-30d30a91261c",
                       "label": "P1000590.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8170976638793945
+                      "size": 0.8170976638793945,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "ab51e1b5-fccd-4b6e-b3f1-b88f9251b07a",
                       "label": "P1000591.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.800572395324707
+                      "size": 0.800572395324707,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "6d906217-6458-439d-b739-9d6f6ed5de1a",
                       "label": "P1000592.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7927703857421875
+                      "size": 0.7927703857421875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "25826c3f-6644-4560-ad1d-90d63d16b977",
                       "label": "P1000593.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8036422729492188
+                      "size": 0.8036422729492188,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "d3c0df7e-7e21-4a2f-8347-7b7d34144551",
                       "label": "P1000594.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8312406539916992
+                      "size": 0.8312406539916992,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "b3e2ab77-273e-412b-8c02-6807f12f8ae9",
                       "label": "P1000595.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8409929275512695
+                      "size": 0.8409929275512695,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "060bda3a-654c-4f72-ac8e-16aaddf4a7e1",
                       "label": "P1000596.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8118019104003906
+                      "size": 0.8118019104003906,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "c23823a9-42c4-4546-aeb6-1507a38b9236",
                       "label": "P1000597.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8356647491455078
+                      "size": 0.8356647491455078,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "be421136-a8dd-457d-9537-3e8154647824",
                       "label": "P1000598.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7507753372192383
+                      "size": 0.7507753372192383,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "77ef26ef-a5e5-49b2-a7fb-0742c5f848b2",
                       "label": "P1000599.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7954301834106445
+                      "size": 0.7954301834106445,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "5b80a6a3-e73a-4366-b130-287aa002f237",
                       "label": "P1000600.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7864618301391602
+                      "size": 0.7864618301391602,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "7c090df9-afbc-4ebd-9832-ef8da3d44c04",
                       "label": "P1000601.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7706813812255859
+                      "size": 0.7706813812255859,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "6d72b786-4718-4d80-a50a-9286ec23c628",
                       "label": "P1000602.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.9040975570678711
+                      "size": 0.9040975570678711,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "0e0f4919-f21e-49db-8f91-44bad02fb9e7",
                       "label": "P1000603.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8049325942993164
+                      "size": 0.8049325942993164,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "940238cc-aa0c-441a-8a41-35364728e429",
                       "label": "P1000604.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8940935134887695
+                      "size": 0.8940935134887695,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "a5a04280-8846-4c91-9a3f-135cacd737b5",
                       "label": "P1000605.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7748327255249023
+                      "size": 0.7748327255249023,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "086be05e-e97c-402e-b5f8-901142fade2f",
                       "label": "P1000606.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.828333854675293
+                      "size": 0.828333854675293,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "1fb3558a-ae76-4149-af0d-eec945782861",
                       "label": "P1000607.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8012609481811523
+                      "size": 0.8012609481811523,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "14b07096-9ea6-48a7-a2e5-271aed872474",
                       "label": "P1000608.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.8071603775024414
+                      "size": 0.8071603775024414,
+                      "bulk_extractor_reports": [
+
+                      ]
                     }
+                  ],
+                  "bulk_extractor_reports": [
+
                   ]
                 }
+              ],
+              "bulk_extractor_reports": [
+
               ]
             },
             {
@@ -968,29 +1289,44 @@
                   "label": "Cool-Cities-Attendees-xls.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.04345703125
+                  "size": 0.04345703125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "6e6000f2-bb3c-4e1f-900f-b5366a6c6770",
                   "label": "Cool-Cities-Overflow.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.01318359375
+                  "size": 0.01318359375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "7c1e12e1-740a-4cdb-9b6a-c66a4d0d425f",
                   "label": "Cool-cities-panel-marquette.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.01708984375
+                  "size": 0.01708984375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "6f4b530e-6a43-4631-8784-ef5bedfbfa76",
                   "label": "Copy-of-Cool-Cities-Overflow-xls.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.02978515625
+                  "size": 0.02978515625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 }
+              ],
+              "bulk_extractor_reports": [
+
               ]
             },
             {
@@ -1012,176 +1348,254 @@
                   "label": "2010-Updates.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.0517578125
+                  "size": 0.0517578125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "17454352-a46e-4515-84ca-067da09d3615",
                   "label": "Academic-SL-2005.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.02490234375
+                  "size": 0.02490234375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "7b8c218c-e209-491b-91b2-1b24887a823f",
                   "label": "All-American-City-Award.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.033203125
+                  "size": 0.033203125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "81f6924c-40df-4ce5-9511-d8c73da3f8e4",
                   "label": "CCI-CEO-Meeting.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.02734375
+                  "size": 0.02734375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "3039bd86-cb4a-4897-b273-93b4a3980434",
                   "label": "Dedications-Groundbreakings-2010.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.03466796875
+                  "size": 0.03466796875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "2508bef1-0161-4505-b0bc-0769b99a44e2",
                   "label": "Final-Leadership-Michigan-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 8.13134765625
+                  "size": 8.13134765625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "3e88bdf3-eb30-4789-9682-30d208971048",
                   "label": "GOVERNORS-UP-Events-xls.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.033203125
+                  "size": 0.033203125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "032b31d6-5850-4fd7-8cbd-7367b0553a1a",
                   "label": "Intergovernmental-Relations.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 7.2451171875
+                  "size": 7.2451171875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "6dd14b4a-e174-439f-a13a-629a0ec14956",
                   "label": "Khoury-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 11.59326171875
+                  "size": 11.59326171875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "b64fef12-3e74-4f15-ae77-d77c308fface",
                   "label": "LeadAcadJan6.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 3.40283203125
+                  "size": 3.40283203125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "2d421c3a-c412-4f5c-93c6-a24c88b707f2",
                   "label": "Logging-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 1.287109375
+                  "size": 1.287109375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "938b88fd-83d3-4be6-aa32-71a19b74a0b1",
                   "label": "Negaunee-Regional-Dispatch-Center.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.19482421875
+                  "size": 0.19482421875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "f057bc7a-5805-4a67-8ca2-3821c0707449",
                   "label": "Revised-UP-Events2.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.0205078125
+                  "size": 0.0205078125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "88468acc-c3ef-480f-8172-c396f5d70649",
                   "label": "SERVICE-SHARING-MEETINGS-SUMMARY.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.04833984375
+                  "size": 0.04833984375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "58092af3-d330-42ff-87c9-9792f2cd0b09",
                   "label": "UP-EVENTS-2005.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.04541015625
+                  "size": 0.04541015625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "540b03c1-d170-4846-9139-7b51b540107d",
                   "label": "UP-Events-by-County.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.01904296875
+                  "size": 0.01904296875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "1a9fca5e-dc8a-43eb-84b4-c4fa24a59797",
                   "label": "UP-accomplishments.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.0341796875
+                  "size": 0.0341796875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "5edd8fe9-0dd3-4ce0-a3ca-b0cd7b459481",
                   "label": "USFS-Memo.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.0263671875
+                  "size": 0.0263671875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "e6121271-2e44-4d6b-8c8b-c7157b942e19",
                   "label": "Updated-Govs-UP-Events.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.02001953125
+                  "size": 0.02001953125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "9a847fe6-33cc-4f8c-81fd-9c42619744ac",
                   "label": "Upper-Peninsula-Hot-Topics.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.0615234375
+                  "size": 0.0615234375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "dafc2bc7-2081-4882-8763-2cce2ae59f4b",
                   "label": "Viosport-briefing.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.025390625
+                  "size": 0.025390625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "b839983f-3b05-4ae3-8831-d4b0f012b76b",
                   "label": "goals-resp.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.03662109375
+                  "size": 0.03662109375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "557195d2-7554-4581-9957-e00278d3af2e",
                   "label": "kipling-meeting-notes.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.037109375
+                  "size": 0.037109375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "25fbad5c-1043-4539-a9b7-1600c1bfbc7c",
                   "label": "smurfit-stone.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.03125
+                  "size": 0.03125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "6f196df8-8612-40be-9882-e15a8ac6aec5",
                   "label": "up-CHAMBER-CONTACTS.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.0390625
+                  "size": 0.0390625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 }
+              ],
+              "bulk_extractor_reports": [
+
               ]
             },
             {
@@ -1219,36 +1633,54 @@
                       "label": "Briefing-Format.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.021484375
+                      "size": 0.021484375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "16d6595e-4675-4e5a-9d10-06c317e602cd",
                       "label": "Luncheon-8-21-Briefing-Format.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.03125
+                      "size": 0.03125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "48712dd2-bb58-4716-80ad-e8e839afe59b",
                       "label": "governors-up-tour-schedule-tentative.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.03466796875
+                      "size": 0.03466796875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "1dd6fb3c-5bb5-4610-b8e6-9cabb580c24f",
                       "label": "governors-up-tour-schedule.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.03857421875
+                      "size": 0.03857421875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "cdf81782-ec5a-4ded-bd2a-074a011fd53f",
                       "label": "governors-up-tour-schedule2.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.056640625
+                      "size": 0.056640625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     }
+                  ],
+                  "bulk_extractor_reports": [
+
                   ]
                 },
                 {
@@ -1289,113 +1721,164 @@
                           "label": "August-2005.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.0283203125
+                          "size": 0.0283203125,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "6da5567a-a26f-4aa3-8712-e8cb91c99ee0",
                           "label": "August-20052.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.03173828125
+                          "size": 0.03173828125,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "228cd181-73ab-4abd-a951-cb526816581c",
                           "label": "Baldini.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.0263671875
+                          "size": 0.0263671875,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "561fe044-c4d3-49f1-ac2b-9a48c9750715",
                           "label": "Briefing-2-17-05-Hockey-NMU-vs-MTU.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.02197265625
+                          "size": 0.02197265625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "bce0b0e4-3226-43f2-ac93-9bb1bbb50368",
                           "label": "December-2005-027.jpg",
                           "format": "Exchangeable Image File Format (Compressed) 2.2",
                           "puid": "x-fmt/391",
-                          "size": 0.18732166290283203
+                          "size": 0.18732166290283203,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "86489154-8ac4-4c70-893e-7217d90581fe",
                           "label": "December-2005-076.jpg",
                           "format": "Exchangeable Image File Format (Compressed) 2.2",
                           "puid": "x-fmt/391",
-                          "size": 0.3082914352416992
+                          "size": 0.3082914352416992,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "adee224e-683d-40a9-8d40-dca105407d92",
                           "label": "Eagle-River-Community-BBQ.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.02978515625
+                          "size": 0.02978515625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "996feff5-173c-4b68-84d3-93ea53f214c3",
                           "label": "Feb18-19-2005.rtf",
                           "format": "RTF 1.7",
                           "puid": "fmt/52",
-                          "size": 0.026185989379882812
+                          "size": 0.026185989379882812,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "75ea4441-a3ba-4c66-aec9-30c1a2f81a34",
                           "label": "February-18-2005-Alpha-List-Final.xls",
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
-                          "size": 0.03125
+                          "size": 0.03125,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "7fcc13da-e5d2-47d1-9917-e1914c8f83cc",
                           "label": "February-18-2005-Alpha-List.xls",
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
-                          "size": 0.03125
+                          "size": 0.03125,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "14a87165-ba8b-4642-af58-a78941518598",
                           "label": "List-of-Govs-Community-Meeting-2-18-05.xls",
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
-                          "size": 0.02880859375
+                          "size": 0.02880859375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "69443f0e-6891-4b77-afbe-69714d4b9c05",
                           "label": "Raildroad-Issue.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.02978515625
+                          "size": 0.02978515625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "dbb284aa-48d1-40de-9d5c-f73bf2a61619",
                           "label": "Saturday-Trip.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.0263671875
+                          "size": 0.0263671875,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "f60a55aa-dd28-42f9-a9e6-f4ef552d7090",
                           "label": "UP-Sheriffs-Meeting.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.03369140625
+                          "size": 0.03369140625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "f7e605d7-5302-424e-9c69-864c6bd7dc9a",
                           "label": "stacys-info-for-oct-15.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.201171875
+                          "size": 0.201171875,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "d2d8260f-1a38-40e2-9ca5-d4d376f28f9b",
                           "label": "stacys-info-for-oct-15.docm",
                           "format": "Macro enabled Microsoft Word Document OOXML",
                           "puid": "fmt/523",
-                          "size": 0.09428215026855469
+                          "size": 0.09428215026855469,
+                          "bulk_extractor_reports": [
+
+                          ]
                         }
+                      ],
+                      "bulk_extractor_reports": [
+
                       ]
                     },
                     {
@@ -1416,133 +1899,190 @@
                           "label": "August-2005.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.0283203125
+                          "size": 0.0283203125,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "d9c5a5ee-6d48-4449-ba27-d012ba7b8351",
                           "label": "Briefing-2-17-05-WNMU.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.02099609375
+                          "size": 0.02099609375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "adaf98fb-8b4e-4f1c-8cf3-18026cd192ed",
                           "label": "Channel-5-10-TapeBriefing.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.02197265625
+                          "size": 0.02197265625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "c796e845-7cf5-493d-a369-00e580bc7f3b",
                           "label": "Channel6-Briefing.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.021484375
+                          "size": 0.021484375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "cde87da1-3981-45ce-9e64-a6272bc150a1",
                           "label": "List-of-Govs-Community-Meeting-2-17-05.xls",
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
-                          "size": 0.0283203125
+                          "size": 0.0283203125,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "9e20a2fe-18cc-4d1e-a2f4-430feae7ab46",
                           "label": "MEA-Briefing.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.02099609375
+                          "size": 0.02099609375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "04579e84-0073-450a-b551-5f97e5302733",
                           "label": "MTUvsNMU-Hockey.rtf",
                           "format": "RTF 1.7",
                           "puid": "fmt/52",
-                          "size": 0.02553844451904297
+                          "size": 0.02553844451904297,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "e60ef089-94e8-4261-9a50-33d5a9ca35dc",
                           "label": "Mining-Journal-Reception.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.021484375
+                          "size": 0.021484375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "f546db3f-e04e-40db-9b3e-fd226ebf6e2d",
                           "label": "Mushers-Banquet.rtf",
                           "format": "RTF 1.7",
                           "puid": "fmt/52",
-                          "size": 0.029611587524414062
+                          "size": 0.029611587524414062,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "f1345d7c-3f39-470f-b945-da091d8b5f84",
                           "label": "Radio-InterviewBriefing.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.02197265625
+                          "size": 0.02197265625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "d33bb877-b513-46ce-91a8-02f4c52441ed",
                           "label": "State-of-State-Event.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.0224609375
+                          "size": 0.0224609375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "00a94dd2-4a7e-43dc-ab38-ca2601b4eafe",
                           "label": "Student-List-for-2-18-05-final.xls",
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
-                          "size": 0.02001953125
+                          "size": 0.02001953125,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "cf1d1a63-b7e9-4498-8e92-7804bc144c44",
                           "label": "Student-List-for-2-18-05.xls",
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
-                          "size": 0.02001953125
+                          "size": 0.02001953125,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "995878a4-48e2-4685-bfe1-254aaeb04132",
                           "label": "StudentPhoto-Op.rtf",
                           "format": "RTF 1.7",
                           "puid": "fmt/52",
-                          "size": 0.09092235565185547
+                          "size": 0.09092235565185547,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "741b89ad-afcf-4e78-bbf4-d3445d973b94",
                           "label": "Thank-yous-for-UP-200.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.03662109375
+                          "size": 0.03662109375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "0d6d11f5-cb26-45ad-85ef-a42f81c9de60",
                           "label": "UP-200-Briefing.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.0283203125
+                          "size": 0.0283203125,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "ed5e4a1e-f8f6-4511-98e3-87e19d99f6a2",
                           "label": "UP-200-TOdo.xls",
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
-                          "size": 0.0146484375
+                          "size": 0.0146484375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "af96037d-13ec-4e8c-8087-64a06e186c96",
                           "label": "UP-Roadbuilders.rtf",
                           "format": "RTF 1.7",
                           "puid": "fmt/52",
-                          "size": 0.024362564086914062
+                          "size": 0.024362564086914062,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "cdf0d9a1-8e9c-4a2f-bed0-cdf8897053cb",
                           "label": "addresses.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.02587890625
+                          "size": 0.02587890625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "6f8389e8-5af4-40f1-9dbc-e7db0ffdf548",
@@ -1560,59 +2100,89 @@
                               "label": "Channel-5-10-TapeBriefing.doc",
                               "format": "Microsoft Word Document 97-2003",
                               "puid": "fmt/40",
-                              "size": 0.02197265625
+                              "size": 0.02197265625,
+                              "bulk_extractor_reports": [
+
+                              ]
                             },
                             {
                               "id": "9892f551-2d10-416c-a2a8-2a03035ae93a",
                               "label": "Channel6-Briefing.doc",
                               "format": "Microsoft Word Document 97-2003",
                               "puid": "fmt/40",
-                              "size": 0.021484375
+                              "size": 0.021484375,
+                              "bulk_extractor_reports": [
+
+                              ]
                             },
                             {
                               "id": "6e5234ab-1901-46b8-883e-75cef99cc59a",
                               "label": "MTUvsNMU-Hockey.rtf",
                               "format": "RTF 1.7",
                               "puid": "fmt/52",
-                              "size": 0.021958351135253906
+                              "size": 0.021958351135253906,
+                              "bulk_extractor_reports": [
+
+                              ]
                             },
                             {
                               "id": "5ff22c6b-8d8d-4135-912d-49cf93f2c0f0",
                               "label": "Mushers-Banquet.rtf",
                               "format": "RTF 1.7",
                               "puid": "fmt/52",
-                              "size": 0.027553558349609375
+                              "size": 0.027553558349609375,
+                              "bulk_extractor_reports": [
+
+                              ]
                             },
                             {
                               "id": "b80d9661-332a-4c3e-be8d-35fafc56fff3",
                               "label": "Radio-InterviewBriefing.doc",
                               "format": "Microsoft Word Document 97-2003",
                               "puid": "fmt/40",
-                              "size": 0.02197265625
+                              "size": 0.02197265625,
+                              "bulk_extractor_reports": [
+
+                              ]
                             },
                             {
                               "id": "6196dc90-41fd-4494-ad51-b8c9fa96851f",
                               "label": "UP-Higher-Ed.rtf",
                               "format": "RTF 1.7",
                               "puid": "fmt/52",
-                              "size": 0.09070301055908203
+                              "size": 0.09070301055908203,
+                              "bulk_extractor_reports": [
+
+                              ]
                             },
                             {
                               "id": "cb810a02-00de-40dc-bdfc-67ef868752ee",
                               "label": "UP-Roadbuilders.rtf",
                               "format": "RTF 1.7",
                               "puid": "fmt/52",
-                              "size": 0.019263267517089844
+                              "size": 0.019263267517089844,
+                              "bulk_extractor_reports": [
+
+                              ]
                             },
                             {
                               "id": "a8edcb1d-611d-4d94-99f1-958b347123a2",
                               "label": "addresses.doc",
                               "format": "Microsoft Word Document 97-2003",
                               "puid": "fmt/40",
-                              "size": 0.02587890625
+                              "size": 0.02587890625,
+                              "bulk_extractor_reports": [
+
+                              ]
                             }
+                          ],
+                          "bulk_extractor_reports": [
+
                           ]
                         }
+                      ],
+                      "bulk_extractor_reports": [
+
                       ]
                     },
                     {
@@ -1631,147 +2201,210 @@
                           "label": "Brinzo.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.033203125
+                          "size": 0.033203125,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "8d4d91aa-316f-472f-b966-e701def05a08",
                           "label": "CCI-Reception.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.02783203125
+                          "size": 0.02783203125,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "12630596-c19e-45d8-84ac-f9b1ea4f2c3d",
                           "label": "HOT-TOPICS-Stacy.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.09228515625
+                          "size": 0.09228515625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "43144f4f-3301-465f-91b8-5c90b152a5ba",
                           "label": "HOT-TOPICS.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.07666015625
+                          "size": 0.07666015625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "b389f053-a87d-418b-bac2-8b864775ef97",
                           "label": "Holiday-Reception-w-State-Employees.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.02978515625
+                          "size": 0.02978515625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "c1a8777c-3e8a-4e60-b9c4-6b39a1e3d864",
                           "label": "Jacobetti.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.0458984375
+                          "size": 0.0458984375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "abb2c7fd-7192-4005-942a-e9970e44bb0e",
                           "label": "MTEC-Smartzone.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.166015625
+                          "size": 0.166015625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "963b83eb-5e78-4d49-bad7-a4275b23f5fb",
                           "label": "Media-Meet.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.02490234375
+                          "size": 0.02490234375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "2a3a96f2-0398-4197-b39e-d9de872c5a0c",
                           "label": "Mqt-Dem-Reception.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.0283203125
+                          "size": 0.0283203125,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "5cff93c5-9534-4019-abb2-450e54177333",
                           "label": "Pioneer-Surgical-Jobs-Stop.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.03369140625
+                          "size": 0.03369140625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "b31461ec-3baf-4f20-b557-8f973aeb9d77",
                           "label": "Precision-Edge-Jobs-Stop.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.03662109375
+                          "size": 0.03662109375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "ee10e602-11a6-4e09-bbca-87b7a643c179",
                           "label": "Radio-Call-Houghton.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.02587890625
+                          "size": 0.02587890625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "8aa7103c-f139-4a47-af80-da9254c0dd7c",
                           "label": "Sheriffs.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.0302734375
+                          "size": 0.0302734375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "27f24a9f-7937-4b6b-9e19-119f592e53f1",
                           "label": "Soo-Evening-News.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.0244140625
+                          "size": 0.0244140625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "3a9792fe-8538-4c0e-aade-86dc5e19d3b9",
                           "label": "Speed-Skating.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.03076171875
+                          "size": 0.03076171875,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "e997cc16-a01e-4ce0-aff2-093f36b99055",
                           "label": "Tellurex-Jobs-Stop.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.03564453125
+                          "size": 0.03564453125,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "20676ce4-29f2-42cf-81df-2e19cf5cb3ab",
                           "label": "Thank-you-list.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.0400390625
+                          "size": 0.0400390625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "493fb126-0d9b-4d78-a579-8d45f74792ee",
                           "label": "WSOO.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.025390625
+                          "size": 0.025390625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "be9e0242-3434-4c06-b4bb-55d1e09304c5",
                           "label": "Walt-Lindala.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.0244140625
+                          "size": 0.0244140625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "ccf7d3eb-28f0-4701-b314-2c5ed4e024b3",
                           "label": "dec-schedule.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.0322265625
+                          "size": 0.0322265625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "825d1146-1f8a-4039-9371-598b1fefcabc",
                           "label": "skeleton-schedule.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.0322265625
+                          "size": 0.0322265625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "7fa523ad-dbef-4b56-9735-1f9d909240e2",
@@ -1789,19 +2422,34 @@
                               "label": "Document-Scrap-UPDATE-ON-THE-MA.shs",
                               "format": "Generic AIFF",
                               "extension": ".aif",
-                              "size": 0.076171875
+                              "size": 0.076171875,
+                              "bulk_extractor_reports": [
+
+                              ]
                             },
                             {
                               "id": "395842f5-a575-45c7-abc0-dce0781139a7",
                               "label": "Hot-topics.doc",
                               "format": "Microsoft Word Document 97-2003",
                               "puid": "fmt/40",
-                              "size": 0.0419921875
+                              "size": 0.0419921875,
+                              "bulk_extractor_reports": [
+
+                              ]
                             }
+                          ],
+                          "bulk_extractor_reports": [
+
                           ]
                         }
+                      ],
+                      "bulk_extractor_reports": [
+
                       ]
                     }
+                  ],
+                  "bulk_extractor_reports": [
+
                   ]
                 },
                 {
@@ -1839,155 +2487,224 @@
                           "label": "Ag-Solutions-1.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.029296875
+                          "size": 0.029296875,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "b5542de6-a0bd-42f6-afb5-452b536f368e",
                           "label": "Ag-Solutions-Attach-1.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.0302734375
+                          "size": 0.0302734375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "a6186720-5430-462a-a28b-eb53e7276512",
                           "label": "Ag-Solutions-Attach-2.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.029296875
+                          "size": 0.029296875,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "a448c397-795a-455b-9cb5-e68c8a3ac677",
                           "label": "Attendance-Listing-Fair-Luncheon.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.2744140625
+                          "size": 0.2744140625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "ae2a1475-940f-41c2-a66b-224a05e401a0",
                           "label": "EMP-BusAug06.ppt",
                           "format": "Powerpoint 97-2002",
                           "puid": "fmt/126",
-                          "size": 0.52001953125
+                          "size": 0.52001953125,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "8ce1a0d8-8feb-4956-8458-36fb8cb7db72",
                           "label": "Fair-growing-up-foresters-exhibit.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.08056640625
+                          "size": 0.08056640625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "edaf7a5a-6cc2-494d-a816-7841e1d9057d",
                           "label": "Issues-and-Answers.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.02685546875
+                          "size": 0.02685546875,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "05fc75fd-6f60-4534-903d-fd4c446c4d0b",
                           "label": "OSF-St-Francis-Hospital.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.04833984375
+                          "size": 0.04833984375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "1bdff87b-9632-444f-b909-50b0063f277e",
                           "label": "Road-Projects-Photo-Op.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.037109375
+                          "size": 0.037109375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "f48dc0ac-3596-4f5a-915d-925c3d978b13",
                           "label": "Schedule-Aug-17-18.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.04248046875
+                          "size": 0.04248046875,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "89ddb9ea-36cf-45b6-8a0a-690a5e918abf",
                           "label": "Systems-Control.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.03076171875
+                          "size": 0.03076171875,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "eca4896c-f745-47a1-8262-1ac29168b15b",
                           "label": "Thomas-St-Onge-Musuem.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.04638671875
+                          "size": 0.04638671875,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "86144a4a-8602-4d3e-97de-5cf38a2d7b0e",
                           "label": "UP-State-Fair-Governors-Luncheon.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.0810546875
+                          "size": 0.0810546875,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "4d30eaf2-055e-4f73-bc64-74233e73aa7f",
                           "label": "UP-State-Fair-Luncheon-SPEECH-Info.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.02001953125
+                          "size": 0.02001953125,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "d1fd867a-fda7-45d2-a8ed-f4f44b825f9e",
                           "label": "hospital-5.jpg",
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
-                          "size": 0.4102621078491211
+                          "size": 0.4102621078491211,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "db28ed82-029d-4c43-9b1d-fa11829a9f24",
                           "label": "hospital-attach-3.jpg",
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
-                          "size": 0.2659187316894531
+                          "size": 0.2659187316894531,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "63dc34fe-9a1e-4a4f-906c-6ab6a4b34631",
                           "label": "hospital-attach-4.jpg",
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
-                          "size": 0.3942089080810547
+                          "size": 0.3942089080810547,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "df9e5388-5a0a-49f7-9aee-531f7ccdc7e9",
                           "label": "hospital-attach1.jpg",
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
-                          "size": 0.3028888702392578
+                          "size": 0.3028888702392578,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "b2ac4479-96a1-4faf-b0b7-e32bd65a1dc9",
                           "label": "hospital-attach2.jpg",
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
-                          "size": 0.2250232696533203
+                          "size": 0.2250232696533203,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "7735175b-a3ae-4c16-a9af-7a55367f0f84",
                           "label": "hospital-map-2.jpg",
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
-                          "size": 0.2515392303466797
+                          "size": 0.2515392303466797,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "d4a3ae3a-8a27-4bef-b324-956fe5df8282",
                           "label": "hospital-map.jpg",
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
-                          "size": 0.3233680725097656
+                          "size": 0.3233680725097656,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "0b106727-712c-46b8-8dce-55cab5518280",
                           "label": "skelton-schedule-draft.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.041015625
+                          "size": 0.041015625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         }
+                      ],
+                      "bulk_extractor_reports": [
+
                       ]
                     },
                     {
@@ -2007,64 +2724,94 @@
                           "label": "2nd-annual-Veterans-Ride.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.025390625
+                          "size": 0.025390625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "a51a71cf-6887-4691-b7d0-945598df2fd5",
                           "label": "Governors-summer-06-up-trip1.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.03759765625
+                          "size": 0.03759765625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "1af5ea2f-e411-4f3e-b3e9-d7603ad21e3c",
                           "label": "Issues-and-Answers.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.02685546875
+                          "size": 0.02685546875,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "45e19805-ebd5-4ce8-b7c5-60bf2f1f545f",
                           "label": "May-30.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.0400390625
+                          "size": 0.0400390625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "39f93859-661a-4ae8-8a00-7be3e81ff16d",
                           "label": "RSVP-State-Employee-Rec.xls",
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
-                          "size": 0.0166015625
+                          "size": 0.0166015625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "1e2d3c50-e569-46bd-94b4-6be3040136ec",
                           "label": "Schedule-Aug-17-18.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.04052734375
+                          "size": 0.04052734375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "06d8687e-4e78-4324-adbc-06f6d996ada6",
                           "label": "Summer-06-up-trip1.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.03759765625
+                          "size": 0.03759765625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "d207dcf6-3612-4898-9ba0-523b49ffd49f",
                           "label": "letter-presentation-311.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.02392578125
+                          "size": 0.02392578125,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "189584fd-3b38-49fb-b9dd-d32abfa3c207",
                           "label": "manistique-diner-meet-and-greet.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.02294921875
+                          "size": 0.02294921875,
+                          "bulk_extractor_reports": [
+
+                          ]
                         }
+                      ],
+                      "bulk_extractor_reports": [
+
                       ]
                     },
                     {
@@ -2082,36 +2829,54 @@
                           "label": "Daily-News-Interview-Hannahville.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.02587890625
+                          "size": 0.02587890625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "43cf44c1-ccce-4e4f-87fe-88fc3c85debd",
                           "label": "Daily-Press-Interview.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.02294921875
+                          "size": 0.02294921875,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "dd25b8c3-bc2f-4aea-ad99-d8dc4057f087",
                           "label": "MIX-106-Interview.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.02294921875
+                          "size": 0.02294921875,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "b6d83d7b-b24b-475e-af9f-9e2311f6df08",
                           "label": "What-is-MCAC.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.23486328125
+                          "size": 0.23486328125,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "59768f7f-f592-4211-84d6-48298ac409d5",
                           "label": "minimum-wage-info.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.04443359375
+                          "size": 0.04443359375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         }
+                      ],
+                      "bulk_extractor_reports": [
+
                       ]
                     },
                     {
@@ -2129,24 +2894,39 @@
                           "label": "Employee-Appreciation.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.03076171875
+                          "size": 0.03076171875,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "ee571b4f-2563-43fd-9268-247e1ce735ab",
                           "label": "SERA-attachment.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.0263671875
+                          "size": 0.0263671875,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "ae7960a5-bf2b-4246-a665-de5e864e9b13",
                           "label": "SERA.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.0283203125
+                          "size": 0.0283203125,
+                          "bulk_extractor_reports": [
+
+                          ]
                         }
+                      ],
+                      "bulk_extractor_reports": [
+
                       ]
                     }
+                  ],
+                  "bulk_extractor_reports": [
+
                   ]
                 },
                 {
@@ -2166,38 +2946,59 @@
                       "label": "Detailed-Western-Lime-Agenda-2.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02001953125
+                      "size": 0.02001953125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "77e60beb-4896-4f3b-9cf2-36f307136d27",
                       "label": "Govs-luncheon-Attendees.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.63134765625
+                      "size": 0.63134765625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "f0ae0d82-42c0-457a-b8d5-2328521bfe4e",
                       "label": "Open-House-Invitations.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.0302734375
+                      "size": 0.0302734375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "fbc9698f-0f15-40d8-8206-c92ffb9ac87d",
                       "label": "UP-State-Fair-Governors-Luncheon-2007.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.08203125
+                      "size": 0.08203125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "30b58a1d-8c9e-4fd0-9695-099c5b6717ec",
                       "label": "Vet-of-the-Year-Background-2007.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0224609375
+                      "size": 0.0224609375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     }
+                  ],
+                  "bulk_extractor_reports": [
+
                   ]
                 }
+              ],
+              "bulk_extractor_reports": [
+
               ]
             },
             {
@@ -2230,85 +3031,124 @@
                       "label": "Bridge-Walk-Overview-2.jpg",
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
-                      "size": 0.09985733032226562
+                      "size": 0.09985733032226562,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "b8a1356e-4563-4a66-b952-099e03de6f18",
                       "label": "Gov-Mackinac-Island.jpg",
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
-                      "size": 2.651556968688965
+                      "size": 2.651556968688965,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "31335337-5557-4658-bc84-45dde970ae17",
                       "label": "Governor-Granholm-Press-Photo.jpg",
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
-                      "size": 3.1488656997680664
+                      "size": 3.1488656997680664,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "4cf9172c-d9e1-4a69-ae76-ab05fe9bd425",
                       "label": "Governor-on-porch.jpg",
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
-                      "size": 0.08105278015136719
+                      "size": 0.08105278015136719,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "03ca0930-3e51-4f69-a2df-1e598132c380",
                       "label": "Governor-with-child.jpg",
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
-                      "size": 0.06903934478759766
+                      "size": 0.06903934478759766,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "5518d947-40cd-4999-b320-06c0a41c21be",
                       "label": "Scan0002.jpg",
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
-                      "size": 2.8761367797851562
+                      "size": 2.8761367797851562,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "68862e72-c8bc-4c44-a216-7cc527b7a3fc",
                       "label": "Scan0003.jpg",
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
-                      "size": 2.986827850341797
+                      "size": 2.986827850341797,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "84cea3d5-9142-4a66-8880-cff5ddf0deb1",
                       "label": "Scan0004.jpg",
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
-                      "size": 2.8685474395751953
+                      "size": 2.8685474395751953,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "e8268c00-579d-4c51-aa31-bc8e2c052917",
                       "label": "Scan0005.jpg",
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
-                      "size": 2.816020965576172
+                      "size": 2.816020965576172,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "7b38982a-d607-42f1-b5ec-0ec5401cc98d",
                       "label": "Scan0006.jpg",
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
-                      "size": 2.466215133666992
+                      "size": 2.466215133666992,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "cda74914-1572-429c-af65-7aa061e64b75",
                       "label": "Scan0007.jpg",
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
-                      "size": 2.4286623001098633
+                      "size": 2.4286623001098633,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "962a887a-9bea-4dd0-b66b-e20a6b1c02bf",
                       "label": "bridge-walk.jpg",
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
-                      "size": 0.03153800964355469
+                      "size": 0.03153800964355469,
+                      "bulk_extractor_reports": [
+
+                      ]
                     }
+                  ],
+                  "bulk_extractor_reports": [
+
                   ]
                 },
                 {
@@ -2326,22 +3166,34 @@
                       "label": "Tristan-and-the-Gov-001.jpg",
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
-                      "size": 0.06311321258544922
+                      "size": 0.06311321258544922,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "456f0ea8-b7f7-4b1d-ab87-f86a3b9ff248",
                       "label": "Tristan-and-the-Gov-002.jpg",
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
-                      "size": 0.19769001007080078
+                      "size": 0.19769001007080078,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "eef8eae4-6f9a-444f-a3d7-13a1d136a191",
                       "label": "Tristan-and-the-Gov.jpg",
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
-                      "size": 0.07115650177001953
+                      "size": 0.07115650177001953,
+                      "bulk_extractor_reports": [
+
+                      ]
                     }
+                  ],
+                  "bulk_extractor_reports": [
+
                   ]
                 },
                 {
@@ -2363,521 +3215,773 @@
                       "label": "101505-govn-002.jpg",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.26255130767822266
+                      "size": 0.26255130767822266,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "7128291d-2bda-467a-baba-5fe7498c9730",
                       "label": "11-8-04-006.jpg",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.1508474349975586
+                      "size": 0.1508474349975586,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "426826a7-5ba2-4fc9-b184-88325d148138",
                       "label": "Arnold-Transit.JPG",
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
-                      "size": 1.6122140884399414
+                      "size": 1.6122140884399414,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "eb2fd7d9-8615-4461-a9d0-717a09f1248a",
                       "label": "Bridge-Walk-101.JPG",
                       "format": "Generic AIFF",
                       "extension": ".aif",
-                      "size": 1.546875
+                      "size": 1.546875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "1a075e38-9446-43c3-bc64-c9bbf01bb838",
                       "label": "DI-00251-136.JPG",
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
-                      "size": 1.310537338256836
+                      "size": 1.310537338256836,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "e9f590c8-8f11-43cc-8cc8-f71d799061c9",
                       "label": "DI-00251-169.JPG",
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
-                      "size": 0.4252357482910156
+                      "size": 0.4252357482910156,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "4a0a06e8-5576-4d25-aa84-d97b22ad204d",
                       "label": "DI-00337-033.JPG",
-                      "size": 1.6778106689453125
+                      "size": 1.6778106689453125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "99ec6d3c-a1a3-4f08-b300-18c024aaf310",
                       "label": "DI-00337-034.JPG",
-                      "size": 1.690093994140625
+                      "size": 1.690093994140625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "7d26fa73-8417-42fb-856c-07a7e0841ccc",
                       "label": "DI-00337-038.JPG",
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
-                      "size": 0.45624446868896484
+                      "size": 0.45624446868896484,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "dd1f2850-f5b5-4ec5-ae45-9772a62883a9",
                       "label": "DI-00337-039.JPG",
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
-                      "size": 0.4790630340576172
+                      "size": 0.4790630340576172,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "bc521ce2-291c-4271-a77b-177997e706ac",
                       "label": "DI-00337-047.JPG",
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
-                      "size": 0.46386051177978516
+                      "size": 0.46386051177978516,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "a6467b12-dc28-4435-808a-cac2ae1085c8",
                       "label": "DI-00337-082.JPG",
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
-                      "size": 0.3663969039916992
+                      "size": 0.3663969039916992,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "3926c73e-8c1b-496c-9037-593c7d069630",
                       "label": "DI-00337-156.JPG",
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
-                      "size": 0.32360172271728516
+                      "size": 0.32360172271728516,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "5f7348ac-8244-49c0-abbe-76a485d37271",
                       "label": "DI-00337-157.JPG",
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
-                      "size": 0.34370899200439453
+                      "size": 0.34370899200439453,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "37b59115-4ecd-4d72-be12-9541be2abcb2",
                       "label": "DI-00337-236.JPG",
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
-                      "size": 0.41729068756103516
+                      "size": 0.41729068756103516,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "0b5d130f-1aa1-40a8-9a78-8f2a55adcd07",
                       "label": "DI-00337-254.JPG",
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
-                      "size": 0.44594573974609375
+                      "size": 0.44594573974609375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "524bc610-82d8-4e58-ae87-a9953bca8141",
                       "label": "DI-00528-019.jpg",
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
-                      "size": 0.43531322479248047
+                      "size": 0.43531322479248047,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "cd8cd995-90df-4989-9dd4-a3ddb02ffd40",
                       "label": "DI-00528-020.jpg",
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
-                      "size": 0.4439363479614258
+                      "size": 0.4439363479614258,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "13f743fc-465c-4566-b981-eb9efb0d02d1",
                       "label": "DI-00551-254.jpg",
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
-                      "size": 0.4545326232910156
+                      "size": 0.4545326232910156,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "f97d556c-6b14-4324-8903-79773b043695",
                       "label": "DSC-0020.JPG",
-                      "size": 2.4220075607299805
+                      "size": 2.4220075607299805,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "d930552a-e387-4a64-baee-3bf94c633fa1",
                       "label": "DSC-0026.JPG",
-                      "size": 2.373368263244629
+                      "size": 2.373368263244629,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "bb66cc1d-71f1-4c46-ab4e-d196f74d8d6d",
                       "label": "DSC-0027.JPG",
-                      "size": 2.2718429565429688
+                      "size": 2.2718429565429688,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "bd2cf859-def3-41d7-bde5-0bb283158284",
                       "label": "DSC-0029.JPG",
-                      "size": 2.2628393173217773
+                      "size": 2.2628393173217773,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "7b18e227-cc5e-49ac-9bd6-f48dfc47c772",
                       "label": "DSC-0031.JPG",
-                      "size": 2.668882369995117
+                      "size": 2.668882369995117,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "589286bf-eb5a-4175-bd90-eb04ab021b75",
                       "label": "DSC-0041.JPG",
-                      "size": 2.673015594482422
+                      "size": 2.673015594482422,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "482db1d6-50b8-468d-aa3f-05b206de7daa",
                       "label": "DSC-0071.JPG",
-                      "size": 2.633615493774414
+                      "size": 2.633615493774414,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "ba9754f5-bd67-4a93-9fd0-76885de30112",
                       "label": "DSC-0076.JPG",
-                      "size": 2.455699920654297
+                      "size": 2.455699920654297,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "18353b0c-0d2b-46be-89bb-a05c7935dde1",
                       "label": "DSC-0077.JPG",
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
-                      "size": 3.08640193939209
+                      "size": 3.08640193939209,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "1186c3f5-a462-4634-818e-ae096f84702a",
                       "label": "DSC-0083.JPG",
-                      "size": 2.7744016647338867
+                      "size": 2.7744016647338867,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "832bd4a8-c51f-4ca2-b855-04c4651ca66a",
                       "label": "DSC-0084.JPG",
-                      "size": 2.270421028137207
+                      "size": 2.270421028137207,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "679bb192-689d-44b8-a7da-46249d82d768",
                       "label": "DSC00164.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.1",
                       "puid": "x-fmt/390",
-                      "size": 0.2032642364501953
+                      "size": 0.2032642364501953,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "036b6dc6-b6ff-4232-87c7-dcaf4d4e5d90",
                       "label": "G-and-MTU.JPG",
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
-                      "size": 1.377579689025879
+                      "size": 1.377579689025879,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "6610e54d-2c50-4056-8030-791d79408078",
                       "label": "Granholm-Bridge-2-2004.JPG",
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
-                      "size": 1.6088199615478516
+                      "size": 1.6088199615478516,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "baa58485-7efc-48e4-b919-27f8e6421d81",
                       "label": "Group-Photo.jpg",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.14389705657958984
+                      "size": 0.14389705657958984,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "f17bab8f-4293-4255-baf3-c32d56c48601",
                       "label": "IMG-5274-fix.jpg",
-                      "size": 0.1832447052001953
+                      "size": 0.1832447052001953,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "f140c613-848e-40bf-925f-6dcd98c31f48",
                       "label": "IMG-5274.jpg",
-                      "size": 0.13155460357666016
+                      "size": 0.13155460357666016,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "c46b50a5-40d4-48e6-b6bc-97064be68ce2",
                       "label": "IMG-5279.jpg",
-                      "size": 0.12340450286865234
+                      "size": 0.12340450286865234,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "81239a76-a2d8-4ac8-983e-03ef188ba450",
                       "label": "IMG-5287.jpg",
-                      "size": 0.11258602142333984
+                      "size": 0.11258602142333984,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "158da30d-a323-41a1-9b49-d780010091a9",
                       "label": "IMG-5297.jpg",
-                      "size": 0.1011962890625
+                      "size": 0.1011962890625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "e8d76c2e-2983-4662-ac82-558326469836",
                       "label": "IMG-5313.jpg",
-                      "size": 0.10376358032226562
+                      "size": 0.10376358032226562,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "7b80d953-ba5d-4605-a85b-6c84723db310",
                       "label": "IMG-5319-Fix.jpg",
-                      "size": 0.13099384307861328
+                      "size": 0.13099384307861328,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "18266a11-ff93-4860-82d9-72a5adcb053b",
                       "label": "IMG-5323.jpg",
-                      "size": 0.1215972900390625
+                      "size": 0.1215972900390625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "7402f5b6-c652-4bc0-9e18-00583f51d1a9",
                       "label": "IMG-5327.jpg",
-                      "size": 0.11837291717529297
+                      "size": 0.11837291717529297,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "e738d031-4460-43e7-8499-72e755e4e943",
                       "label": "IMG-5332.jpg",
-                      "size": 0.1204996109008789
+                      "size": 0.1204996109008789,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "a45dda7f-82e8-42ff-88f8-bdd1532df627",
                       "label": "IMG-5351.jpg",
-                      "size": 0.09708595275878906
+                      "size": 0.09708595275878906,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "4dbb101b-0aa9-4c3f-9af8-9c95c4083b67",
                       "label": "IMG-5360.jpg",
-                      "size": 0.10139942169189453
+                      "size": 0.10139942169189453,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "eff707a4-e120-4552-ac6b-f5d005965874",
                       "label": "IMG-5372.jpg",
-                      "size": 0.10463619232177734
+                      "size": 0.10463619232177734,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "d1f3d7b0-b561-4788-8b0e-c6feb5b0cc36",
                       "label": "IMG-5380-fix.jpg",
-                      "size": 0.13574981689453125
+                      "size": 0.13574981689453125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "fb677ab7-7c9f-49b7-bb30-6c8ffd7f2b8e",
                       "label": "IMG-5387.jpg",
-                      "size": 0.14077186584472656
+                      "size": 0.14077186584472656,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "06ffdc7c-8b8e-43f3-a664-6b42ef368ce3",
                       "label": "IMG-5398.jpg",
-                      "size": 0.12474918365478516
+                      "size": 0.12474918365478516,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "4866a15f-b943-4c61-b9ee-1cbe594a502d",
                       "label": "P1000552.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.7818355560302734
+                      "size": 0.7818355560302734,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "8ef7abe1-36e2-4230-b8de-b6dcee4d0cb4",
                       "label": "P1000553.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.763340950012207
+                      "size": 0.763340950012207,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "7a0fe2fb-2a03-4e89-b094-318907f93c27",
                       "label": "Prusi-Girls.JPG",
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
-                      "size": 3.209157943725586
+                      "size": 3.209157943725586,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "34010b68-0542-4977-9e40-636291f718a5",
                       "label": "SA400215.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.17055892944335938
+                      "size": 0.17055892944335938,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "6b14ca18-343a-4561-bfe3-623a0d7bfdc0",
                       "label": "SA400217.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.1499309539794922
+                      "size": 0.1499309539794922,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "b42527b5-6684-49ea-86de-c3b71d0e9037",
                       "label": "SA400219.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.31831836700439453
+                      "size": 0.31831836700439453,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "cf7db69b-9ba4-4656-a828-d834cf0e1681",
                       "label": "SA400223.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.21117401123046875
+                      "size": 0.21117401123046875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "9788e6d1-9180-49a8-b03a-b0e1ab919385",
                       "label": "SA400228.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.28608131408691406
+                      "size": 0.28608131408691406,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "0b394751-85d5-4318-ae0c-92e5db7bb912",
                       "label": "SA400231.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.2673311233520508
+                      "size": 0.2673311233520508,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "bcb03667-11da-45fe-ab53-3c27c89f8456",
                       "label": "SA400245.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.27196598052978516
+                      "size": 0.27196598052978516,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "6df4c73c-dae5-4d78-883d-a4e7f6b18088",
                       "label": "SA400247.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.2172842025756836
+                      "size": 0.2172842025756836,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "ecb7779f-6666-46bd-a59c-9fa1f4cabfc5",
                       "label": "SA400250.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.1890125274658203
+                      "size": 0.1890125274658203,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "10457f76-9f06-46b0-8902-1840c568858d",
                       "label": "SA400251.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.21115779876708984
+                      "size": 0.21115779876708984,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "8d830bc1-3b32-4dce-a902-ed67c5d3c114",
                       "label": "SA400252.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.2390613555908203
+                      "size": 0.2390613555908203,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "ebcecc63-db45-4d04-a971-25e4a0d60228",
                       "label": "SA400253.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.3374481201171875
+                      "size": 0.3374481201171875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "b85c5a88-ae47-4bee-9ea1-4cef6c996aaf",
                       "label": "SA400259.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.30179500579833984
+                      "size": 0.30179500579833984,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "3e167416-a38e-40d9-a4c6-911f19850bf3",
                       "label": "SA400267.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.17090320587158203
+                      "size": 0.17090320587158203,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "c88390ac-5289-45bc-881e-e4e2a6603361",
                       "label": "SA400273.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.17932510375976562
+                      "size": 0.17932510375976562,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "e1f232bd-db21-42eb-98e1-9b756c2e20f0",
                       "label": "SA400274.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.19205665588378906
+                      "size": 0.19205665588378906,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "f573226d-a1c7-4d73-b018-7fe5f8c62518",
                       "label": "SA400275.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.15217113494873047
+                      "size": 0.15217113494873047,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "22ad29a5-113d-47dc-80d6-413d2def0feb",
                       "label": "SA400276.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.17298507690429688
+                      "size": 0.17298507690429688,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "21626442-a671-40eb-9083-7d9a27ab3500",
                       "label": "SA400277.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.20209980010986328
+                      "size": 0.20209980010986328,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "d598a31f-fbe7-4d51-8710-3a71a0af46f2",
                       "label": "SA400280.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.2320108413696289
+                      "size": 0.2320108413696289,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "b4998d61-f59d-4598-bbf1-cb67feb71a04",
                       "label": "SA400286.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.23481273651123047
+                      "size": 0.23481273651123047,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "d5a959a3-9f5f-421e-b109-73d59161e322",
                       "label": "SA400290.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.2750892639160156
+                      "size": 0.2750892639160156,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "6326035e-a98f-4956-8357-dca490452968",
                       "label": "SA400294.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.18602752685546875
+                      "size": 0.18602752685546875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "93ffa7c0-a095-4d26-b95b-7abb173e4466",
                       "label": "Timber-Award.JPG",
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
-                      "size": 0.19728374481201172
+                      "size": 0.19728374481201172,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "75a615c4-bce3-409b-9dc7-261f4fc54ab4",
                       "label": "Two-Families.JPG",
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
-                      "size": 1.415628433227539
+                      "size": 1.415628433227539,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "3d5ad885-5abf-47fa-aab2-3fa4e7b29657",
                       "label": "UP-200-Family-Pic.jpg",
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
-                      "size": 0.03112316131591797
+                      "size": 0.03112316131591797,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "7585c403-b4a9-4609-8f5e-0400a2dd66f9",
                       "label": "gov.JPG",
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
-                      "size": 1.7589893341064453
+                      "size": 1.7589893341064453,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "691fa6d2-b738-4cce-bdcf-139242882ea9",
                       "label": "pistons.jpg",
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
-                      "size": 0.8100271224975586
+                      "size": 0.8100271224975586,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "c79204e4-c6ec-483d-afb7-3fb00a810620",
                       "label": "tree-pic.JPG",
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
-                      "size": 2.6764650344848633
+                      "size": 2.6764650344848633,
+                      "bulk_extractor_reports": [
+
+                      ]
                     }
+                  ],
+                  "bulk_extractor_reports": [
+
                   ]
                 }
+              ],
+              "bulk_extractor_reports": [
+
               ]
             },
             {
@@ -2901,97 +4005,142 @@
                   "label": "December-2005-004.jpg",
                   "format": "Exchangeable Image File Format (Compressed) 2.2",
                   "puid": "x-fmt/391",
-                  "size": 0.14422321319580078
+                  "size": 0.14422321319580078,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "1a35801d-573c-433b-908c-da4cd857da33",
                   "label": "December-2005-027.jpg",
                   "format": "Exchangeable Image File Format (Compressed) 2.2",
                   "puid": "x-fmt/391",
-                  "size": 0.18732166290283203
+                  "size": 0.18732166290283203,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "104183db-923b-41d0-b1b2-face6543e1f2",
                   "label": "December-2005-051.jpg",
                   "format": "Exchangeable Image File Format (Compressed) 2.2",
                   "puid": "x-fmt/391",
-                  "size": 0.16927814483642578
+                  "size": 0.16927814483642578,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "0e8632a7-2721-49aa-9bdd-abf0505d2350",
                   "label": "December-2005-074.jpg",
                   "format": "Exchangeable Image File Format (Compressed) 2.2",
                   "puid": "x-fmt/391",
-                  "size": 0.28711509704589844
+                  "size": 0.28711509704589844,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "37eebc6b-e4d0-4cf2-8756-6f2b814bd5c5",
                   "label": "December-2005-078.jpg",
                   "format": "Exchangeable Image File Format (Compressed) 2.2",
                   "puid": "x-fmt/391",
-                  "size": 0.2734041213989258
+                  "size": 0.2734041213989258,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "ef72fa90-e94a-4bd5-9dee-5a83d3427100",
                   "label": "December-2005-088.jpg",
                   "format": "Exchangeable Image File Format (Compressed) 2.2",
                   "puid": "x-fmt/391",
-                  "size": 0.20899200439453125
+                  "size": 0.20899200439453125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "8553e67f-31e3-4f41-b1fd-3b58c6ee6fab",
                   "label": "December-2005-090.jpg",
                   "format": "Exchangeable Image File Format (Compressed) 2.2",
                   "puid": "x-fmt/391",
-                  "size": 0.33354949951171875
+                  "size": 0.33354949951171875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "8b35cfb0-d7c6-4373-b395-be3dc5441996",
                   "label": "Inaugural-Invite-List-1.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.03271484375
+                  "size": 0.03271484375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "7bba8e15-1ae9-44a0-a104-19ae94cd84ec",
                   "label": "Inaugural-Invite-List-2.xls",
-                  "size": 0.04345703125
+                  "size": 0.04345703125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "8358a4d9-b5d9-4f90-aeeb-1a41cad3dac4",
                   "label": "Inaugural-Invite-List-3.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.02783203125
+                  "size": 0.02783203125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "0efdfb9f-b49e-4925-b3fa-9b44bd775d0c",
                   "label": "Inaugural-Invite-List-4.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.03955078125
+                  "size": 0.03955078125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "cde55a81-8177-4631-ae6b-389f238df034",
                   "label": "Inaugural-Invite-List-5.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.04248046875
+                  "size": 0.04248046875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "51b165cd-3206-4139-852a-7d2ce667802f",
                   "label": "pistons.jpg",
                   "format": "JPEG 1.01",
                   "puid": "fmt/43",
-                  "size": 0.8100271224975586
+                  "size": 0.8100271224975586,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "899932ad-4292-4e12-b524-ed9c8e617df9",
                   "label": "up-staff-slide.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 4.3955078125
+                  "size": 4.3955078125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 }
+              ],
+              "bulk_extractor_reports": [
+
               ]
             },
             {
@@ -3017,245 +4166,350 @@
                   "label": "2005-numbers.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.01708984375
+                  "size": 0.01708984375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "e6172444-fa09-42ec-b050-c31c3e391666",
                   "label": "COMBINED-CODEBOOK.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.1650390625
+                  "size": 0.1650390625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "90dc1ac8-973d-4b50-bdcb-57b17fcc7312",
                   "label": "Combined-Data-Sheet-without-no-response.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.03125
+                  "size": 0.03125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "9972b98d-5640-45a7-ada7-584fd7ca0494",
                   "label": "Final-Draft-II.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.0341796875
+                  "size": 0.0341796875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "db642396-61f4-4b23-99c1-78437442f133",
                   "label": "Final-Draft.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.0341796875
+                  "size": 0.0341796875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "ab0cc285-d7d0-427b-8d6a-faf4bf3a46eb",
                   "label": "Iron-Mountain-Survey-Data-Sheet-without-no-response.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.02001953125
+                  "size": 0.02001953125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "6719ee5a-e00a-40e3-aed3-c4fe4644c6b2",
                   "label": "Iron-Mountain-Survey-Data-Sheet.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.0205078125
+                  "size": 0.0205078125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "7b830f92-93dc-4853-be6b-67d6dbd58ccb",
                   "label": "LANSE-CODEBOOK.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.107421875
+                  "size": 0.107421875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "12fa00be-faaa-43e1-b5d8-b3d974a02757",
                   "label": "LAnse-Survey-Data-Sheet-without-no-response.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.02001953125
+                  "size": 0.02001953125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "fbad70fe-59b8-4bb0-a6d9-3fcd48400fd1",
                   "label": "LAnse-Survey-Data-Sheet.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.0205078125
+                  "size": 0.0205078125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "70f7bc23-7614-4ee0-8e86-f1ba76ec151d",
                   "label": "Log-Truck-Safety-Study-OVERALL.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.0322265625
+                  "size": 0.0322265625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "ed60d665-4666-4a67-a9a8-e842b43c3532",
                   "label": "Logging-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.7734375
+                  "size": 0.7734375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "88248250-c0f7-4ba4-b0fc-767ced819959",
                   "label": "Logging-Stats-04-05.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.01513671875
+                  "size": 0.01513671875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "5bc85298-e317-49b3-87a9-3e522bf6be02",
                   "label": "Logging-Truck-Safety-Survey-CODEBOOK-iRON-MT.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.052734375
+                  "size": 0.052734375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "b4447196-2adf-4f6e-a1a8-e2d61b877e92",
                   "label": "Logging-Truck-Safety-Survey-CODEBOOK.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.0810546875
+                  "size": 0.0810546875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "f8486360-f4ef-43b2-b5a8-23961763dabd",
                   "label": "Logging-Truck-Safety-Survey.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.07958984375
+                  "size": 0.07958984375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "96381fd3-0546-4532-a401-f747b57944a7",
                   "label": "Narrative-Log-Truck-Safety-Study.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.08447265625
+                  "size": 0.08447265625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "d439fca5-a632-4d55-8d82-3a424b40cfdd",
                   "label": "Newberry-Codebook.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.0908203125
+                  "size": 0.0908203125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "f0cec30a-0e3a-4fba-a96a-cb4960832ea7",
                   "label": "Newberry-Codebook2.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.09033203125
+                  "size": 0.09033203125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "22b8bda5-e1d6-4cb1-81f2-162a83d1a6f4",
                   "label": "Newberry-Survey-Data-Sheet-without-no-response.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.02001953125
+                  "size": 0.02001953125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "8be6703d-0195-4fdf-ae4f-9226ebc9708a",
                   "label": "Newberry-Survey-Data-Sheet.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.0205078125
+                  "size": 0.0205078125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "4833fdf1-23f3-46e0-98a7-6c783872c41d",
                   "label": "Original-overall.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.02197265625
+                  "size": 0.02197265625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "6a43227a-e7ce-4eaf-a125-20fbe122fb87",
                   "label": "Preliminary-Stats-Logging-April-05.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.0244140625
+                  "size": 0.0244140625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "b34ec5a1-5989-4eb8-9ef5-29490310dcba",
                   "label": "Truck-study-Raw-comments-COMBINED.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.08544921875
+                  "size": 0.08544921875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "5158bf21-ad8d-41bc-ad09-ab9b06835596",
                   "label": "Truck-study-Raw-comments-Iron-Mountain.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.0478515625
+                  "size": 0.0478515625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "87860d86-1034-42ee-b18a-1f738cc5894e",
                   "label": "Truck-study-Raw-comments-Lanse.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.06640625
+                  "size": 0.06640625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "bf250b2c-5155-41bb-ba78-31d8faa76574",
                   "label": "Truck-study-Raw-comments-Newberry-1.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.03125
+                  "size": 0.03125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "d83f5b19-66ae-448f-9595-b9d293d5924f",
                   "label": "Truck-study-Raw-comments-Newberry.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.046875
+                  "size": 0.046875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "85ca38c6-a756-4855-9758-1835f795cae8",
                   "label": "Truck-study-Raw-comments.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.02978515625
+                  "size": 0.02978515625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "70b87896-c7ac-4643-a3e4-f8f4ffbb5fb0",
                   "label": "UP-Map-Large.JPG",
                   "format": "JPEG 1.01",
                   "puid": "fmt/43",
-                  "size": 1.4146223068237305
+                  "size": 1.4146223068237305,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "e4ae1d81-6a1a-4b70-b61a-0e8d6c00cfad",
                   "label": "combo-map.pdf",
                   "format": "Acrobat PDF 1.3",
                   "puid": "fmt/17",
-                  "size": 0.25935840606689453
+                  "size": 0.25935840606689453,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "1e84e6b0-0579-4169-8c01-87ff993fe9be",
                   "label": "final-numbers.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.03369140625
+                  "size": 0.03369140625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "45b96dff-daf5-4a08-8002-0a1098d78abe",
                   "label": "legend.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.02294921875
+                  "size": 0.02294921875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "a8cfc31c-1645-4285-ba20-bd69bf9a8332",
                   "label": "log-truck-study-map-with-pins.JPG",
                   "format": "JPEG 1.01",
                   "puid": "fmt/43",
-                  "size": 0.18114852905273438
+                  "size": 0.18114852905273438,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "f4024182-1b48-4a49-932a-4f31ce6aca7c",
                   "label": "overall.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.03076171875
+                  "size": 0.03076171875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "89d1887b-a0a2-4369-832c-b1b9bc7695fa",
@@ -3280,234 +4534,339 @@
                       "label": "2005-numbers.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.01708984375
+                      "size": 0.01708984375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "d3ef8d99-8cee-4c30-b5e3-0baf54bbe252",
                       "label": "COMBINED-CODEBOOK.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.1650390625
+                      "size": 0.1650390625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "4d90bd8b-b36a-4475-b67b-014f84ef6c4e",
                       "label": "Combined-Data-Sheet-without-no-response.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.03125
+                      "size": 0.03125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "c5eab27d-37af-4e60-a531-201470bbebea",
                       "label": "Final-Draft-II.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.0341796875
+                      "size": 0.0341796875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "cf1076c1-72b9-4241-9631-38d4409b8068",
                       "label": "Final-Draft.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.0341796875
+                      "size": 0.0341796875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "904e9aff-5b51-424a-addb-6c1214f17cab",
                       "label": "Iron-Mountain-Survey-Data-Sheet-without-no-response.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.02001953125
+                      "size": 0.02001953125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "a29234cc-57fa-44bf-a4b0-ab25ad838711",
                       "label": "Iron-Mountain-Survey-Data-Sheet.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.0205078125
+                      "size": 0.0205078125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "35a7a1e2-05c2-4eaa-8368-23933da9a30f",
                       "label": "LANSE-CODEBOOK.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.107421875
+                      "size": 0.107421875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "2e768e67-be09-40a1-b608-8ac24470e26e",
                       "label": "LAnse-Survey-Data-Sheet-without-no-response.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.02001953125
+                      "size": 0.02001953125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "9366bc54-f742-4eba-bbcf-d8b19c0376c7",
                       "label": "LAnse-Survey-Data-Sheet.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.0205078125
+                      "size": 0.0205078125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "862cdedb-90a2-4c3d-9d4f-9b8e5ef86e4e",
                       "label": "Log-Truck-Safety-Study-OVERALL.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.0322265625
+                      "size": 0.0322265625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "3fd2135d-fb8d-4d1c-ae2c-fde24cf3881b",
                       "label": "Logging-Presentation.ppt",
                       "format": "Powerpoint 97-2002",
                       "puid": "fmt/126",
-                      "size": 0.7734375
+                      "size": 0.7734375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "481f2ff7-e4eb-4b24-9bff-b5ca9608606a",
                       "label": "Logging-Stats-04-05.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.01513671875
+                      "size": 0.01513671875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "c083a940-d8d0-4ded-972c-ef9c38c6f143",
                       "label": "Logging-Truck-Safety-Survey-CODEBOOK-iRON-MT.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.052734375
+                      "size": 0.052734375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "c595a5d4-e274-4794-a039-c2a0946b36dd",
                       "label": "Logging-Truck-Safety-Survey-CODEBOOK.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.0810546875
+                      "size": 0.0810546875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "03bdb447-5b7b-459d-82f6-c9b6647de9b9",
                       "label": "Logging-Truck-Safety-Survey.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.07958984375
+                      "size": 0.07958984375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "f901219e-abc8-4913-bc3a-cdc9aba6699a",
                       "label": "Newberry-Codebook.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.0908203125
+                      "size": 0.0908203125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "c5712cd1-ec28-4c08-bf43-4d323c7d82dd",
                       "label": "Newberry-Codebook2.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.09033203125
+                      "size": 0.09033203125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "e28b8207-7c5d-446b-867e-1b0624f39e57",
                       "label": "Newberry-Survey-Data-Sheet-without-no-response.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.02001953125
+                      "size": 0.02001953125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "f861d61e-0a7c-47c0-aed5-902eb13ff453",
                       "label": "Newberry-Survey-Data-Sheet.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.0205078125
+                      "size": 0.0205078125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "3a14ddb6-5653-4868-9611-be023ee7cff4",
                       "label": "Preliminary-Stats-Logging-April-05.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.0244140625
+                      "size": 0.0244140625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "c73b7d3b-805c-4236-ae2f-ea83f9583eca",
                       "label": "Truck-study-Raw-comments-COMBINED.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.08544921875
+                      "size": 0.08544921875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "0d5bfa5d-012e-41bb-acca-77f17571d28e",
                       "label": "Truck-study-Raw-comments-Iron-Mountain.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0478515625
+                      "size": 0.0478515625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "bedfa2a1-c98f-408d-a7a1-62559b040672",
                       "label": "Truck-study-Raw-comments-Lanse.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.06640625
+                      "size": 0.06640625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "d48b614a-ab47-4a15-bce9-ad5671e30ce6",
                       "label": "Truck-study-Raw-comments-Newberry-1.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.03125
+                      "size": 0.03125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "502a9bdc-8c05-436e-9513-8009837a868f",
                       "label": "Truck-study-Raw-comments-Newberry.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.046875
+                      "size": 0.046875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "0d431223-b9a9-40f7-9439-ba01d9755289",
                       "label": "Truck-study-Raw-comments.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02978515625
+                      "size": 0.02978515625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "6d9ea667-a038-48dc-8a02-9014ccaa3a4b",
                       "label": "UP-Map-Large.JPG",
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
-                      "size": 1.4146223068237305
+                      "size": 1.4146223068237305,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "733fef21-bb68-41cf-a66f-bbe81ef1f6f2",
                       "label": "combo-map.pdf",
                       "format": "Acrobat PDF 1.3",
                       "puid": "fmt/17",
-                      "size": 0.25935840606689453
+                      "size": 0.25935840606689453,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "1a5771ea-bbef-4ab5-950e-f678a6b25af5",
                       "label": "final-numbers.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.03369140625
+                      "size": 0.03369140625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "b009ca37-fc92-4d7d-83c0-9f55b1dd6750",
                       "label": "legend.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02294921875
+                      "size": 0.02294921875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "d93de470-c3ef-45cf-a599-be6f9ee30daa",
                       "label": "log-truck-study-map-with-pins.JPG",
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
-                      "size": 0.18114852905273438
+                      "size": 0.18114852905273438,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "5acfc44e-348d-4882-9615-3c90fb01ef57",
                       "label": "overall.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.03076171875
+                      "size": 0.03076171875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     }
+                  ],
+                  "bulk_extractor_reports": [
+
                   ]
                 }
+              ],
+              "bulk_extractor_reports": [
+
               ]
             },
             {
@@ -3534,7 +4893,10 @@
                   "label": "final-48-take1.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 6.14501953125
+                  "size": 6.14501953125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "3da0777a-da75-49f1-862f-b117cd3aae50",
@@ -3559,147 +4921,210 @@
                       "label": "2005-Existing-TST.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.01953125
+                      "size": 0.01953125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "ac5792f8-e310-4fe6-9b27-45f1d16ea3ed",
                       "label": "2005-TST-MAP.pdf",
                       "format": "Acrobat PDF 1.3",
                       "puid": "fmt/17",
-                      "size": 0.25484752655029297
+                      "size": 0.25484752655029297,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "61641a11-bb43-41e8-8984-df0288efc910",
                       "label": "2005-submitted-report.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0244140625
+                      "size": 0.0244140625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "69517523-890a-4481-b235-6b2a491b35db",
                       "label": "Alpena-SFI.ppt",
                       "format": "Powerpoint 97-2002",
                       "puid": "fmt/126",
-                      "size": 7.5048828125
+                      "size": 7.5048828125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "c22aad0d-4379-4f0d-8d22-2d81176a5ae9",
                       "label": "Book5.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.0146484375
+                      "size": 0.0146484375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "102e3480-1644-4348-bc0e-b2604a25c5e7",
                       "label": "Book9.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.0166015625
+                      "size": 0.0166015625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "00cc69eb-04f2-472a-9d7f-d36b40c6777d",
                       "label": "Individual-Files.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.0146484375
+                      "size": 0.0146484375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "a7acdb94-8ced-446e-b826-7390af6194bd",
                       "label": "Logging-Presentation.ppt",
                       "format": "Powerpoint 97-2002",
                       "puid": "fmt/126",
-                      "size": 1.66796875
+                      "size": 1.66796875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "904e62c7-14eb-434b-a255-461f6ae0913b",
                       "label": "Logging-Truck-Safety-Survey-Part-II-2.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0302734375
+                      "size": 0.0302734375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "b83512ee-e3b0-4c79-a0af-3565d863bb57",
                       "label": "Old-truck.jpg",
                       "format": "JPEG 1.00",
                       "puid": "fmt/42",
-                      "size": 0.008736610412597656
+                      "size": 0.008736610412597656,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "f0024ccb-d6bb-4ac6-b4c0-7c2ea7765ed0",
                       "label": "POST-Alpena-SFI.ppt",
                       "format": "Powerpoint 97-2002",
                       "puid": "fmt/126",
-                      "size": 6.24169921875
+                      "size": 6.24169921875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "61d37a19-802c-4071-b900-2f7cd34fff8c",
                       "label": "Question1Chart.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.0166015625
+                      "size": 0.0166015625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "345467c7-9a82-40e5-a505-545f3bb287d5",
                       "label": "Question2.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.0166015625
+                      "size": 0.0166015625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "9c13a4ad-5b78-4899-9db2-4bd1fafbdce7",
                       "label": "Question3.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.01513671875
+                      "size": 0.01513671875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "1824dcd2-27e8-44f3-84a4-ea16ae226b60",
                       "label": "Question4-What-type-of-additional-training.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.0712890625
+                      "size": 0.0712890625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "86a9e61a-73e4-4af5-866f-e4bae5878ed8",
                       "label": "Question5.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.0166015625
+                      "size": 0.0166015625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "ba8c79af-f69e-4f8e-bef3-e22ea56cf1cd",
                       "label": "Should-Truck-Safety-be-an-Industry-Standard-tABLE.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.05908203125
+                      "size": 0.05908203125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "a1449bfb-9f7f-46c7-b7c3-cefb2305709d",
                       "label": "St-Ignace-SFI-113.ppt",
                       "format": "Powerpoint 97-2002",
                       "puid": "fmt/126",
-                      "size": 6.5654296875
+                      "size": 6.5654296875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "96e7105f-d244-4ccb-a5d2-991bd008e458",
                       "label": "What-type-of-additional-training.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.01318359375
+                      "size": 0.01318359375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "6861983c-0dc3-435b-bf13-bf5258f1b654",
                       "label": "combo-map.pdf",
                       "format": "Acrobat PDF 1.3",
                       "puid": "fmt/17",
-                      "size": 0.25981807708740234
+                      "size": 0.25981807708740234,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "10af630a-3245-4843-8e2a-0fba660f5249",
                       "label": "final-final-final-2005-logging.ppt",
                       "format": "Powerpoint 97-2002",
                       "puid": "fmt/126",
-                      "size": 6.142578125
+                      "size": 6.142578125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "2eff7757-93df-41a3-876f-ff6092661cfb",
@@ -3716,10 +5141,19 @@
                           "label": "final-48-take1.ppt",
                           "format": "Powerpoint 97-2002",
                           "puid": "fmt/126",
-                          "size": 6.14501953125
+                          "size": 6.14501953125,
+                          "bulk_extractor_reports": [
+
+                          ]
                         }
+                      ],
+                      "bulk_extractor_reports": [
+
                       ]
                     }
+                  ],
+                  "bulk_extractor_reports": [
+
                   ]
                 },
                 {
@@ -3754,57 +5188,84 @@
                           "label": "Question-6.xls",
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
-                          "size": 0.0146484375
+                          "size": 0.0146484375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "1c8f28de-7e65-4e7e-bd49-745496c32b75",
                           "label": "Question-7.xls",
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
-                          "size": 0.0166015625
+                          "size": 0.0166015625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "473283c0-4a89-467d-8d37-3bf63f57d91b",
                           "label": "Question1Chart.xls",
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
-                          "size": 0.0166015625
+                          "size": 0.0166015625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "7e562a1f-8fff-40c0-ab5e-bcbb9a524140",
                           "label": "Question2.xls",
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
-                          "size": 0.0166015625
+                          "size": 0.0166015625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "60622636-d3f5-4a5b-ba3f-4dbb7bcdf8af",
                           "label": "Question3.xls",
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
-                          "size": 0.01708984375
+                          "size": 0.01708984375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "dd6cc36e-fa2a-49eb-abc6-5556f6349078",
                           "label": "Question4-What-type-of-additional-training.xls",
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
-                          "size": 0.05859375
+                          "size": 0.05859375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "d328bcbb-bbc7-47b7-8fce-3d1ff68b5cd4",
                           "label": "Question5.xls",
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
-                          "size": 0.0166015625
+                          "size": 0.0166015625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "66cfe287-47f6-4f3b-a61d-2bae5bf4106f",
                           "label": "What-type-of-additional-training.xls",
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
-                          "size": 0.01318359375
+                          "size": 0.01318359375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         }
+                      ],
+                      "bulk_extractor_reports": [
+
                       ]
                     },
                     {
@@ -3829,152 +5290,224 @@
                           "label": "2005-numbers.xls",
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
-                          "size": 0.0166015625
+                          "size": 0.0166015625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "d36476e2-c63a-4f91-9d7d-8492e199fe9a",
                           "label": "36ford.jpg",
                           "format": "JPEG 1.00",
                           "puid": "fmt/42",
-                          "size": 0.013105392456054688
+                          "size": 0.013105392456054688,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "27aed5c0-1715-4ede-8759-2bb98854f34f",
                           "label": "Big-Wheels-T02.jpg",
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
-                          "size": 0.016592979431152344
+                          "size": 0.016592979431152344,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "a64e4705-c5af-410f-b4c6-310b80d45880",
                           "label": "Book5.xls",
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
-                          "size": 0.01318359375
+                          "size": 0.01318359375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "b464d03c-739d-45f7-a141-4e360d6fd836",
                           "label": "Comments-Logging-Iron-Mt-05.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.02587890625
+                          "size": 0.02587890625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "8db78705-2075-4c6e-810d-37920e026eaf",
                           "label": "Doc3.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.12109375
+                          "size": 0.12109375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "338064c7-aedf-4c76-889a-8fc23e199b1a",
                           "label": "Logging-Presentation.ppt",
                           "format": "Powerpoint 97-2002",
                           "puid": "fmt/126",
-                          "size": 1.435546875
+                          "size": 1.435546875,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "40f6e155-0a8d-437f-96ba-be43bacb5842",
                           "label": "Logging-Truck-Safety-Survey-Part-II-2.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.029296875
+                          "size": 0.029296875,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "540e0ee4-2936-4308-8ede-a15c99dad408",
                           "label": "MDOT.jpg",
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
-                          "size": 0.00270843505859375
+                          "size": 0.00270843505859375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "dd55d0a4-0011-4dc8-984a-2b8674fa0fd8",
                           "label": "MUNISING-NUMBERS.xls",
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
-                          "size": 0.01318359375
+                          "size": 0.01318359375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "aaa3cc15-3e6f-48d6-aa8b-70d46d21d221",
                           "label": "Narrative-Log-Truck-Safety-Study.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.16357421875
+                          "size": 0.16357421875,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "660ad288-99c3-4f0d-95ab-6103016f2239",
                           "label": "Old-truck.jpg",
                           "format": "JPEG 1.00",
                           "puid": "fmt/42",
-                          "size": 0.008736610412597656
+                          "size": 0.008736610412597656,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "fbfd2206-c8b6-4581-ae13-4402d0ea8a6a",
                           "label": "Police-and-Driver.jpg",
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
-                          "size": 0.024092674255371094
+                          "size": 0.024092674255371094,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "cda57011-4b5c-4140-b388-c77447800dfa",
                           "label": "PulpTruck-small.jpg",
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
-                          "size": 0.015050888061523438
+                          "size": 0.015050888061523438,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "6a2838a4-1305-4a57-a8f3-c7368a258698",
                           "label": "PulpTruckLoading-small.jpg",
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
-                          "size": 0.021584510803222656
+                          "size": 0.021584510803222656,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "1f74b08b-903b-4b8b-b430-81c624704967",
                           "label": "Stacys-Grandpa.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.53662109375
+                          "size": 0.53662109375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "da685b82-7084-4edc-ba98-2edcda2bca10",
                           "label": "Truck-study-Raw-comments-COMBINED.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.0859375
+                          "size": 0.0859375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "c9d97393-b234-4b30-83c1-f938c4200f76",
                           "label": "Truck-study-Raw-comments.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.02783203125
+                          "size": 0.02783203125,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "49ac3c30-3367-40a4-a9eb-f4ef788f3e01",
                           "label": "final-48-take1.ppt",
                           "format": "Powerpoint 97-2002",
                           "puid": "fmt/126",
-                          "size": 5.6044921875
+                          "size": 5.6044921875,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "3a683e6e-f394-446a-a3ce-4651357d9ec0",
                           "label": "loading-logs.jpg",
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
-                          "size": 0.04587841033935547
+                          "size": 0.04587841033935547,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "b41adb00-7864-4a0a-8147-954fe12d25e7",
                           "label": "loggers.jpg",
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
-                          "size": 0.02455902099609375
+                          "size": 0.02455902099609375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         }
+                      ],
+                      "bulk_extractor_reports": [
+
                       ]
                     }
+                  ],
+                  "bulk_extractor_reports": [
+
                   ]
                 }
+              ],
+              "bulk_extractor_reports": [
+
               ]
             },
             {
@@ -4002,21 +5535,30 @@
                   "label": "1Governors-Conference-Nashville.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.23974609375
+                  "size": 0.23974609375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "81a9a867-b84c-42c7-ad61-096f2214261a",
                   "label": "1MTU-Forest-Certification-Strategy.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 1.79296875
+                  "size": 1.79296875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "7f82324f-f6d4-4e0d-b4b0-aa8aacabe568",
                   "label": "2007-GOVERNOR’S-UPPER-PENINSULA-INAUGURAL.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 36.5107421875
+                  "size": 36.5107421875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "b7dd1e90-a31f-4048-914a-8f89cfa14b58",
@@ -4024,776 +5566,1112 @@
                   "format": "Powerpoint for Windows 2007+",
                   "puid": "fmt/215",
                   "extension": ".pptx",
-                  "size": 36.08389949798584
+                  "size": 36.08389949798584,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "7f973d7e-5326-4790-bdd7-f0cf49e5c2a2",
                   "label": "20070620-PC-auto.pdf",
                   "format": "Acrobat PDF 1.3",
                   "puid": "fmt/17",
-                  "size": 0.058150291442871094
+                  "size": 0.058150291442871094,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "1c1b906c-d774-4f61-b42f-ea66b0fcac7e",
                   "label": "2007ConsentDecree-pressavail9-26-07.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 6.87353515625
+                  "size": 6.87353515625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "2652b603-226c-49b0-8ca3-0b4325156f2a",
                   "label": "2008Hiring-Process-Flow-Chart-1.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.037109375
+                  "size": 0.037109375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "72139d86-8d5c-4288-936d-77916d56e2fd",
                   "label": "A-Carbon-Offset-Cost-Benefit-Analysis-Test-Case-version-2-CCX.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 3.18896484375
+                  "size": 3.18896484375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "bdd54650-671b-455d-a913-083de75614e9",
                   "label": "AFFIRMATIVE-ACTION-3-Final.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.064453125
+                  "size": 0.064453125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "e6da8025-83db-4c4a-848d-98e9d42a0b27",
                   "label": "American-Legion-Roast.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.02490234375
+                  "size": 0.02490234375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "77b83820-4efc-4372-a496-8188e8d083c1",
                   "label": "AppropSub-on-Nat-Res-12-11-07.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 8.68115234375
+                  "size": 8.68115234375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "bdaac43e-0680-4f30-999a-a8dece1dab8d",
                   "label": "BioDiesel-2-08-flat.JPG",
                   "format": "JPEG 1.01",
                   "puid": "fmt/43",
-                  "size": 0.528172492980957
+                  "size": 0.528172492980957,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "1c0dc438-27ff-499e-a217-da41542bb3be",
                   "label": "Book1.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.01513671875
+                  "size": 0.01513671875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "2ac46918-cc89-496c-abc6-f415a6f235c2",
                   "label": "CREDIBILITY.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 2.91552734375
+                  "size": 2.91552734375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "432c49a8-44c9-40e2-b146-db6ed682d455",
                   "label": "CUPPAD.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 12.71728515625
+                  "size": 12.71728515625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "1ce24e87-1c60-4e0a-b1ec-c0d324686ce6",
                   "label": "Can-You-Budget-Personnel.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.00927734375
+                  "size": 0.00927734375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "cd26e0c2-fc2a-4541-b2a3-2e3363c17f4c",
                   "label": "Career-Day.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 6.9580078125
+                  "size": 6.9580078125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "a92aef42-d629-4419-be18-0c9bf135a86b",
                   "label": "Charts-for-Budget-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.974609375
+                  "size": 0.974609375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "a6b4a784-38c8-4f5a-b6f4-4be769a9fedb",
                   "label": "Cherry-Comm-Hearing.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.017578125
+                  "size": 0.017578125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "718a5a4f-4755-4da9-8632-b4254883fa54",
                   "label": "Christian-Demorcracy.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 9.3583984375
+                  "size": 9.3583984375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "f7a31308-f7f1-465f-a599-c251b61bcc94",
                   "label": "Community-Partnership.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 4.2080078125
+                  "size": 4.2080078125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "79b09046-4203-465a-abc3-2f2c24686117",
                   "label": "Community-partnership-pre-show-slides.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.08349609375
+                  "size": 0.08349609375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "5f71d23c-ee52-4ab4-a32a-79670456cdb7",
                   "label": "Cool-Attendees.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.0537109375
+                  "size": 0.0537109375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "03bb6577-7860-424e-9ddf-f104dfaf19cd",
                   "label": "Corn-based-Ethanol-ppt-BB-2-08.JPG",
                   "format": "JPEG 1.01",
                   "puid": "fmt/43",
-                  "size": 0.9645919799804688
+                  "size": 0.9645919799804688,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "677d7bb9-a948-4e1a-b9fc-feb0c2a18065",
                   "label": "County-Commission-Meeting-10-12.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 10.7734375
+                  "size": 10.7734375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "14866b9f-6b5c-4909-a46a-8b39247e48f5",
                   "label": "Criminal-Justice-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 4.22119140625
+                  "size": 4.22119140625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "cf00c7ea-a6c0-40b6-b2b7-215bafaa53f4",
                   "label": "Delta-County-Township-Association.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 18.5
+                  "size": 18.5,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "006a5b70-8c97-4c9c-9507-77018db0aaa5",
                   "label": "EOY-Prison-Population-1995-2006.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.07421875
+                  "size": 0.07421875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "c076d0d6-0e9a-4a5f-b472-b4007605ec3b",
                   "label": "Executive-Budget-Presentation-2-8-07.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.10888671875
+                  "size": 0.10888671875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "139d3054-3cf9-45fd-8afe-840e1201bc34",
                   "label": "Fair-Registration.xls",
-                  "size": 0.0361328125
+                  "size": 0.0361328125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "5157e070-d5bd-45b5-9f8a-4ad8165fe20e",
                   "label": "Final-Leadership-Michigan-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 14.638671875
+                  "size": 14.638671875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "b95af23e-b5de-4fed-8fc5-a8bbf9ebaeaa",
                   "label": "Final-leadership-michigan.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 3.47998046875
+                  "size": 3.47998046875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "87650036-e9ed-4132-ae97-2940ac2efa34",
                   "label": "Forest-Finance-Authority.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.0458984375
+                  "size": 0.0458984375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "6a6ed72c-832f-4bb3-9bc8-17123fb8418d",
                   "label": "Forest-lands.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.439453125
+                  "size": 0.439453125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "d59dca0d-b954-46a4-b70a-d92969a2b1b7",
                   "label": "Fuels-From-The-Forest.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 2.44775390625
+                  "size": 2.44775390625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "1977ea9c-9d23-40b7-bdd3-1b4ba7b3e33f",
                   "label": "Gogebic-Conservation-District.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 16.63623046875
+                  "size": 16.63623046875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "fc0cc04b-73a5-4f79-ba5b-0de72ad92698",
                   "label": "Gogebic-Leadership.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 4.9072265625
+                  "size": 4.9072265625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "23bcd60a-b9cd-42a1-a86e-5ce2a41dc5dd",
                   "label": "Governors-economic-plan.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 1.35595703125
+                  "size": 1.35595703125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "caab6851-04a2-459f-ade3-5abf8476667a",
                   "label": "Khoury-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 11.96728515625
+                  "size": 11.96728515625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "5e7d5e1c-1af2-45fd-9587-8c6337198eb9",
                   "label": "Khoury-Presentation2.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 11.58447265625
+                  "size": 11.58447265625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "0908668b-80ff-4b26-abd5-a720b5fbf613",
                   "label": "Khoury-Presentation3.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 13.8837890625
+                  "size": 13.8837890625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "c87d42d9-d05f-42d4-a3d7-15cdd0f8b63f",
                   "label": "Kiwanis.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.9775390625
+                  "size": 0.9775390625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "d1e83d0a-da80-4c99-aecf-e291ee49d9ee",
                   "label": "LSCP-March-29.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 1.39599609375
+                  "size": 1.39599609375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "66eff2e7-e6a3-4a32-ae4c-f72782e6c3a8",
                   "label": "Lake-Superior-Leadership-Academy.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 15.2744140625
+                  "size": 15.2744140625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "f1be4cc3-6420-4917-ab63-9167427d6e2e",
                   "label": "LeadAcadJan6.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 3.4033203125
+                  "size": 3.4033203125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "00c3a866-c9ab-480f-8165-b917ddacc649",
                   "label": "Leadership-Michigan-2007-final.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 15.572265625
+                  "size": 15.572265625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "58fd359c-b4b7-4ea2-a54f-5c79fcb5a0d5",
                   "label": "Leadership-Michigan-2007.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 15.56787109375
+                  "size": 15.56787109375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "ab22a393-c38e-46f1-acfe-76a4b7c7dcf7",
                   "label": "Leadership-West-Michigan.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 16.1064453125
+                  "size": 16.1064453125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "53ca6598-82c1-4480-af56-5fa5c7d5e7aa",
                   "label": "Loc-Mackinac-GovernorsOffice.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.43798828125
+                  "size": 0.43798828125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "47c3d83a-ce92-43f3-abd0-9f87ee493508",
                   "label": "Loc-Schoolcraft-GovernorsOffice.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.30322265625
+                  "size": 0.30322265625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "72d6153f-575e-4e2f-be5c-6127d8752eed",
                   "label": "MBT-Short.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 1.3486328125
+                  "size": 1.3486328125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "06bb5964-6b5e-43fd-863c-882771c44d02",
                   "label": "MCTA-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.3564453125
+                  "size": 0.3564453125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "2cce5c73-8d4c-4788-a38f-d2e6ab6b664b",
                   "label": "MIFFA-Forest-Carbon-Presentation-24-August-2006.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 2.31201171875
+                  "size": 2.31201171875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "2a6efd79-46fb-4276-9456-242315c2ad35",
                   "label": "MPRI-Model-101.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 1.11328125
+                  "size": 1.11328125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "568967d0-7761-4f22-91df-657e1f9c61c0",
                   "label": "MSEA1.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 5.9345703125
+                  "size": 5.9345703125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "6035924a-4831-4b9f-b2bf-ea62328cbd12",
                   "label": "Manistique-High-School.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 8.70263671875
+                  "size": 8.70263671875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "e333b88e-5f65-4e6a-8363-e672feab53c0",
                   "label": "Marquette-County-Township-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 15.89501953125
+                  "size": 15.89501953125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "23bec771-e9c8-463a-9fa0-19dbda0c00b8",
                   "label": "MedCaseload.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.05224609375
+                  "size": 0.05224609375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "a44eac70-99f7-48f6-8faa-a6f36cdc2542",
                   "label": "Mqt-Higher-Ed-Speakers.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.017578125
+                  "size": 0.017578125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "d7c7ec19-1495-4842-b4d8-84194476d6b4",
                   "label": "Municpal-Management.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 6.47509765625
+                  "size": 6.47509765625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "0ea655da-323e-4dc3-9db2-0064c637de02",
                   "label": "NMPSA2005.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 3.89013671875
+                  "size": 3.89013671875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "0bea6b83-e580-4809-b63b-ec77eb78d8c9",
                   "label": "NMU-Budget-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 10.88134765625
+                  "size": 10.88134765625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "bcc81641-bf74-46a3-9e59-dd1061e52b17",
                   "label": "Nursing-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 2.1484375
+                  "size": 2.1484375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "da934e38-be1a-48a8-8879-bcd2321eb972",
                   "label": "Office-of-Community-Corrections.PPT",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.11279296875
+                  "size": 0.11279296875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "c816bd40-ad02-45e6-83ea-2d4527ebae5f",
                   "label": "Oscoda-County-Conservation-District.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 16.72216796875
+                  "size": 16.72216796875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "a16e7efa-33d0-4c2a-82a5-42df154f9027",
                   "label": "Overall-Budget-Picture.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 10.5029296875
+                  "size": 10.5029296875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "e2739449-afc2-4b87-ac0c-afebd4da0f89",
                   "label": "PARKVIEW-1.JPG",
                   "format": "JPEG 1.01",
                   "puid": "fmt/43",
-                  "size": 0.19284820556640625
+                  "size": 0.19284820556640625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "8d3463b3-7c92-4b2f-a139-f02ab9168da8",
                   "label": "PPT-CRC-FINAL-10-5-07.ppt",
                   "format": "Generic AIFF",
                   "extension": ".aif",
-                  "size": 0.04685211181640625
+                  "size": 0.04685211181640625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "cb761ad4-7301-421e-b5d0-8ed33896b328",
                   "label": "PPT-Surrogate-31506.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.1728515625
+                  "size": 0.1728515625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "7dc10281-d850-4eec-8cf9-31885fe1031e",
                   "label": "PS-528-Final-Power-Point.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 1.26220703125
+                  "size": 1.26220703125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "91e2f2b0-29a6-4e4d-bbfd-2db8e4479506",
                   "label": "Pavement-Condition-1.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.1162109375
+                  "size": 0.1162109375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "49cb638f-28c9-4413-b596-983d2caf4e64",
                   "label": "Politics-of-Media.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 1.373046875
+                  "size": 1.373046875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "07b97d74-ed87-420a-bacf-69a3cb7d27a6",
                   "label": "Powers-Class.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 3.91259765625
+                  "size": 3.91259765625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "5599b16c-2c67-41bc-8819-cdff1fcc7786",
                   "label": "Powers-class-2-25.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 4.02294921875
+                  "size": 4.02294921875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "3844471b-b7ed-4aab-bee2-064e2e40dae4",
                   "label": "Presentation-Slides.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.4638671875
+                  "size": 0.4638671875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "003253d2-3ad2-4110-9ef2-1f731fd9fca7",
                   "label": "Rotary-Presentation.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 3.0341796875
+                  "size": 3.0341796875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "721214c2-f7c7-4165-9d90-f424e270fdf1",
                   "label": "SBT-presentation.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.125
+                  "size": 0.125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "e68f3e8c-38c6-420c-9dc0-fc6b63a5132a",
                   "label": "SERA.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 1.82958984375
+                  "size": 1.82958984375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "1bb57ef3-0b52-4e0b-ad90-8a9eff20d038",
                   "label": "SHARED-SERVICES-1.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 1.59423828125
+                  "size": 1.59423828125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "bd3800fc-ff2e-4358-ba4a-12d03f4ce201",
                   "label": "SHARED-SERVICES.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 1.73193359375
+                  "size": 1.73193359375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "2be09d3e-1efe-4b42-b474-f63f05fb0e2a",
                   "label": "Schoolcraft-Township-Association.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 20.294921875
+                  "size": 20.294921875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "c9e3614c-0fbc-4937-9258-097089ab6d82",
                   "label": "Sled-Dog-Fundraiser.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.0224609375
+                  "size": 0.0224609375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "0d87206e-d5ce-4df7-97a7-957a867b4090",
                   "label": "Social-Welfare-Policy.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 4.03515625
+                  "size": 4.03515625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "789a5650-df44-41da-955d-01f07f807447",
                   "label": "Social-Welfare-Policy2.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 4.1181640625
+                  "size": 4.1181640625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "ec73e7d5-df56-480d-a70e-45e37e5f72e1",
                   "label": "State-and-Local-Govts.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 3.25439453125
+                  "size": 3.25439453125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "0bb41e14-62dc-45b1-9eac-585ab25e2c30",
                   "label": "SummitNMU.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 1.51513671875
+                  "size": 1.51513671875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "7628249b-9847-48a8-9da1-3ab6ed0b82b4",
                   "label": "Surrogate-6-9-06-161851-7.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 1.67333984375
+                  "size": 1.67333984375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "fd8c981c-1c90-4da1-a3bf-9944b3753b44",
                   "label": "TC-Slides-2.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.06298828125
+                  "size": 0.06298828125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "e1af0433-4248-43de-ab60-da0c3fd47d07",
                   "label": "UPEDA.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 1.029296875
+                  "size": 1.029296875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "854c9ac3-1fd8-4df9-b47c-c4ccdc16d1e7",
                   "label": "Video-Franchising-Powerpoint.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.06201171875
+                  "size": 0.06201171875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "4d98a0e1-c53b-4bb9-9c13-893d21873787",
                   "label": "Video-Franchising-Presentation-NMPSA.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 1.3466796875
+                  "size": 1.3466796875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "4d80ba4c-3e44-4107-9f85-8b940058d344",
                   "label": "Website-Electronic-Monitoring-of-Offenders-in-the-Community-2.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.06396484375
+                  "size": 0.06396484375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "4c769be6-8691-428a-b265-8e98ca8cf3fb",
                   "label": "budget-new-taxes.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 1.62744140625
+                  "size": 1.62744140625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "5dfc17ba-bc9e-464f-95d6-d613290a05f0",
                   "label": "china-slides.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.03515625
+                  "size": 0.03515625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "c3100b39-3be2-476d-8882-3214b9cb1f63",
                   "label": "corrections-reform.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 11.04248046875
+                  "size": 11.04248046875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "c54bd138-115e-4b6d-a1e3-679868419b7f",
                   "label": "emp-Final-Techinvite2004.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.15673828125
+                  "size": 0.15673828125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "3f3ce1cb-7cd0-4872-b18f-8c4d3f29d598",
                   "label": "end-of-line.JPG",
                   "format": "JPEG 1.01",
                   "puid": "fmt/43",
-                  "size": 1.7736444473266602
+                  "size": 1.7736444473266602,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "6c6412e0-e646-4b87-8298-37142d43fc0a",
                   "label": "environmental-policy.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 19.42333984375
+                  "size": 19.42333984375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "10fbf7ba-252e-48bb-b35b-ab365d7ddc9f",
                   "label": "fundraisersledog.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.021484375
+                  "size": 0.021484375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "f07f481f-e354-40e7-b84b-4be225bfe329",
                   "label": "kiwanis-menominee.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 6.4892578125
+                  "size": 6.4892578125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "2ec91ebb-b77e-491f-b33c-317225967700",
                   "label": "leadership-michigan-powerpoint.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.61279296875
+                  "size": 0.61279296875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "82ddeed9-ec25-4db7-874d-332acbc397f9",
                   "label": "leadership-michigan-powerpointfinaldraft.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 3.07958984375
+                  "size": 3.07958984375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "7413eebd-ee3c-4e86-bea9-045f680c223d",
                   "label": "logs-rolling-off-debarker.JPG",
                   "format": "JPEG 1.01",
                   "puid": "fmt/43",
-                  "size": 1.1215858459472656
+                  "size": 1.1215858459472656,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "bfca29d1-5d17-4aa2-b326-d630b756a966",
                   "label": "mbt.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.07080078125
+                  "size": 0.07080078125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "09cffaf4-6ddb-43fd-a066-715b96acc94a",
                   "label": "mml-Oct-2006-1.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.85595703125
+                  "size": 0.85595703125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "6894ca16-5189-4333-8b9a-c3ba17c671de",
                   "label": "outcome-measurement-framework.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.01318359375
+                  "size": 0.01318359375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "4598e44b-0db9-44b4-91d5-d7122a472796",
                   "label": "pp-react-usa.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 1.26611328125
+                  "size": 1.26611328125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "2ed0e440-916c-4315-8194-70f9863d0923",
                   "label": "ps-528-power-point.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.0693359375
+                  "size": 0.0693359375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "2063bc88-23ba-460c-ac41-d2395cdcad0a",
                   "label": "regional-colaboration.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 4.673828125
+                  "size": 4.673828125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "075a0ba6-471a-4dc4-abc6-d82fb13bb1ac",
                   "label": "smoking-rates-success.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.0400390625
+                  "size": 0.0400390625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "5d9e39af-ee3e-4b68-bcef-26c06155097a",
                   "label": "state-and-local-short.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 7.51708984375
+                  "size": 7.51708984375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "22aa0644-7a59-4f75-ad67-98edf180e46e",
                   "label": "state-and-local.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 10.6787109375
+                  "size": 10.6787109375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "dbb0eb8d-0028-4346-ae2c-f979577d9cfe",
                   "label": "tilden-township.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 0.3095703125
+                  "size": 0.3095703125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "c1a9b55c-4011-4281-a9b2-11c39a0a6b90",
                   "label": "up-STAFF1.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
-                  "size": 4.5419921875
+                  "size": 4.5419921875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 }
+              ],
+              "bulk_extractor_reports": [
+
               ]
             },
             {
@@ -4841,265 +6719,382 @@
                       "label": "2004-Master-Calendar.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.01904296875
+                      "size": 0.01904296875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "777c31be-466d-45e1-a556-fb05abbfbf0d",
                       "label": "Description-of-internship-for-Governor-Jennifer-Granholm1.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02392578125
+                      "size": 0.02392578125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "3f08d205-63c1-4ffc-ba51-93d71c29e56b",
                       "label": "Engineered-Manufactured-Products.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02392578125
+                      "size": 0.02392578125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "58e2fb84-4923-4a4b-a65f-b11199345a04",
                       "label": "Fax-Wizard.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0322265625
+                      "size": 0.0322265625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "431d13c9-b60e-47d7-8648-4cee0471896b",
                       "label": "Final-leadership-michigan.ppt",
                       "format": "Powerpoint 97-2002",
                       "puid": "fmt/126",
-                      "size": 3.8642578125
+                      "size": 3.8642578125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "b124c0d7-2d87-4d08-bd46-87d30eda09fc",
                       "label": "INTERN.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02294921875
+                      "size": 0.02294921875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "5a436c06-b4c7-4c63-af45-3da6c727cd66",
                       "label": "Logging-Truck-Safety-Survey-CODEBOOK-COMBINED.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.10498046875
+                      "size": 0.10498046875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "2102f43a-78bb-460e-93ed-ae05f661a3b9",
                       "label": "Logging-Truck-Safety-Survey-COMBINED-CODEBOOK.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.16796875
+                      "size": 0.16796875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "d81d4a3a-e589-422c-bf10-e30f85b7b82b",
                       "label": "Logging-Truck-Safety-Survey-LANSE-CODEBOOK.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.107421875
+                      "size": 0.107421875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "86d23952-106c-41aa-97e9-8b8ecee82698",
                       "label": "MI-watershed-alliance.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0234375
+                      "size": 0.0234375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "b4d4e5aa-4ac6-4b6c-939c-8359c5e59143",
                       "label": "Marquette-Budget-Forum.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.037109375
+                      "size": 0.037109375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "2ffee209-7bcc-4330-9590-8a46582d67a7",
                       "label": "Memo-Dans-visit.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.021484375
+                      "size": 0.021484375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "6f0274fe-af95-416e-b4c6-6e89524acf67",
                       "label": "Mentor-Conference.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02294921875
+                      "size": 0.02294921875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "1ca81e00-cd8c-4678-8b78-ae3c0a364441",
                       "label": "Michigan-Broadband-Authority.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0234375
+                      "size": 0.0234375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "f512bc9c-ddf0-46e5-b078-d901768a0c12",
                       "label": "Michigan-Sample-Slides.ppt",
                       "format": "Powerpoint 97-2002",
                       "puid": "fmt/126",
-                      "size": 0.0859375
+                      "size": 0.0859375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "7c2de80d-c45f-449e-971e-1f81cdfabc04",
                       "label": "New-Microsoft-Access-Application.mdb",
-                      "size": 0.09375
+                      "size": 0.09375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "fb9c7a39-c251-41fa-9438-a27cdfa234c9",
                       "label": "New-Microsoft-Word-Document.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.01025390625
+                      "size": 0.01025390625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "470d1831-3543-405a-afee-ed7dfde9cf95",
                       "label": "Ontonagon-notes.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02685546875
+                      "size": 0.02685546875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "871a3295-b293-4804-a559-00e53db22a6e",
                       "label": "PILT-spreadsheet.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.0390625
+                      "size": 0.0390625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "2c16d1ce-3241-4bfd-b85c-719b0c77eb55",
                       "label": "SERVICE-SHARING-MEETINGS-SUMMARY.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.05126953125
+                      "size": 0.05126953125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "6878efa1-d7d0-47f8-b11d-89e8d53a5f9b",
                       "label": "Shared-Services-Metting-Notes.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02490234375
+                      "size": 0.02490234375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "ec353763-9962-4c83-a2e0-5c80ddd604bc",
                       "label": "Student-List-for-2-18-05.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.01708984375
+                      "size": 0.01708984375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "5c8cb018-9a53-4e87-9f18-dd4229846032",
                       "label": "UP-Events.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.017578125
+                      "size": 0.017578125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "7f33d40e-4078-43cf-b21d-1f4478c181fb",
                       "label": "UP-Shared-Service-Examples.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0341796875
+                      "size": 0.0341796875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "b4d159a9-3461-4bd4-abb8-ecd8dbc51ed4",
                       "label": "UPPER-PENINSULA1.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0517578125
+                      "size": 0.0517578125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "e95dc4a0-43f1-4abe-b3f8-b493c7082934",
                       "label": "UPandlowpenn1.jpg",
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
-                      "size": 0.03262042999267578
+                      "size": 0.03262042999267578,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "03452c9c-8b98-4870-9184-9d4f8df90a46",
                       "label": "UPonly1.jpg",
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
-                      "size": 0.028840065002441406
+                      "size": 0.028840065002441406,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "899683d5-796f-41da-81f6-69bc7f7e9d77",
                       "label": "Volume-Purchasing.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02392578125
+                      "size": 0.02392578125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "dad0094c-6813-4bb7-8fcb-f40b3a0f9976",
                       "label": "bridge-walk.jpg",
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
-                      "size": 0.03153800964355469
+                      "size": 0.03153800964355469,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "c77a7f9c-f8c1-4868-9566-80d547efd1bf",
                       "label": "lansing-schedule.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02392578125
+                      "size": 0.02392578125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "512f0cef-dcf9-463c-82d6-e148aebd3e07",
                       "label": "leadership-michigan-powerpoint.ppt",
                       "format": "Powerpoint 97-2002",
                       "puid": "fmt/126",
-                      "size": 0.6708984375
+                      "size": 0.6708984375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "047efa98-8a46-4459-aa2b-e5a3e2c1c62b",
                       "label": "lp-ma.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.03173828125
+                      "size": 0.03173828125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "9d966a3f-c034-46d0-9c2d-6ce2ef9c0739",
                       "label": "map.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0244140625
+                      "size": 0.0244140625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "b8067234-b6dc-43c9-97fc-1a546e5c6a25",
                       "label": "memo-from-kennecott-presentation.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.04052734375
+                      "size": 0.04052734375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "a098f84a-4ce6-4d8d-9e24-d1f2024a135d",
                       "label": "memo-on-service-sharing-in-hospitals.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0400390625
+                      "size": 0.0400390625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "d2134aee-87a5-4f8f-95d2-621656e2df09",
                       "label": "memo-on-wind-turbines.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0380859375
+                      "size": 0.0380859375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "80a555b2-b330-4808-aadb-66e6153e3334",
                       "label": "school-numbers.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02294921875
+                      "size": 0.02294921875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "88d90134-53fe-4887-ba73-7b5de7f60141",
                       "label": "tilden-township.ppt",
                       "format": "Powerpoint 97-2002",
                       "puid": "fmt/126",
-                      "size": 0.30322265625
+                      "size": 0.30322265625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     }
+                  ],
+                  "bulk_extractor_reports": [
+
                   ]
                 },
                 {
@@ -5117,8 +7112,14 @@
                       "label": "Truck-study-Raw-comments-Lanse.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.05419921875
+                      "size": 0.05419921875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     }
+                  ],
+                  "bulk_extractor_reports": [
+
                   ]
                 },
                 {
@@ -5159,57 +7160,84 @@
                           "label": "Briefing-2-17-05-Hockey-NMU-vs-MTU.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.02197265625
+                          "size": 0.02197265625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "0082f86b-163c-4601-9f51-7dda34760993",
                           "label": "Briefing-2-17-05-UP-Road-Builders-Conference.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.02197265625
+                          "size": 0.02197265625,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "57623ea4-3415-47cc-a19e-c42b9d671890",
                           "label": "Briefing-2-17-05-WNMU.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.021484375
+                          "size": 0.021484375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "3fd8157c-2ef8-4e66-a6d5-2b9f606f5105",
                           "label": "Briefing-Format.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.021484375
+                          "size": 0.021484375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "8a98f1f1-f1a1-41d5-a3be-487b06499eb4",
                           "label": "Duty-Logf.xls",
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
-                          "size": 0.0146484375
+                          "size": 0.0146484375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "acd7d9b4-6dfb-4045-bcf3-b70a66b43b86",
                           "label": "INTERNLOG.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.02490234375
+                          "size": 0.02490234375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "c29ee111-db51-47a6-b3aa-d8d0b3841ff0",
                           "label": "June-Log.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.0224609375
+                          "size": 0.0224609375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "e774dee5-d70c-460f-9fcb-fbc33ebc1542",
                           "label": "Student-Work-Log-Sample.xls",
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
-                          "size": 0.013671875
+                          "size": 0.013671875,
+                          "bulk_extractor_reports": [
+
+                          ]
                         }
+                      ],
+                      "bulk_extractor_reports": [
+
                       ]
                     },
                     {
@@ -5235,7 +7263,10 @@
                           "label": "upper-peninsula-map.htm",
                           "format": "Hypertext Markup Language 4.0",
                           "puid": "fmt/99",
-                          "size": 0.0017805099487304688
+                          "size": 0.0017805099487304688,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "0ff81300-dc48-4aea-b81e-486fb1e699fc",
@@ -5257,62 +7288,92 @@
                               "label": "Bridge-Walk-Overview-2.jpg",
                               "format": "JPEG 1.01",
                               "puid": "fmt/43",
-                              "size": 0.09985733032226562
+                              "size": 0.09985733032226562,
+                              "bulk_extractor_reports": [
+
+                              ]
                             },
                             {
                               "id": "9722d84a-54d8-4ec6-ad01-c1ea99a6af58",
                               "label": "Bridge-Walk-Overview.jpg",
                               "format": "JPEG 1.01",
                               "puid": "fmt/43",
-                              "size": 0.0044155120849609375
+                              "size": 0.0044155120849609375,
+                              "bulk_extractor_reports": [
+
+                              ]
                             },
                             {
                               "id": "c5220716-d35c-4f10-8b31-90de7cb4363f",
                               "label": "Chinese-Glass-Dome.jpg",
                               "format": "JPEG 1.01",
                               "puid": "fmt/43",
-                              "size": 0.026022911071777344
+                              "size": 0.026022911071777344,
+                              "bulk_extractor_reports": [
+
+                              ]
                             },
                             {
                               "id": "4f2c148b-b1fb-40e8-9ee7-0a4048ffc4eb",
                               "label": "Desktop.ini",
-                              "size": 0.00010204315185546875
+                              "size": 0.00010204315185546875,
+                              "bulk_extractor_reports": [
+
+                              ]
                             },
                             {
                               "id": "e97a1519-6e6d-404d-941a-50b31baf38ac",
                               "label": "Empire-Mine.jpg",
                               "format": "JPEG 1.01",
                               "puid": "fmt/43",
-                              "size": 0.006748199462890625
+                              "size": 0.006748199462890625,
+                              "bulk_extractor_reports": [
+
+                              ]
                             },
                             {
                               "id": "6020af21-7b2d-46ab-93fb-576a255f766d",
                               "label": "UP-picture.rtf",
                               "format": "RTF 1.5-1.6",
                               "puid": "fmt/50",
-                              "size": 0.7602930068969727
+                              "size": 0.7602930068969727,
+                              "bulk_extractor_reports": [
+
+                              ]
                             },
                             {
                               "id": "739a6eef-0df1-4390-a446-3e01b070aaad",
                               "label": "Upper-Peninsula-County-Map.jpg",
                               "format": "JPEG 1.02",
                               "puid": "fmt/44",
-                              "size": 0.04015159606933594
+                              "size": 0.04015159606933594,
+                              "bulk_extractor_reports": [
+
+                              ]
                             },
                             {
                               "id": "4dae7d2d-80bd-44dc-8cc7-c8a0560b1581",
                               "label": "leadership.gif",
                               "format": "1989a",
                               "puid": "fmt/4",
-                              "size": 0.004961967468261719
+                              "size": 0.004961967468261719,
+                              "bulk_extractor_reports": [
+
+                              ]
                             },
                             {
                               "id": "700af938-facb-4933-b177-60aefd6e9996",
                               "label": "tilden-mine.jpg",
                               "format": "JPEG 1.01",
                               "puid": "fmt/43",
-                              "size": 0.012227058410644531
+                              "size": 0.012227058410644531,
+                              "bulk_extractor_reports": [
+
+                              ]
                             }
+                          ],
+                          "bulk_extractor_reports": [
+
                           ]
                         },
                         {
@@ -5330,8 +7391,14 @@
                               "label": "college-stats.gif",
                               "format": "1989a",
                               "puid": "fmt/4",
-                              "size": 0.02887439727783203
+                              "size": 0.02887439727783203,
+                              "bulk_extractor_reports": [
+
+                              ]
                             }
+                          ],
+                          "bulk_extractor_reports": [
+
                           ]
                         },
                         {
@@ -5352,49 +7419,70 @@
                               "label": "030718deer.jpg",
                               "format": "JPEG 1.02",
                               "puid": "fmt/44",
-                              "size": 0.007403373718261719
+                              "size": 0.007403373718261719,
+                              "bulk_extractor_reports": [
+
+                              ]
                             },
                             {
                               "id": "cbb5f202-b03b-4d57-89fa-980a59fd830a",
                               "label": "Empire20aerial202.jpg",
                               "format": "JPEG 1.01",
                               "puid": "fmt/43",
-                              "size": 0.013245582580566406
+                              "size": 0.013245582580566406,
+                              "bulk_extractor_reports": [
+
+                              ]
                             },
                             {
                               "id": "90cac1b5-95d0-4280-8dab-c48defe2ced5",
                               "label": "Tilden20aerial20220web.jpg",
                               "format": "JPEG 1.02",
                               "puid": "fmt/44",
-                              "size": 0.005615234375
+                              "size": 0.005615234375,
+                              "bulk_extractor_reports": [
+
+                              ]
                             },
                             {
                               "id": "e85a95b5-2cea-415e-ade8-5e0c0ff979d8",
                               "label": "artwork03.jpg",
                               "format": "JPEG 1.02",
                               "puid": "fmt/44",
-                              "size": 0.05019664764404297
+                              "size": 0.05019664764404297,
+                              "bulk_extractor_reports": [
+
+                              ]
                             },
                             {
                               "id": "08fa0000-2332-41a0-a6ab-fa968615d940",
                               "label": "artwork04.jpg",
                               "format": "JPEG 1.02",
                               "puid": "fmt/44",
-                              "size": 0.05620861053466797
+                              "size": 0.05620861053466797,
+                              "bulk_extractor_reports": [
+
+                              ]
                             },
                             {
                               "id": "a26d413f-7171-43c6-bbf8-77ee12052ea6",
                               "label": "artwork06.jpg",
                               "format": "JPEG 1.02",
                               "puid": "fmt/44",
-                              "size": 0.059363365173339844
+                              "size": 0.059363365173339844,
+                              "bulk_extractor_reports": [
+
+                              ]
                             },
                             {
                               "id": "e32c8ad5-06b6-4574-9e88-dfa71e53d114",
                               "label": "fall-colors.jpg",
                               "format": "JPEG 1.02",
                               "puid": "fmt/44",
-                              "size": 0.009907722473144531
+                              "size": 0.009907722473144531,
+                              "bulk_extractor_reports": [
+
+                              ]
                             },
                             {
                               "id": "9a161ece-0c41-4b59-a4da-58fbf83c317f",
@@ -5402,28 +7490,49 @@
                               "format": "TIFF",
                               "puid": "fmt/353",
                               "extension": ".tif",
-                              "size": 4.756345748901367
+                              "size": 4.756345748901367,
+                              "bulk_extractor_reports": [
+
+                              ]
                             },
                             {
                               "id": "01f4cf81-ce8d-485c-97fa-7aa60b0c731c",
                               "label": "upmap4.jpg",
                               "format": "JPEG 1.01",
                               "puid": "fmt/43",
-                              "size": 0.020229339599609375
+                              "size": 0.020229339599609375,
+                              "bulk_extractor_reports": [
+
+                              ]
                             },
                             {
                               "id": "3c5f01cd-8c1f-4ff5-a56a-8dba5e1c9b88",
                               "label": "welcomup.gif",
                               "format": "1989a",
                               "puid": "fmt/4",
-                              "size": 0.0064105987548828125
+                              "size": 0.0064105987548828125,
+                              "bulk_extractor_reports": [
+
+                              ]
                             }
+                          ],
+                          "bulk_extractor_reports": [
+
                           ]
                         }
+                      ],
+                      "bulk_extractor_reports": [
+
                       ]
                     }
+                  ],
+                  "bulk_extractor_reports": [
+
                   ]
                 }
+              ],
+              "bulk_extractor_reports": [
+
               ]
             },
             {
@@ -5455,176 +7564,254 @@
                       "label": "8-14-08-Mascoma-Gov-Brief.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0302734375
+                      "size": 0.0302734375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "42ca5547-9289-431f-8f7c-e07616072f98",
                       "label": "DNR-Pocket-Park-Ribbon-Cutting.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.03515625
+                      "size": 0.03515625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "43a58620-25c2-4a98-98ca-f25157a92f88",
                       "label": "Delta-County.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.01953125
+                      "size": 0.01953125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "fe95bf37-aa7e-45ff-aaec-380c2f932fea",
                       "label": "Ed-Board-Daily-Press.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0283203125
+                      "size": 0.0283203125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "e1a42695-2c6a-4b90-8d65-7c869ceec5a2",
                       "label": "Governor-UP-August-2008.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.03173828125
+                      "size": 0.03173828125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "6f8c1413-45b2-410b-b3e3-9ccb0ae1f0df",
                       "label": "Lofts-on-Ludington.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.03173828125
+                      "size": 0.03173828125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "576d11e9-1a66-40ed-9450-a69469d988c4",
                       "label": "LunchwGovAd2008.pdf",
                       "format": "Acrobat PDF 1.3",
                       "puid": "fmt/17",
-                      "size": 0.0376129150390625
+                      "size": 0.0376129150390625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "c791010d-493a-4e16-9a66-235b97b0db0e",
                       "label": "Marquette-County.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.021484375
+                      "size": 0.021484375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "2483f88e-d62d-43f2-9095-65ced01c4728",
                       "label": "Mascoma-Meeting.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02783203125
+                      "size": 0.02783203125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "fcea0bfa-8e67-4606-8c43-75b1f81d9088",
                       "label": "Media-Meet-brief.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0302734375
+                      "size": 0.0302734375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "58b9896c-70be-432d-b804-69dab53eedd4",
                       "label": "Mining-Journal-Ed-Board-Visit.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0283203125
+                      "size": 0.0283203125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "c4264495-b595-41c1-8b4b-b9c12f288b45",
                       "label": "NWLB-Press-Conference.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02685546875
+                      "size": 0.02685546875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "c02f719b-e349-489a-8302-65e6fb46a33e",
                       "label": "State-Bird-Carving-Presentation.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.03173828125
+                      "size": 0.03173828125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "77933055-9bad-4f1a-9737-729a02f5c54a",
                       "label": "Stupak-FR-Hot-Issues.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0234375
+                      "size": 0.0234375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "dff2880c-705f-43cf-92e5-0a2e65a2186c",
                       "label": "Stupak-Fundraiser.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0302734375
+                      "size": 0.0302734375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "fc8ab3fc-63e9-4035-9a5f-ad776ea4b7f0",
                       "label": "Tim-Kobasic-WYKK-Interview-brief.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02978515625
+                      "size": 0.02978515625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "1d787f99-42c9-4911-8c0c-67840fe13459",
                       "label": "UP-HOT-TOPICS-2007.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.1455078125
+                      "size": 0.1455078125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "36ec1b1c-8685-4d4e-8c9e-85edf7cc75eb",
                       "label": "UP-HOT-TOPICS-2008.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.13623046875
+                      "size": 0.13623046875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "3c18c1bd-d1de-497f-8eb8-cc898d96adb2",
                       "label": "UP-State-Fair-Governors-Luncheon-2008.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.44873046875
+                      "size": 0.44873046875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "181a3b0c-6a8a-442b-8496-7fcbee857e47",
                       "label": "Upper-Peninsula-Hot-Topics.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.064453125
+                      "size": 0.064453125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "6fadf2ae-99cd-44cb-805c-772d63a48320",
                       "label": "Vet-of-the-Year-Brief.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.033203125
+                      "size": 0.033203125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "9f497db0-3ae6-4a88-992b-15f1dae7d5c4",
                       "label": "Veteran-Background.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02490234375
+                      "size": 0.02490234375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "8572787f-bcf5-41df-b720-42b3751e37d0",
                       "label": "WCHT-Radio-Interview.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0283203125
+                      "size": 0.0283203125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "50674d8a-daa6-4783-8146-9d98fe998d76",
                       "label": "WMXG-FM-radio-interview-brief.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0283203125
+                      "size": 0.0283203125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "15dc2741-c74b-4703-b2df-8a518b7a39ac",
                       "label": "Walt-Lindala.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.029296875
+                      "size": 0.029296875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     }
+                  ],
+                  "bulk_extractor_reports": [
+
                   ]
                 },
                 {
@@ -5642,77 +7829,110 @@
                       "label": "Bay-College-Tour.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0322265625
+                      "size": 0.0322265625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "63746990-43b0-4d5a-a4fe-30c1f01e5247",
                       "label": "Governors-Luncheon-Summer-Youth-Initiative.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.03173828125
+                      "size": 0.03173828125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "90f6a55c-d0e9-47d7-bd13-a38dd7626581",
                       "label": "IM-Schools-Meeting.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.033203125
+                      "size": 0.033203125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "54b1bb93-fa96-4d1c-a3a6-19fcabb5537c",
                       "label": "Lofts-on-Ludington-Tour.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02783203125
+                      "size": 0.02783203125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "96f719f8-e76e-4c94-9484-ae85740693c4",
                       "label": "Lunch-with-Bay-College-Bd-of-Trustees.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.03076171875
+                      "size": 0.03076171875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "602df535-034a-4dc4-9f9a-c5952ec03140",
                       "label": "Luncheon.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.08984375
+                      "size": 0.08984375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "32f6cae5-c60c-4328-a7ba-41a160714f1a",
                       "label": "No-Worker-Left-Behind-Event.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0322265625
+                      "size": 0.0322265625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "142ef483-1117-4217-8544-25c0d3ad0028",
                       "label": "Photo-Op-with-Orrin-Bailey.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0302734375
+                      "size": 0.0302734375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "888326bc-afc7-4236-897e-99ec6bb3d1ae",
                       "label": "St-John-Forest-Products-Tour.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.03173828125
+                      "size": 0.03173828125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "8dd14878-8aa1-4dca-9bd5-4c93bcc134ac",
                       "label": "State-Bird-Carving-Presentation.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0322265625
+                      "size": 0.0322265625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "f412d8ac-ffbf-4f05-ba4f-cfbc5998e2a8",
                       "label": "Vet-of-the-Year-Brief-2009.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.083984375
+                      "size": 0.083984375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "344a8de5-fa9c-4f2e-8e98-a0719c4fe8e2",
@@ -5729,47 +7949,74 @@
                           "label": "Lofts-on-Ludington-Tour.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.03173828125
+                          "size": 0.03173828125,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "b9d7b8ef-5b53-4de5-94f7-cbab34e2493e",
                           "label": "Lunch-with-Bay-College-Bd-of-Trustees.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.03076171875
+                          "size": 0.03076171875,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "c70aaabb-b48e-490d-9c95-bb8530ee3840",
                           "label": "Photo-Op-with-Orrin-Bailey.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.0302734375
+                          "size": 0.0302734375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "5286d20f-32e3-49e8-b696-3a4a9138964a",
                           "label": "St-John-Forest-Products-Tour.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.03173828125
+                          "size": 0.03173828125,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "db3cf8f1-d42f-4b43-a398-d7de26cf7c8b",
                           "label": "State-Bird-Carving-Presentation.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.03173828125
+                          "size": 0.03173828125,
+                          "bulk_extractor_reports": [
+
+                          ]
                         },
                         {
                           "id": "642899f9-0f6d-49c9-adde-0977ca2fc113",
                           "label": "Vet-of-the-Year-Brief-2009.doc",
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
-                          "size": 0.083984375
+                          "size": 0.083984375,
+                          "bulk_extractor_reports": [
+
+                          ]
                         }
+                      ],
+                      "bulk_extractor_reports": [
+
                       ]
                     }
+                  ],
+                  "bulk_extractor_reports": [
+
                   ]
                 }
+              ],
+              "bulk_extractor_reports": [
+
               ]
             },
             {
@@ -5805,204 +8052,294 @@
                       "label": "Background-Info-Western-Lime-3.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0224609375
+                      "size": 0.0224609375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "ac9340b2-5629-4ede-bb63-d1953698b69d",
                       "label": "Bonifas-Arts-Center-Brief.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0322265625
+                      "size": 0.0322265625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "3b21f7ce-b61f-4176-a167-4d312b9fb11d",
                       "label": "CCI-Announcement-brief.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.04052734375
+                      "size": 0.04052734375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "c3b8e1ec-356c-4293-8a79-1db21ab873a5",
                       "label": "Cleveland-Cliffs-Announcement.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.138671875
+                      "size": 0.138671875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "b1a8db6d-317c-48fa-8a81-b1313a152a14",
                       "label": "Cliffs-Dignitary-Reception-brief.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.03125
+                      "size": 0.03125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "23e802c7-6947-4948-819d-ebc9949f5144",
                       "label": "DJG-Remarks-8-16-07-draft8-2.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0302734375
+                      "size": 0.0302734375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "b710bc07-b896-483a-988c-3b8d8d85b6cb",
                       "label": "Delta-County.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.01953125
+                      "size": 0.01953125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "2c594d09-a5eb-472d-8f1b-4640a9caf65c",
                       "label": "Detailed-Western-Lime-Agenda-2.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02001953125
+                      "size": 0.02001953125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "11d34b64-c213-4659-b9ad-a812934cdded",
                       "label": "Dick-Storm-Radio-Interview-Brief.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0283203125
+                      "size": 0.0283203125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "89ac8941-59d9-4f17-a70a-fba0da15f899",
                       "label": "Governor-s-UP-FINAL-Schedule.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.04541015625
+                      "size": 0.04541015625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "c7a48ba8-8949-4962-8e99-734598e472a7",
                       "label": "Govs-luncheon-Attendees.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.63134765625
+                      "size": 0.63134765625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "b708aaac-165d-4d4b-b88c-db6116405fbe",
                       "label": "Guinness-book-of-records.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0869140625
+                      "size": 0.0869140625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "c721512e-b340-40bf-9ce1-b30479d97d0a",
                       "label": "GuinnessWorldRecords-for-skateboard.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02734375
+                      "size": 0.02734375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "c9039a57-22ec-4716-a4ac-998dcd687d64",
                       "label": "Les-Wong-meeting-brief.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.03076171875
+                      "size": 0.03076171875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "e041382f-1c40-4477-b684-226feb410590",
                       "label": "Manistique-Officials-Meeting-Brief.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02978515625
+                      "size": 0.02978515625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "6be703aa-c193-4ea6-8241-de7c781c8515",
                       "label": "Marquette-County.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.021484375
+                      "size": 0.021484375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "b1774bcd-71c0-4740-8668-270f39a15e55",
                       "label": "Media-Meet-brief.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.03125
+                      "size": 0.03125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "4735b376-694c-4067-8cf7-196b69e5a110",
                       "label": "Never-mistake-a-clear-vision-for-a-short-journey-3.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02587890625
+                      "size": 0.02587890625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "3db2e66a-fb8d-420b-88b2-6d5dee296395",
                       "label": "Open-House-Invitations.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.0302734375
+                      "size": 0.0302734375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "5b59f123-da48-4e42-b946-6643c85b1fa8",
                       "label": "Schoolcraft-County.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02099609375
+                      "size": 0.02099609375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "c46e1af0-b258-4c90-a6cd-cc33ab74120e",
                       "label": "Tim-Kobasic-WYKK-Interview-brief.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02978515625
+                      "size": 0.02978515625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "f6ce22bb-0afc-4df0-a729-e9920abf0469",
                       "label": "UP-State-Fair-Governors-Luncheon-2007.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.650390625
+                      "size": 0.650390625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "a586640f-b47a-494e-a3e0-c2fa29de4a01",
                       "label": "UP-State-Fair-Luncheon-SPEECH-Info.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02001953125
+                      "size": 0.02001953125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "f4b770d6-6c4e-49eb-b358-554e4c3f53e4",
                       "label": "Vet-of-the-Year-Background-2007.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0224609375
+                      "size": 0.0224609375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "37b6a833-efea-4f00-a350-709ae580560e",
                       "label": "Vet-of-the-Year-Event-Brief.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.08203125
+                      "size": 0.08203125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "02f4fafa-60b8-421e-b288-7d16abe9691a",
                       "label": "WMXG-FM-radio-interview-brief.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0244140625
+                      "size": 0.0244140625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "fc445b29-e398-477b-8515-9cf1f15282a5",
                       "label": "Western-Lime-Brief-1.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.05224609375
+                      "size": 0.05224609375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "db2bf5d2-8c91-484c-9b6c-f97e0b56beda",
                       "label": "Western-Lime-Brief.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0322265625
+                      "size": 0.0322265625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "206a7f82-0590-44ae-add7-4c449c02553f",
                       "label": "Western-Lime-Info.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02197265625
+                      "size": 0.02197265625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     }
+                  ],
+                  "bulk_extractor_reports": [
+
                   ]
                 },
                 {
@@ -6026,122 +8363,179 @@
                       "label": "8-18-Media-2.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.033203125
+                      "size": 0.033203125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "bfb771b8-e7d7-47eb-bd89-2f1079f2e9a7",
                       "label": "Briefing-Memo-ATV-OHV-Practical-Skills-Track-Dedication.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0322265625
+                      "size": 0.0322265625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "17497749-0ccc-4dcb-a2cd-410857c055b1",
                       "label": "Briefing-Memo-H-for-H-Home-Dedication.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02490234375
+                      "size": 0.02490234375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "ab81254b-45f0-4de2-8118-d30e670693b1",
                       "label": "Briefing-Memo-H-for-H-Manistique.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02392578125
+                      "size": 0.02392578125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "3625e2d2-0e27-4ffe-9d51-db07bfdcc259",
                       "label": "Briefing-Memo-Manistique-Memorial-Fountain.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02783203125
+                      "size": 0.02783203125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "3d7a9ea6-c626-49f8-a169-e42dae990d5b",
                       "label": "Briefing-Memo-UPSF-Luncheon.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02783203125
+                      "size": 0.02783203125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "886d1d5b-f228-4566-be95-398dc1b83fd4",
                       "label": "Briefing-Memo-War-Memorial-Hospital-Medical-Building.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0234375
+                      "size": 0.0234375,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "467f9b0f-12db-461d-8bb4-894c6cd55fc6",
                       "label": "CONTACTS-August-19-20-2010.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.0205078125
+                      "size": 0.0205078125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "db9b741d-d7ae-49ef-b3da-21d59a50fb8f",
                       "label": "Fw-Moyle-Ribbon-Cutting-List-Moyle-Investment-as-it-relates-to-War-Memorial-Hospital.htm",
                       "format": "Hypertext Markup Language 4.0",
                       "puid": "fmt/99",
-                      "size": 0.04069709777832031
+                      "size": 0.04069709777832031,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "cd19f388-0a33-4f9c-806c-600afaea09cf",
                       "label": "Fw-tentative-groundbreaking-agenda-2-GFWC.htm",
                       "format": "Hypertext Markup Language 4.0",
                       "puid": "fmt/99",
-                      "size": 0.017065048217773438
+                      "size": 0.017065048217773438,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "3937a42f-2f40-46c2-87b0-9adc62e8e27f",
                       "label": "GFWC.pdf",
                       "format": "Acrobat PDF 1.6",
                       "puid": "fmt/20",
-                      "size": 0.15174293518066406
+                      "size": 0.15174293518066406,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "9bcd1dcd-d451-4ee8-9ba1-de29c17372be",
                       "label": "HforH-2.pdf",
                       "format": "Acrobat PDF 1.6",
                       "puid": "fmt/20",
-                      "size": 0.6819515228271484
+                      "size": 0.6819515228271484,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "528a7571-86dd-4a81-b03a-16aed00bf89f",
                       "label": "MOB-Mailing-List.xls",
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
-                      "size": 0.02197265625
+                      "size": 0.02197265625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "16312664-8946-4e0d-94cc-2f04b4a4cdf2",
                       "label": "UPSF-2010-UPDATE.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.0283203125
+                      "size": 0.0283203125,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "b6cfe345-fae1-4676-a1b2-1668267634ed",
                       "label": "UPSF.pdf",
                       "format": "Acrobat PDF 1.6",
                       "puid": "fmt/20",
-                      "size": 0.07654857635498047
+                      "size": 0.07654857635498047,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "9cdb5bb9-a3be-4d35-9274-72ac1e003d8e",
                       "label": "invitation.htm",
                       "format": "Hypertext Markup Language 4.0",
                       "puid": "fmt/99",
-                      "size": 0.019969940185546875
+                      "size": 0.019969940185546875,
+                      "bulk_extractor_reports": [
+
+                      ]
                     },
                     {
                       "id": "5115ebdd-50a4-4d2f-ada8-9eea06d4da40",
                       "label": "mob-2.doc",
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
-                      "size": 0.02587890625
+                      "size": 0.02587890625,
+                      "bulk_extractor_reports": [
+
+                      ]
                     }
+                  ],
+                  "bulk_extractor_reports": [
+
                   ]
                 }
+              ],
+              "bulk_extractor_reports": [
+
               ]
             },
             {
@@ -6161,278 +8555,404 @@
                   "label": "August-2005-list-of-events-part-1.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.02734375
+                  "size": 0.02734375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "81d38289-5dd7-4b30-b317-0f140a10e347",
                   "label": "Baraga-County.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.0283203125
+                  "size": 0.0283203125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "251d1018-4e3f-4a76-ba8e-469040ec2fee",
                   "label": "Coffee-with-the-Governor-Baraga.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.04052734375
+                  "size": 0.04052734375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "0be77823-4276-41b3-9032-c58747c848b2",
                   "label": "Copy-of-phone-numbers.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.017578125
+                  "size": 0.017578125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "c86c9da9-c96a-4667-86fb-4ed7d1e459f5",
                   "label": "Delta-County.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.0263671875
+                  "size": 0.0263671875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "984b03ba-4b49-4788-9c0d-3e947e1a706e",
                   "label": "Eagle-Herald-Newspaper-bio.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.02392578125
+                  "size": 0.02392578125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "a14c9037-48e4-42f7-b8cc-b982c95cdbe9",
                   "label": "Eagle-River-Community-BBQ.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.02978515625
+                  "size": 0.02978515625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "7a146662-32e0-4f47-99ab-db45a52ad41f",
                   "label": "Firefighter-Recognition.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.0361328125
+                  "size": 0.0361328125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "9a055d83-0d18-4f4b-9dfb-b4c30d58bba7",
                   "label": "Interview-with-Iron-River-County-Reporter.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.04248046875
+                  "size": 0.04248046875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "34cb6798-9e1c-48b9-a9fa-44804c7ac05b",
                   "label": "Interview-with-WDBC-Escanaba.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.03076171875
+                  "size": 0.03076171875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "e566a1a5-f8a7-4c46-9769-026e391c56fb",
                   "label": "Interview-with-editorial-board-lanse-sentinel.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.02587890625
+                  "size": 0.02587890625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "1358e5f6-312e-4875-a5bb-9cc4cfb6a430",
                   "label": "Interview-witht-the-Escanaba-Daily-Press.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.0302734375
+                  "size": 0.0302734375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "934cf71f-b74f-417c-bbf1-b6d835589e81",
                   "label": "Iron-Mnt-out-to-lunch.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.0302734375
+                  "size": 0.0302734375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "02a9a091-a16b-4f12-9168-72a4fc4063d9",
                   "label": "Iron-River-Roundtable.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.03466796875
+                  "size": 0.03466796875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "9511cd47-3de6-4bca-92b3-291648597f3e",
                   "label": "Menominee-County.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.02734375
+                  "size": 0.02734375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "2a59646a-510f-43d8-9cbb-3811dbc07028",
                   "label": "Pinecrest-Nursing-Home-visit.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.04541015625
+                  "size": 0.04541015625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "4077f08e-7759-4dc4-99e7-129981e1eb88",
                   "label": "Reception-for-Mitch-Irwin.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.033203125
+                  "size": 0.033203125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "cf0826bb-02db-4bd7-958f-12bbe7acd143",
                   "label": "Skeleton-Schedule.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.0302734375
+                  "size": 0.0302734375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "98d8a818-04eb-4ea4-a596-8cf0a37f3483",
                   "label": "Thank-you-2005.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.0390625
+                  "size": 0.0390625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "6fe69727-81b6-45c0-aa23-47c6f8e7e8d8",
                   "label": "Thank-you-note-list.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.03759765625
+                  "size": 0.03759765625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "bb42cba2-a016-463d-8165-72162a856f36",
                   "label": "Township-Supervisors-and-City-Managers-for-U.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.02294921875
+                  "size": 0.02294921875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "0bc1d393-32ab-49fc-86e8-13379eabcc9a",
                   "label": "UP-State-Fair-4-H-dedication.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.0361328125
+                  "size": 0.0361328125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "9a3d1321-3a5e-41b2-8b92-90bf28a64a9f",
                   "label": "UP-State-Fair-Veterans-Ceremony2.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.03173828125
+                  "size": 0.03173828125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "c691969e-4aab-4b95-b7b8-ce0b0df934c5",
                   "label": "UP-State-Fair.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.0361328125
+                  "size": 0.0361328125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "03ee42c2-a9b8-4f71-b44d-ee769ad3091c",
                   "label": "UP-Swing-Follow-Up.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.02294921875
+                  "size": 0.02294921875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "728b9ec5-8313-42e0-9c76-c80433b5bad2",
                   "label": "Upper-Peninsula-Hot-Topics.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.064453125
+                  "size": 0.064453125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "8e70c704-ab40-40e9-9995-6c9ba478315d",
                   "label": "art-project-bd.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.037109375
+                  "size": 0.037109375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "f76295ff-f2fd-49b4-8fc0-06e5b41a0e21",
                   "label": "august-2005-list-of-events-part-2.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.1318359375
+                  "size": 0.1318359375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "e6c8545b-093e-44eb-8ade-4cc79ee3df98",
                   "label": "fundraiser-for-Senator-Mike-Prusi.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.02880859375
+                  "size": 0.02880859375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "a998a205-34e8-4848-945d-837c8803b543",
                   "label": "international-paper-bd.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.044921875
+                  "size": 0.044921875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "670c716b-f6ca-47cd-9590-e4f17e355158",
                   "label": "international-paper-bd2.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.03662109375
+                  "size": 0.03662109375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "a8499275-22bc-418a-9021-7e29d52e85e2",
                   "label": "newpage.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.03173828125
+                  "size": 0.03173828125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "40769334-200a-45ac-b226-d063f17931f1",
                   "label": "numbers-and-addresses-for-august-2005-visit.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.0595703125
+                  "size": 0.0595703125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "c4d8ed8f-2bf1-4b05-a82c-f4f57d725f8e",
                   "label": "phone-numbers.xls",
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
-                  "size": 0.01806640625
+                  "size": 0.01806640625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "8ead7e2e-ba40-4aba-9781-0e984e2037de",
                   "label": "up-fair-reading-program-event.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.0322265625
+                  "size": 0.0322265625,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "879328d6-ec06-4447-b3c4-611204ec71e6",
                   "label": "up-state-dnr-pocket-park.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.03076171875
+                  "size": 0.03076171875,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "c3f1f342-873b-46d2-ba35-b207249a0ec2",
                   "label": "up-state-fair-animal-barn.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.02880859375
+                  "size": 0.02880859375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "7b511d12-7889-4294-b3e5-c84d5f340156",
                   "label": "up-state-fair-governor-luncheon-and-tour.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.02734375
+                  "size": 0.02734375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "09a81af7-804c-4008-9e73-8040ebe5cd58",
                   "label": "up-state-fairgrounds-map.doc",
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
-                  "size": 0.068359375
+                  "size": 0.068359375,
+                  "bulk_extractor_reports": [
+
+                  ]
                 }
+              ],
+              "bulk_extractor_reports": [
+
               ]
             }
+          ],
+          "bulk_extractor_reports": [
+
           ]
         }
+      ],
+      "bulk_extractor_reports": [
+
       ]
     },
     {
@@ -6491,7 +9011,10 @@
               "format": "Microsoft Word for Windows 2007+",
               "puid": "fmt/412",
               "extension": ".docx",
-              "size": 0.010906219482421875
+              "size": 0.010906219482421875,
+              "bulk_extractor_reports": [
+
+              ]
             },
             {
               "id": "c93564d6-306c-400f-9bfe-73508ef1addf",
@@ -6500,14 +9023,20 @@
               "puid": "fmt/215",
               "extension": ".pptx",
               "size": 0.04548835754394531,
-              "bulk_extractor": "fixtures/transferdata/bulk-c93564d6-306c-400f-9bfe-73508ef1addf.zip"
+              "bulk_extractor": "fixtures/transferdata/bulk-c93564d6-306c-400f-9bfe-73508ef1addf.zip",
+              "bulk_extractor_reports": [
+                "pii"
+              ]
             },
             {
               "id": "7fc27b8f-fd4e-4220-bd6d-9db98fb14c9d",
               "label": "Credit Report.pdf",
               "format": "Acrobat PDF 1.5",
               "puid": "fmt/19",
-              "size": 0.037242889404296875
+              "size": 0.037242889404296875,
+              "bulk_extractor_reports": [
+
+              ]
             },
             {
               "id": "8ca89491-5b9a-45e0-8202-3e1a1357eab4",
@@ -6515,24 +9044,36 @@
               "format": "Comma Separated Values",
               "puid": "x-fmt/18",
               "extension": ".csv",
-              "size": 0.0016050338745117188
+              "size": 0.0016050338745117188,
+              "bulk_extractor_reports": [
+
+              ]
             },
             {
               "id": "d2523802-203b-43e5-b5a9-c719985f726b",
               "label": "Employee Database.accdb",
-              "size": 0.37109375
+              "size": 0.37109375,
+              "bulk_extractor_reports": [
+
+              ]
             },
             {
               "id": "2927af84-d519-41f6-8bda-5c1caec67d0c",
               "label": "Employee Database.mdb",
-              "size": 0.21875
+              "size": 0.21875,
+              "bulk_extractor_reports": [
+
+              ]
             },
             {
               "id": "e198fa44-5958-4039-9273-7239e5c7e571",
               "label": "Hidden Column.xls",
               "format": "Excel 97 Workbook",
               "puid": "fmt/61",
-              "size": 0.01953125
+              "size": 0.01953125,
+              "bulk_extractor_reports": [
+
+              ]
             },
             {
               "id": "7fce5968-013c-46f5-9e9b-3774b2aa5cb0",
@@ -6540,7 +9081,10 @@
               "format": "Acrobat PDF 1.5",
               "puid": "fmt/19",
               "size": 0.020104408264160156,
-              "bulk_extractor": "fixtures/transferdata/bulk-7fce5968-013c-46f5-9e9b-3774b2aa5cb0.zip"
+              "bulk_extractor": "fixtures/transferdata/bulk-7fce5968-013c-46f5-9e9b-3774b2aa5cb0.zip",
+              "bulk_extractor_reports": [
+                "pii"
+              ]
             },
             {
               "id": "a7bf717f-c0bd-4161-9a02-a7cb1674c634",
@@ -6548,14 +9092,20 @@
               "format": "Acrobat PDF 1.5",
               "puid": "fmt/19",
               "size": 0.08741188049316406,
-              "bulk_extractor": "fixtures/transferdata/bulk-a7bf717f-c0bd-4161-9a02-a7cb1674c634.zip"
+              "bulk_extractor": "fixtures/transferdata/bulk-a7bf717f-c0bd-4161-9a02-a7cb1674c634.zip",
+              "bulk_extractor_reports": [
+                "ccn"
+              ]
             },
             {
               "id": "875d8e59-2ff3-4e9e-a4dd-90edd4152305",
               "label": "college essay w footer.doc",
               "format": "Microsoft Word Document 97-2003",
               "puid": "fmt/40",
-              "size": 0.02978515625
+              "size": 0.02978515625,
+              "bulk_extractor_reports": [
+
+              ]
             },
             {
               "id": "c233ba1e-014b-4d74-958a-fb05dabc7932",
@@ -6563,7 +9113,10 @@
               "format": "Excel for Windows 2007+",
               "puid": "fmt/214",
               "extension": ".xlsx",
-              "size": 0.011753082275390625
+              "size": 0.011753082275390625,
+              "bulk_extractor_reports": [
+
+              ]
             },
             {
               "id": "8f5abbd7-046f-40bd-bae6-6646463c2a41",
@@ -6572,14 +9125,21 @@
               "puid": "x-fmt/263",
               "extension": ".zip",
               "size": 0.00031948089599609375,
-              "bulk_extractor": "fixtures/transferdata/bulk-8f5abbd7-046f-40bd-bae6-6646463c2a41.zip"
+              "bulk_extractor": "fixtures/transferdata/bulk-8f5abbd7-046f-40bd-bae6-6646463c2a41.zip",
+              "bulk_extractor_reports": [
+                "pii",
+                "ccn"
+              ]
             },
             {
               "id": "61f32c21-46b8-442f-9d55-e1828ea788b5",
               "label": "students.ppt",
               "format": "Powerpoint 97-2002",
               "puid": "fmt/126",
-              "size": 0.1494140625
+              "size": 0.1494140625,
+              "bulk_extractor_reports": [
+
+              ]
             },
             {
               "id": "d12aaf8b-1265-47a4-97c3-64ab03fb2c20",
@@ -6597,8 +9157,14 @@
                   "format": "Generic TXT",
                   "puid": "x-fmt/111",
                   "extension": ".txt",
-                  "size": 0.05178642272949219
+                  "size": 0.05178642272949219,
+                  "bulk_extractor_reports": [
+
+                  ]
                 }
+              ],
+              "bulk_extractor_reports": [
+
               ]
             },
             {
@@ -6617,7 +9183,10 @@
                   "format": "Generic TXT",
                   "puid": "x-fmt/111",
                   "extension": ".txt",
-                  "size": 0.00034046173095703125
+                  "size": 0.00034046173095703125,
+                  "bulk_extractor_reports": [
+
+                  ]
                 },
                 {
                   "id": "97331076-6932-4e19-ad9a-7c31115493e8",
@@ -6626,8 +9195,14 @@
                   "puid": "x-fmt/111",
                   "extension": ".txt",
                   "size": 0.008740425109863281,
-                  "bulk_extractor": "fixtures/transferdata/bulk-97331076-6932-4e19-ad9a-7c31115493e8.zip"
+                  "bulk_extractor": "fixtures/transferdata/bulk-97331076-6932-4e19-ad9a-7c31115493e8.zip",
+                  "bulk_extractor_reports": [
+                    "ccn"
+                  ]
                 }
+              ],
+              "bulk_extractor_reports": [
+
               ]
             },
             {
@@ -6647,12 +9222,25 @@
                   "puid": "x-fmt/111",
                   "extension": ".txt",
                   "size": 0.00025177001953125,
-                  "bulk_extractor": "fixtures/transferdata/bulk-2812a935-017d-4a9c-ab68-6938a9f50f6b.zip"
+                  "bulk_extractor": "fixtures/transferdata/bulk-2812a935-017d-4a9c-ab68-6938a9f50f6b.zip",
+                  "bulk_extractor_reports": [
+                    "pii",
+                    "ccn"
+                  ]
                 }
+              ],
+              "bulk_extractor_reports": [
+
               ]
             }
+          ],
+          "bulk_extractor_reports": [
+
           ]
         }
+      ],
+      "bulk_extractor_reports": [
+
       ]
     }
   ]

--- a/app/services/selected.service.js
+++ b/app/services/selected.service.js
@@ -3,14 +3,10 @@
 (function() {
   angular.module('selectedFilesService', ['fileService']).service('SelectedFiles', function(File) {
     return {
-      add: function(uuid) {
-        // assign `this` to another variable to pass it into the `then` function
-        var self = this;
-        File.get(uuid).then(function(file) {
-          // Remove any occurrences of this file if they already exist
-          self.remove(uuid);
-          self.selected.push(file);
-        });
+      add: function(file) {
+        // Remove any occurrences of this file if they already exist
+        this.remove(file.id);
+        this.selected.push(file);
       },
       remove: function(uuid) {
         this.selected = this.selected.filter(function(el) {

--- a/app/tree/tree.controller.js
+++ b/app/tree/tree.controller.js
@@ -22,7 +22,7 @@
     };
 
     var add_file = function(node) {
-      SelectedFiles.add(node.id);
+      SelectedFiles.add(node);
       $scope.selected.push(node);
       if (node.children) {
         for (var i = 0; i < node.children.length; i++) {


### PR DESCRIPTION
This makes some changes to the way that we work with/fetch file data.

There were very few differences between the transfer data in the main transfers.json (e.g., what would initially be returned by Elasticsearch) and the file-level metadata; the differences were just enough to make search and filtering difficult, but not enough to offer a clear benefit in terms of saved bandwidth/server response time.

This makes the following changes:
- Adds the "size" and "bulk_extractor" keys to every file in transferdata
- Adds a new key to every file in transferdata indicating which bulk_extractor reports are present, if any
- Updates the SelectedFiles service to copy over records directly, instead of fetching them separately. This means that selecting the 840-file transfer is now blazing fast!
