### PR TITLE
Examine contents tab changes

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -39,6 +39,7 @@ config(['$routeSegmentProvider', function($routeSegmentProvider) {
     when('/report', 'report').
     when('/tag', 'tag').
     when('/contents', 'examine_contents').
+    when('/contents/:type', 'examine_contents').
     when('/contents/:id/:type', 'examine_contents.file_info').
     when('/visualizations', 'visualizations').
     when('/visualizations/files', 'visualizations.files').
@@ -58,6 +59,7 @@ config(['$routeSegmentProvider', function($routeSegmentProvider) {
     segment('examine_contents', {
       templateUrl: 'examine_contents/examine_contents.html',
       controller: 'ExamineContentsController',
+      dependencies: ['type'],
     }).
     within().
       segment('file_info', {

--- a/app/examine_contents/examine_contents.controller.js
+++ b/app/examine_contents/examine_contents.controller.js
@@ -3,7 +3,8 @@
 (function() {
   angular.module('examineContentsController', []).
 
-  controller('ExamineContentsController', ['$scope', 'SelectedFiles', function($scope, SelectedFiles) {
+  controller('ExamineContentsController', ['$scope', '$routeSegment', 'SelectedFiles', function($scope, $routeSegment, SelectedFiles) {
+    $scope.type = $routeSegment.$routeParams.type;
     $scope.SelectedFiles = SelectedFiles;
   }]).
 

--- a/app/examine_contents/examine_contents.html
+++ b/app/examine_contents/examine_contents.html
@@ -1,4 +1,15 @@
-<ul class="report-panel">
+<!-- TODO: when styling, make sure it's clear why nothing is being displayed if
+           there are no hits for PII or CCN -->
+<ul class="nav links">
+  <li class="internal" ng-class="{ active: type === 'pii' }">
+    <a href="#/contents/pii">PII</a>
+  </li>
+  <li class="internal" ng-class="{ active: type === 'ccn' }">
+    <a href="#/contents/ccn">Credit card numbers</a>
+  </li>
+</ul>
+
+<ul ng-if="type" class="report-panel">
   <h1 ng-if="(SelectedFiles.selected | find_transfers).length != 0">Transfers:</h1>
   <li ng-repeat="record in SelectedFiles.selected | find_transfers">
     {{ record.label }}:
@@ -6,8 +17,8 @@
       <a ng-if="!record.original_order" class="disabled">original order</a>
   </li>
   <h1 ng-if="(SelectedFiles.selected | find_files).length != 0">Files</h1>
-  <li ng-repeat="record in SelectedFiles.selected | find_files">
-    <a href="#/contents/{{ record.id }}/pii">{{ record.label }}</a>:
+  <li ng-repeat="record in SelectedFiles.selected | find_files | filter:{bulk_extractor_reports: type}">
+    <a href="#/contents/{{ record.id }}/{{ type }}">{{ record.label }}</a>:
       <a ng-if="record.bulk_extractor" href="{{ record.bulk_extractor}}">Bulk Extractor logs</a>
   </li>
 </ul>

--- a/app/examine_contents/file_info.html
+++ b/app/examine_contents/file_info.html
@@ -8,14 +8,3 @@
     <td>{{ feature.context }}</td>
   </tr>
 </table>
-
-<!-- TODO: when styling, make sure it's clear why nothing is being displayed if
-           there are no hits for PII or CCN -->
-<ul class="nav links">
-  <li class="internal" ng-if="file.pii.length > 0" ng-class="{ active: $routeSegment.contains('pii') }">
-    <a href="#/contents/{{ id }}/pii">PII</a>
-  </li>
-  <li class="internal" ng-if="file.ccn.length > 0" ng-class="{ active: $routeSegment.contains('ccn') }">
-    <a href="#/contents/{{ id }}/ccn">Credit card numbers</a>
-  </li>
-</ul>

--- a/app/examine_contents/file_info.html
+++ b/app/examine_contents/file_info.html
@@ -1,9 +1,7 @@
 <table ng-if="file[type].length > 0">
-  <th>Offset</th>
   <th>Content</th>
   <th>Context</th>
   <tr ng-repeat="feature in file[type]">
-    <td>{{ feature.offset }}</td>
     <td>{{ feature.content }}</td>
     <td>{{ feature.context }}</td>
   </tr>


### PR DESCRIPTION
The "CCI/PII" links have been moved into a parent template, where they now control filtering the selected files by files which contain the requested reports. This makes it a bit easier to tell at a glance how many files in a given set contain data potentially.

This also removes the "offset" column; that data's provided by bulk_extractor, but was judged not useful in this context.
