### PR TITLE
Filter tree view using facets

### DIFF
--- a/app/facet_selector/facet_selector.controller.js
+++ b/app/facet_selector/facet_selector.controller.js
@@ -6,6 +6,7 @@
   controller('FacetController', ['$scope', 'Transfer', 'Facet', 'Tag', function($scope, Transfer, Facet, Tag) {
       $scope.remove_facet = function(name, id) {
         Facet.remove_by_id(name, id);
+        Transfer.filter();
       };
       $scope.Facet = Facet;
       $scope.transfers = Transfer;
@@ -20,6 +21,7 @@
           return selected === value.substr(value.lastIndexOf('.')).toLowerCase();
         };
         Facet.add('text', facet_fn, {name: 'Extension', text: selected});
+        Transfer.filter();
       });
 
       var format_date = function(start, end) {
@@ -50,6 +52,7 @@
           return date_as_int > start_date && date_as_int < end_date;
         };
         Facet.add('date', facet_fn, {name: 'Date', text: format_date($scope.date_start, $scope.date_end)});
+        Transfer.filter();
       });
 
       $scope.$watch('puid', function(selected) {
@@ -58,6 +61,7 @@
         }
 
         Facet.add('puid', selected, {name: 'Format', text: selected});
+        Transfer.filter();
       });
     }]);
 })();

--- a/app/facet_selector/facet_selector.controller.js
+++ b/app/facet_selector/facet_selector.controller.js
@@ -20,7 +20,7 @@
         var facet_fn = function(value) {
           return selected === value.substr(value.lastIndexOf('.')).toLowerCase();
         };
-        Facet.add('text', facet_fn, {name: 'Extension', text: selected});
+        Facet.add('label', facet_fn, {name: 'Extension', text: selected});
         Transfer.filter();
       });
 

--- a/app/facet_selector/facet_selector.controller.js
+++ b/app/facet_selector/facet_selector.controller.js
@@ -63,5 +63,14 @@
         Facet.add('puid', selected, {name: 'Format', text: selected});
         Transfer.filter();
       });
+
+      $scope.$watch('tag_facet', function(selected) {
+        if (!selected) {
+          return;
+        }
+
+        Facet.add('tags', selected, {name: 'Tag', text: selected});
+        Transfer.filter();
+      });
     }]);
 })();

--- a/app/facet_selector/facet_selector.controller.js
+++ b/app/facet_selector/facet_selector.controller.js
@@ -20,7 +20,7 @@
         var facet_fn = function(value) {
           return selected === value.substr(value.lastIndexOf('.')).toLowerCase();
         };
-        Facet.add('label', facet_fn, {name: 'Extension', text: selected});
+        Facet.add('title', facet_fn, {name: 'Extension', text: selected});
         Transfer.filter();
       });
 

--- a/app/fixtures/transfers.json
+++ b/app/fixtures/transfers.json
@@ -353,13 +353,15 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "puid": ""
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
-              "type": "directory"
+              "type": "directory",
+              "puid": ""
             },
             {
               "id": "c7d10d01-a6e6-4942-9d5e-6b7022308536",
@@ -386,7 +388,8 @@
               "bulk_extractor_reports": [
 
               ],
-              "type": "directory"
+              "type": "directory",
+              "puid": ""
             },
             {
               "id": "24732795-8715-452a-9309-5cae7da81dfb",
@@ -1371,13 +1374,15 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "directory"
+                  "type": "directory",
+                  "puid": ""
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
-              "type": "directory"
+              "type": "directory",
+              "puid": ""
             },
             {
               "id": "8168bac8-ae50-4914-a515-b778518ab675",
@@ -1439,7 +1444,8 @@
               "bulk_extractor_reports": [
 
               ],
-              "type": "directory"
+              "type": "directory",
+              "puid": ""
             },
             {
               "id": "6136fc85-4d42-45bc-affd-5f521c1db4ee",
@@ -1734,7 +1740,8 @@
               "bulk_extractor_reports": [
 
               ],
-              "type": "directory"
+              "type": "directory",
+              "puid": ""
             },
             {
               "id": "a9d7da66-e504-4b9a-ad02-63efeaaaaef6",
@@ -1825,7 +1832,8 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "directory"
+                  "type": "directory",
+                  "puid": ""
                 },
                 {
                   "id": "117e99f6-c8f3-4380-87ce-65709d9da571",
@@ -2040,7 +2048,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "directory"
+                      "type": "directory",
+                      "puid": ""
                     },
                     {
                       "id": "22ca959a-b4da-42ae-aed4-4de86ba3c7b1",
@@ -2367,13 +2376,15 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "directory"
+                          "type": "directory",
+                          "puid": ""
                         }
                       ],
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "directory"
+                      "type": "directory",
+                      "puid": ""
                     },
                     {
                       "id": "06a98817-da21-46be-8062-b24d213a84df",
@@ -2637,7 +2648,8 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "puid": ""
                             },
                             {
                               "id": "395842f5-a575-45c7-abc0-dce0781139a7",
@@ -2654,19 +2666,22 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "directory"
+                          "type": "directory",
+                          "puid": ""
                         }
                       ],
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "directory"
+                      "type": "directory",
+                      "puid": ""
                     }
                   ],
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "directory"
+                  "type": "directory",
+                  "puid": ""
                 },
                 {
                   "id": "9d66bd11-d039-4463-95f1-0f899e418f07",
@@ -2944,7 +2959,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "directory"
+                      "type": "directory",
+                      "puid": ""
                     },
                     {
                       "id": "f9b9190e-42be-4b98-bbe5-c78711a861b8",
@@ -3061,7 +3077,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "directory"
+                      "type": "directory",
+                      "puid": ""
                     },
                     {
                       "id": "5554ab06-6e32-410c-b543-cb9202f97f98",
@@ -3132,7 +3149,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "directory"
+                      "type": "directory",
+                      "puid": ""
                     },
                     {
                       "id": "4332f40c-5b43-4192-ae9d-ec4396019b88",
@@ -3181,13 +3199,15 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "directory"
+                      "type": "directory",
+                      "puid": ""
                     }
                   ],
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "directory"
+                  "type": "directory",
+                  "puid": ""
                 },
                 {
                   "id": "941a7160-8063-43bc-bf64-d50d8de6f703",
@@ -3260,13 +3280,15 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "directory"
+                  "type": "directory",
+                  "puid": ""
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
-              "type": "directory"
+              "type": "directory",
+              "puid": ""
             },
             {
               "id": "6fa231c1-68ee-40c1-aae0-8e9230541c25",
@@ -3429,7 +3451,8 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "directory"
+                  "type": "directory",
+                  "puid": ""
                 },
                 {
                   "id": "ace7177e-c8b7-4c11-aa88-5fb16c28f6b5",
@@ -3478,7 +3501,8 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "directory"
+                  "type": "directory",
+                  "puid": ""
                 },
                 {
                   "id": "f87d69f8-df46-4753-bbfa-751c8d8c9a9a",
@@ -3536,7 +3560,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "1a075e38-9446-43c3-bc64-c9bbf01bb838",
@@ -3567,7 +3592,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "99ec6d3c-a1a3-4f08-b300-18c024aaf310",
@@ -3576,7 +3602,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "7d26fa73-8417-42fb-856c-07a7e0841ccc",
@@ -3706,7 +3733,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "d930552a-e387-4a64-baee-3bf94c633fa1",
@@ -3715,7 +3743,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "bb66cc1d-71f1-4c46-ab4e-d196f74d8d6d",
@@ -3724,7 +3753,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "bd2cf859-def3-41d7-bde5-0bb283158284",
@@ -3733,7 +3763,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "7b18e227-cc5e-49ac-9bd6-f48dfc47c772",
@@ -3742,7 +3773,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "589286bf-eb5a-4175-bd90-eb04ab021b75",
@@ -3751,7 +3783,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "482db1d6-50b8-468d-aa3f-05b206de7daa",
@@ -3760,7 +3793,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "ba9754f5-bd67-4a93-9fd0-76885de30112",
@@ -3769,7 +3803,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "18353b0c-0d2b-46be-89bb-a05c7935dde1",
@@ -3789,7 +3824,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "832bd4a8-c51f-4ca2-b855-04c4651ca66a",
@@ -3798,7 +3834,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "679bb192-689d-44b8-a7da-46249d82d768",
@@ -3851,7 +3888,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "f140c613-848e-40bf-925f-6dcd98c31f48",
@@ -3860,7 +3898,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "c46b50a5-40d4-48e6-b6bc-97064be68ce2",
@@ -3869,7 +3908,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "81239a76-a2d8-4ac8-983e-03ef188ba450",
@@ -3878,7 +3918,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "158da30d-a323-41a1-9b49-d780010091a9",
@@ -3887,7 +3928,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "e8d76c2e-2983-4662-ac82-558326469836",
@@ -3896,7 +3938,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "7b80d953-ba5d-4605-a85b-6c84723db310",
@@ -3905,7 +3948,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "18266a11-ff93-4860-82d9-72a5adcb053b",
@@ -3914,7 +3958,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "7402f5b6-c652-4bc0-9e18-00583f51d1a9",
@@ -3923,7 +3968,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "e738d031-4460-43e7-8499-72e755e4e943",
@@ -3932,7 +3978,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "a45dda7f-82e8-42ff-88f8-bdd1532df627",
@@ -3941,7 +3988,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "4dbb101b-0aa9-4c3f-9af8-9c95c4083b67",
@@ -3950,7 +3998,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "eff707a4-e120-4552-ac6b-f5d005965874",
@@ -3959,7 +4008,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "d1f3d7b0-b561-4788-8b0e-c6feb5b0cc36",
@@ -3968,7 +4018,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "fb677ab7-7c9f-49b7-bb30-6c8ffd7f2b8e",
@@ -3977,7 +4028,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "06ffdc7c-8b8e-43f3-a664-6b42ef368ce3",
@@ -3986,7 +4038,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "4866a15f-b943-4c61-b9ee-1cbe594a502d",
@@ -4344,13 +4397,15 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "directory"
+                  "type": "directory",
+                  "puid": ""
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
-              "type": "directory"
+              "type": "directory",
+              "puid": ""
             },
             {
               "id": "0871253d-5849-4f78-90ee-2da6526bd726",
@@ -4463,7 +4518,8 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "puid": ""
                 },
                 {
                   "id": "8358a4d9-b5d9-4f90-aeeb-1a41cad3dac4",
@@ -4524,7 +4580,8 @@
               "bulk_extractor_reports": [
 
               ],
-              "type": "directory"
+              "type": "directory",
+              "puid": ""
             },
             {
               "id": "fd45f0d9-f966-428c-af77-59b73a445b84",
@@ -5314,13 +5371,15 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "directory"
+                  "type": "directory",
+                  "puid": ""
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
-              "type": "directory"
+              "type": "directory",
+              "puid": ""
             },
             {
               "id": "19b4ccb5-841e-40ce-ad93-474d6a812f55",
@@ -5626,13 +5685,15 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "directory"
+                      "type": "directory",
+                      "puid": ""
                     }
                   ],
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "directory"
+                  "type": "directory",
+                  "puid": ""
                 },
                 {
                   "id": "1eff381b-6a99-4cc7-b16d-c9c3802a8201",
@@ -5753,7 +5814,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "directory"
+                      "type": "directory",
+                      "puid": ""
                     },
                     {
                       "id": "27ee652e-1464-46d0-95fa-5f2751b34b04",
@@ -6007,19 +6069,22 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "directory"
+                      "type": "directory",
+                      "puid": ""
                     }
                   ],
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "directory"
+                  "type": "directory",
+                  "puid": ""
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
-              "type": "directory"
+              "type": "directory",
+              "puid": ""
             },
             {
               "id": "639257b7-1aef-4fbb-880c-a1de7b16ca2d",
@@ -6368,7 +6433,8 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "puid": ""
                 },
                 {
                   "id": "5157e070-d5bd-45b5-9f8a-4ad8165fe20e",
@@ -6786,7 +6852,8 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "puid": ""
                 },
                 {
                   "id": "cb761ad4-7301-421e-b5d0-8ed33896b328",
@@ -7298,7 +7365,8 @@
               "bulk_extractor_reports": [
 
               ],
-              "type": "directory"
+              "type": "directory",
+              "puid": ""
             },
             {
               "id": "87995f00-4ad5-433f-8e39-35bbb3e4993e",
@@ -7512,7 +7580,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "puid": ""
                     },
                     {
                       "id": "fb9c7a39-c251-41fa-9438-a27cdfa234c9",
@@ -7760,7 +7829,8 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "directory"
+                  "type": "directory",
+                  "puid": ""
                 },
                 {
                   "id": "2f77b316-5c7e-4c1d-939b-8f4c61cd459b",
@@ -7787,7 +7857,8 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "directory"
+                  "type": "directory",
+                  "puid": ""
                 },
                 {
                   "id": "debd66ba-e2ad-46c5-af90-d2d0318e6cf8",
@@ -7914,7 +7985,8 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "directory"
+                      "type": "directory",
+                      "puid": ""
                     },
                     {
                       "id": "679e63d7-6668-4cd4-a625-34b3c16e8c07",
@@ -8000,7 +8072,8 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "puid": ""
                             },
                             {
                               "id": "e97a1519-6e6d-404d-941a-50b31baf38ac",
@@ -8061,7 +8134,8 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "directory"
+                          "type": "directory",
+                          "puid": ""
                         },
                         {
                           "id": "83b975ab-9988-42ba-87a3-90b6dbe60aa3",
@@ -8088,7 +8162,8 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "directory"
+                          "type": "directory",
+                          "puid": ""
                         },
                         {
                           "id": "92c8fd20-c362-4154-a590-e917c76f54de",
@@ -8218,25 +8293,29 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "directory"
+                          "type": "directory",
+                          "puid": ""
                         }
                       ],
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "directory"
+                      "type": "directory",
+                      "puid": ""
                     }
                   ],
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "directory"
+                  "type": "directory",
+                  "puid": ""
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
-              "type": "directory"
+              "type": "directory",
+              "puid": ""
             },
             {
               "id": "d0ea44a3-042a-4f15-b26d-3e8ee087514b",
@@ -8541,7 +8620,8 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "directory"
+                  "type": "directory",
+                  "puid": ""
                 },
                 {
                   "id": "aca4b6a9-4f6a-4923-9516-1501eecc3919",
@@ -8754,19 +8834,22 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "directory"
+                      "type": "directory",
+                      "puid": ""
                     }
                   ],
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "directory"
+                  "type": "directory",
+                  "puid": ""
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
-              "type": "directory"
+              "type": "directory",
+              "puid": ""
             },
             {
               "id": "c818f091-9f65-42ae-8f2f-a4bce9176e30",
@@ -9119,7 +9202,8 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "directory"
+                  "type": "directory",
+                  "puid": ""
                 },
                 {
                   "id": "fa51a383-0e0a-4824-83a7-b71ffa2601c8",
@@ -9328,13 +9412,15 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "directory"
+                  "type": "directory",
+                  "puid": ""
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
-              "type": "directory"
+              "type": "directory",
+              "puid": ""
             },
             {
               "id": "7138fb42-8465-4864-a349-a142678fe739",
@@ -9781,19 +9867,22 @@
               "bulk_extractor_reports": [
 
               ],
-              "type": "directory"
+              "type": "directory",
+              "puid": ""
             }
           ],
           "bulk_extractor_reports": [
 
           ],
-          "type": "directory"
+          "type": "directory",
+          "puid": ""
         }
       ],
       "bulk_extractor_reports": [
 
       ],
-      "type": "directory"
+      "type": "directory",
+      "puid": ""
     },
     {
       "id": "49a16b4d-beb1-4bbf-ada0-e362d4f32651",
@@ -9900,7 +9989,8 @@
               "bulk_extractor_reports": [
 
               ],
-              "type": "file"
+              "type": "file",
+              "puid": ""
             },
             {
               "id": "2927af84-d519-41f6-8bda-5c1caec67d0c",
@@ -9909,7 +9999,8 @@
               "bulk_extractor_reports": [
 
               ],
-              "type": "file"
+              "type": "file",
+              "puid": ""
             },
             {
               "id": "e198fa44-5958-4039-9273-7239e5c7e571",
@@ -10020,7 +10111,8 @@
               "bulk_extractor_reports": [
 
               ],
-              "type": "directory"
+              "type": "directory",
+              "puid": ""
             },
             {
               "id": "a2f5cfb5-87eb-47be-9c97-5ae5837f5410",
@@ -10061,7 +10153,8 @@
               "bulk_extractor_reports": [
 
               ],
-              "type": "directory"
+              "type": "directory",
+              "puid": ""
             },
             {
               "id": "184f3861-fd90-4fdb-96da-6d595da56cd7",
@@ -10091,19 +10184,22 @@
               "bulk_extractor_reports": [
 
               ],
-              "type": "directory"
+              "type": "directory",
+              "puid": ""
             }
           ],
           "bulk_extractor_reports": [
 
           ],
-          "type": "directory"
+          "type": "directory",
+          "puid": ""
         }
       ],
       "bulk_extractor_reports": [
 
       ],
-      "type": "directory"
+      "type": "directory",
+      "puid": ""
     }
   ]
 }

--- a/app/fixtures/transfers.json
+++ b/app/fixtures/transfers.json
@@ -199,7 +199,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "fba05cf5-5eb2-4051-b7ce-4db43c97f9fc",
@@ -210,7 +213,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "fd54a7dd-6d40-4257-9be5-13df0b3e9a09",
@@ -221,7 +227,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "b1ed33b9-ba6b-41e0-9063-00099f809d57",
@@ -232,7 +241,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "7c7af5e8-0b61-4490-a30d-cb414d1b7303",
@@ -243,7 +255,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "e2f8e0fe-8620-4814-abc0-e50dfd7872de",
@@ -254,7 +269,10 @@
                   "bulk_extractor_reports": [
                     "ccn"
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "980c54d1-b4f2-41c9-b0f2-5556512f26ed",
@@ -265,7 +283,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "cb5ab84e-52d0-473c-896b-c380cc41fb05",
@@ -276,7 +297,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "3b80e783-3ad3-4fca-9c66-d5cae4b649bd",
@@ -287,7 +311,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "404a4e1f-abb5-4d14-86cd-6f2f9ea72189",
@@ -298,7 +325,10 @@
                   "bulk_extractor_reports": [
                     "ccn"
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "0d09569d-e6e3-4207-94dd-3c9cbd5a153f",
@@ -309,7 +339,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "939a1545-91ee-484b-9d87-af3b61b13758",
@@ -320,7 +353,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "594719c0-b8d6-4dc6-9fa9-3e03154d5e90",
@@ -331,7 +367,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "e72a068d-c634-4194-8910-ba474d001427",
@@ -342,7 +381,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "dc08bcee-c4b9-490e-a98e-a884c4a9973c",
@@ -354,14 +396,20 @@
 
                   ],
                   "type": "file",
-                  "puid": ""
+                  "puid": "",
+                  "tags": [
+
+                  ]
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
               "type": "directory",
-              "puid": ""
+              "puid": "",
+              "tags": [
+
+              ]
             },
             {
               "id": "c7d10d01-a6e6-4942-9d5e-6b7022308536",
@@ -382,14 +430,20 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
               "type": "directory",
-              "puid": ""
+              "puid": "",
+              "tags": [
+
+              ]
             },
             {
               "id": "24732795-8715-452a-9309-5cae7da81dfb",
@@ -422,7 +476,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "497d3903-a7d2-4645-8033-14842ff7725f",
@@ -433,7 +490,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "be9f817f-c17d-4475-b735-2bd898bce100",
@@ -444,7 +504,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "7ff32b8d-bd5e-4aaf-83bb-42d86a0feafd",
@@ -455,7 +518,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "132c18e8-a1fa-4f01-b1ca-469e037d06f5",
@@ -466,7 +532,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "f7985dea-9e3f-428e-933a-0f410bc70c06",
@@ -477,7 +546,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "e3407b7a-9fdc-4e2f-b976-2a0140a7df62",
@@ -488,7 +560,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "761d4f12-6cee-4c99-b8c8-49ba5728357e",
@@ -499,7 +574,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "3eb7a763-a55c-4149-af48-84d8ad0755d0",
@@ -510,7 +588,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "05e38971-f835-4828-b643-f74396a073b7",
@@ -521,7 +602,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "20961c83-a976-4bed-909d-41fe82938325",
@@ -532,7 +616,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "50928d0f-7855-4775-82d7-f5b9db3654cc",
@@ -543,7 +630,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "ebb8345f-80e8-45d3-8470-338c66931f5c",
@@ -554,7 +644,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "5c14dc3f-93ed-4bd7-b234-ec4e8299cd1c",
@@ -565,7 +658,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "7cbd68c0-a33c-4987-aedd-2af406fd69c3",
@@ -576,7 +672,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "e56b9643-24db-4adf-85ca-cdde977abfb0",
@@ -587,7 +686,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "2e31051c-965c-4b91-b882-0cc23d939d17",
@@ -598,7 +700,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "d476f3a5-1071-44c3-87ba-eb2bed302492",
@@ -609,7 +714,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "22397de5-7ff3-4c65-8e00-d02123df2cdc",
@@ -620,7 +728,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "de8c868d-9f68-43f6-a104-31b225095714",
@@ -631,7 +742,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "a9dea238-a58c-4e47-bb4d-20cd4e968daf",
@@ -642,7 +756,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "d7822633-b99e-40c2-a789-f9ff4bed50b4",
@@ -653,7 +770,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "76b49be6-2ef0-40a6-afcd-55e037324ffd",
@@ -664,7 +784,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "e3abf244-378b-42f5-9bb0-52de529aadb6",
@@ -675,7 +798,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "5596a7cc-1152-4c4e-9242-6af68f959970",
@@ -686,7 +812,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "8483d5f9-d52f-453f-a728-fd4532f1124f",
@@ -697,7 +826,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "a5c6d5ff-1a07-497a-b1e2-cb3818a191aa",
@@ -708,7 +840,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "65fecb74-0db3-425b-81be-756a28b65333",
@@ -719,7 +854,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "c04d9251-771a-49ee-8f81-4da082779d34",
@@ -730,7 +868,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "dc76634e-8f65-4f32-9002-7877b2e7bc82",
@@ -741,7 +882,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "5b6e53ac-cf5c-4317-869e-f2e5d53b15df",
@@ -752,7 +896,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "84e9b639-4e73-4251-a199-eba0e0175b70",
@@ -763,7 +910,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "785efffc-ab11-43b3-84ae-f529e6a5bc0e",
@@ -774,7 +924,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "f79b20ae-8afe-4a97-b5cd-7f3fc44e917a",
@@ -785,7 +938,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "cc87baf1-ca3c-4ec5-890f-f8d78b300b9f",
@@ -796,7 +952,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "157988d8-da8b-42e3-b27b-da3cd84c5036",
@@ -807,7 +966,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "0142ab23-7ad4-4e4d-a40a-f727f2e8b9c1",
@@ -818,7 +980,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "f3501517-d363-435f-a5de-b2d6374ce4f3",
@@ -829,7 +994,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "88192250-59c0-4f9d-b21f-05102e8b36b1",
@@ -840,7 +1008,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "0793f544-83b5-49cc-8862-3d0b8fcde3d8",
@@ -851,7 +1022,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "1f63a706-cf3e-4a8d-8569-5092e6edc2c4",
@@ -862,7 +1036,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "f5bed50d-ec8b-4bc5-8f78-08bd81db830f",
@@ -873,7 +1050,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "0d650bbc-c323-429c-9720-74262580d356",
@@ -884,7 +1064,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "9d970656-204e-4536-85c5-e6fbbc859082",
@@ -895,7 +1078,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "461668df-7cab-44ca-a530-dbc82216b478",
@@ -906,7 +1092,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "f756d45f-c4fe-4181-b7d4-932edb79c0b0",
@@ -917,7 +1106,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "a0cf623f-11b8-43c0-bc55-8039fed63465",
@@ -928,7 +1120,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "24e38fd3-4e53-48c1-84cc-a4c36cc1fa53",
@@ -939,7 +1134,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "d40562b8-160e-45b2-a722-4c0a66b6757d",
@@ -950,7 +1148,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "88a5bb2e-f97e-4ab5-aed5-cebbdd8a956e",
@@ -961,7 +1162,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "9b77a50f-21bd-4b1e-9bc8-bc7401efb524",
@@ -972,7 +1176,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "faaae401-3b69-4529-bf01-ead46223e9da",
@@ -983,7 +1190,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "7197e739-68ef-4475-b4ff-b0b380da4f83",
@@ -994,7 +1204,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "cb5503b7-b8e7-422f-bd71-b8a18cc87908",
@@ -1005,7 +1218,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "f43e7a56-c3a0-4d75-9ccb-68884d226b5c",
@@ -1016,7 +1232,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "68083f0f-b8a6-4f42-9511-bc56d6bb82fb",
@@ -1027,7 +1246,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "f97697b1-4f9f-4ff9-a458-56467c85f884",
@@ -1038,7 +1260,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "30c43413-e0aa-418c-b0c4-42a7c86afda2",
@@ -1049,7 +1274,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "dd34d12d-b14b-417c-977d-7b136f1e755e",
@@ -1060,7 +1288,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "8397474d-5c4b-440f-9121-2c5650003aec",
@@ -1071,7 +1302,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "48c5e31d-8c51-4708-a6ef-cd6e4c78d609",
@@ -1082,7 +1316,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "501f0542-c4e1-48c2-b2ed-1fe8a1da198a",
@@ -1093,7 +1330,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "3672bbea-ac24-464a-849f-3fcc2ba167dd",
@@ -1104,7 +1344,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "99de286e-324c-4e88-964f-75c6c8c84d60",
@@ -1115,7 +1358,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "2eb3b488-b691-4f99-bf96-97d4acaa054f",
@@ -1126,7 +1372,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "efc67149-fbad-440a-b2fe-4319feec5d55",
@@ -1137,7 +1386,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "c6d3e75b-a371-4d2f-a79f-1e79c592a140",
@@ -1148,7 +1400,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "70f65deb-9e7a-4f92-a99c-0fdf294f7fdd",
@@ -1159,7 +1414,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "f54243ae-a4f5-4ac6-8202-30d30a91261c",
@@ -1170,7 +1428,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "ab51e1b5-fccd-4b6e-b3f1-b88f9251b07a",
@@ -1181,7 +1442,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "6d906217-6458-439d-b739-9d6f6ed5de1a",
@@ -1192,7 +1456,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "25826c3f-6644-4560-ad1d-90d63d16b977",
@@ -1203,7 +1470,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "d3c0df7e-7e21-4a2f-8347-7b7d34144551",
@@ -1214,7 +1484,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "b3e2ab77-273e-412b-8c02-6807f12f8ae9",
@@ -1225,7 +1498,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "060bda3a-654c-4f72-ac8e-16aaddf4a7e1",
@@ -1236,7 +1512,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "c23823a9-42c4-4546-aeb6-1507a38b9236",
@@ -1247,7 +1526,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "be421136-a8dd-457d-9537-3e8154647824",
@@ -1258,7 +1540,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "77ef26ef-a5e5-49b2-a7fb-0742c5f848b2",
@@ -1269,7 +1554,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "5b80a6a3-e73a-4366-b130-287aa002f237",
@@ -1280,7 +1568,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "7c090df9-afbc-4ebd-9832-ef8da3d44c04",
@@ -1291,7 +1582,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "6d72b786-4718-4d80-a50a-9286ec23c628",
@@ -1302,7 +1596,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "0e0f4919-f21e-49db-8f91-44bad02fb9e7",
@@ -1313,7 +1610,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "940238cc-aa0c-441a-8a41-35364728e429",
@@ -1324,7 +1624,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "a5a04280-8846-4c91-9a3f-135cacd737b5",
@@ -1335,7 +1638,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "086be05e-e97c-402e-b5f8-901142fade2f",
@@ -1346,7 +1652,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "1fb3558a-ae76-4149-af0d-eec945782861",
@@ -1357,7 +1666,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "14b07096-9ea6-48a7-a2e5-271aed872474",
@@ -1368,21 +1680,30 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     }
                   ],
                   "bulk_extractor_reports": [
 
                   ],
                   "type": "directory",
-                  "puid": ""
+                  "puid": "",
+                  "tags": [
+
+                  ]
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
               "type": "directory",
-              "puid": ""
+              "puid": "",
+              "tags": [
+
+              ]
             },
             {
               "id": "8168bac8-ae50-4914-a515-b778518ab675",
@@ -1405,7 +1726,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "6e6000f2-bb3c-4e1f-900f-b5366a6c6770",
@@ -1416,7 +1740,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "7c1e12e1-740a-4cdb-9b6a-c66a4d0d425f",
@@ -1427,7 +1754,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "6f4b530e-6a43-4631-8784-ef5bedfbfa76",
@@ -1438,14 +1768,20 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
               "type": "directory",
-              "puid": ""
+              "puid": "",
+              "tags": [
+
+              ]
             },
             {
               "id": "6136fc85-4d42-45bc-affd-5f521c1db4ee",
@@ -1470,7 +1806,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "17454352-a46e-4515-84ca-067da09d3615",
@@ -1481,7 +1820,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "7b8c218c-e209-491b-91b2-1b24887a823f",
@@ -1492,7 +1834,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "81f6924c-40df-4ce5-9511-d8c73da3f8e4",
@@ -1503,7 +1848,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "3039bd86-cb4a-4897-b273-93b4a3980434",
@@ -1514,7 +1862,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "2508bef1-0161-4505-b0bc-0769b99a44e2",
@@ -1525,7 +1876,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "3e88bdf3-eb30-4789-9682-30d208971048",
@@ -1536,7 +1890,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "032b31d6-5850-4fd7-8cbd-7367b0553a1a",
@@ -1547,7 +1904,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "6dd14b4a-e174-439f-a13a-629a0ec14956",
@@ -1558,7 +1918,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "b64fef12-3e74-4f15-ae77-d77c308fface",
@@ -1569,7 +1932,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "2d421c3a-c412-4f5c-93c6-a24c88b707f2",
@@ -1580,7 +1946,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "938b88fd-83d3-4be6-aa32-71a19b74a0b1",
@@ -1591,7 +1960,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "f057bc7a-5805-4a67-8ca2-3821c0707449",
@@ -1602,7 +1974,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "88468acc-c3ef-480f-8172-c396f5d70649",
@@ -1613,7 +1988,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "58092af3-d330-42ff-87c9-9792f2cd0b09",
@@ -1624,7 +2002,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "540b03c1-d170-4846-9139-7b51b540107d",
@@ -1635,7 +2016,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "1a9fca5e-dc8a-43eb-84b4-c4fa24a59797",
@@ -1646,7 +2030,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "5edd8fe9-0dd3-4ce0-a3ca-b0cd7b459481",
@@ -1657,7 +2044,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "e6121271-2e44-4d6b-8c8b-c7157b942e19",
@@ -1668,7 +2058,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "9a847fe6-33cc-4f8c-81fd-9c42619744ac",
@@ -1679,7 +2072,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "dafc2bc7-2081-4882-8763-2cce2ae59f4b",
@@ -1690,7 +2086,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "b839983f-3b05-4ae3-8831-d4b0f012b76b",
@@ -1701,7 +2100,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "557195d2-7554-4581-9957-e00278d3af2e",
@@ -1712,7 +2114,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "25fbad5c-1043-4539-a9b7-1600c1bfbc7c",
@@ -1723,7 +2128,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "6f196df8-8612-40be-9882-e15a8ac6aec5",
@@ -1734,14 +2142,20 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
               "type": "directory",
-              "puid": ""
+              "puid": "",
+              "tags": [
+
+              ]
             },
             {
               "id": "a9d7da66-e504-4b9a-ad02-63efeaaaaef6",
@@ -1782,7 +2196,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "16d6595e-4675-4e5a-9d10-06c317e602cd",
@@ -1793,7 +2210,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "48712dd2-bb58-4716-80ad-e8e839afe59b",
@@ -1804,7 +2224,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "1dd6fb3c-5bb5-4610-b8e6-9cabb580c24f",
@@ -1815,7 +2238,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "cdf81782-ec5a-4ded-bd2a-074a011fd53f",
@@ -1826,14 +2252,20 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     }
                   ],
                   "bulk_extractor_reports": [
 
                   ],
                   "type": "directory",
-                  "puid": ""
+                  "puid": "",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "117e99f6-c8f3-4380-87ce-65709d9da571",
@@ -1877,7 +2309,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "6da5567a-a26f-4aa3-8712-e8cb91c99ee0",
@@ -1888,7 +2323,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "228cd181-73ab-4abd-a951-cb526816581c",
@@ -1899,7 +2337,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "561fe044-c4d3-49f1-ac2b-9a48c9750715",
@@ -1910,7 +2351,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "bce0b0e4-3226-43f2-ac93-9bb1bbb50368",
@@ -1921,7 +2365,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "86489154-8ac4-4c70-893e-7217d90581fe",
@@ -1932,7 +2379,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "adee224e-683d-40a9-8d40-dca105407d92",
@@ -1943,7 +2393,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "996feff5-173c-4b68-84d3-93ea53f214c3",
@@ -1954,7 +2407,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "75ea4441-a3ba-4c66-aec9-30c1a2f81a34",
@@ -1965,7 +2421,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "7fcc13da-e5d2-47d1-9917-e1914c8f83cc",
@@ -1976,7 +2435,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "14a87165-ba8b-4642-af58-a78941518598",
@@ -1987,7 +2449,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "69443f0e-6891-4b77-afbe-69714d4b9c05",
@@ -1998,7 +2463,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "dbb284aa-48d1-40de-9d5c-f73bf2a61619",
@@ -2009,7 +2477,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "f60a55aa-dd28-42f9-a9e6-f4ef552d7090",
@@ -2020,7 +2491,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "f7e605d7-5302-424e-9c69-864c6bd7dc9a",
@@ -2031,7 +2505,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "d2d8260f-1a38-40e2-9ca5-d4d376f28f9b",
@@ -2042,14 +2519,20 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         }
                       ],
                       "bulk_extractor_reports": [
 
                       ],
                       "type": "directory",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "22ca959a-b4da-42ae-aed4-4de86ba3c7b1",
@@ -2073,7 +2556,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "d9c5a5ee-6d48-4449-ba27-d012ba7b8351",
@@ -2084,7 +2570,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "adaf98fb-8b4e-4f1c-8cf3-18026cd192ed",
@@ -2095,7 +2584,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "c796e845-7cf5-493d-a369-00e580bc7f3b",
@@ -2106,7 +2598,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "cde87da1-3981-45ce-9e64-a6272bc150a1",
@@ -2117,7 +2612,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "9e20a2fe-18cc-4d1e-a2f4-430feae7ab46",
@@ -2128,7 +2626,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "04579e84-0073-450a-b551-5f97e5302733",
@@ -2139,7 +2640,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "e60ef089-94e8-4261-9a50-33d5a9ca35dc",
@@ -2150,7 +2654,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "f546db3f-e04e-40db-9b3e-fd226ebf6e2d",
@@ -2161,7 +2668,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "f1345d7c-3f39-470f-b945-da091d8b5f84",
@@ -2172,7 +2682,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "d33bb877-b513-46ce-91a8-02f4c52441ed",
@@ -2183,7 +2696,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "00a94dd2-4a7e-43dc-ab38-ca2601b4eafe",
@@ -2194,7 +2710,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "cf1d1a63-b7e9-4498-8e92-7804bc144c44",
@@ -2205,7 +2724,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "995878a4-48e2-4685-bfe1-254aaeb04132",
@@ -2216,7 +2738,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "741b89ad-afcf-4e78-bbf4-d3445d973b94",
@@ -2227,7 +2752,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "0d6d11f5-cb26-45ad-85ef-a42f81c9de60",
@@ -2238,7 +2766,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "ed5e4a1e-f8f6-4511-98e3-87e19d99f6a2",
@@ -2249,7 +2780,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "af96037d-13ec-4e8c-8087-64a06e186c96",
@@ -2260,7 +2794,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "cdf0d9a1-8e9c-4a2f-bed0-cdf8897053cb",
@@ -2271,7 +2808,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "6f8389e8-5af4-40f1-9dbc-e7db0ffdf548",
@@ -2293,7 +2833,10 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             },
                             {
                               "id": "9892f551-2d10-416c-a2a8-2a03035ae93a",
@@ -2304,7 +2847,10 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             },
                             {
                               "id": "6e5234ab-1901-46b8-883e-75cef99cc59a",
@@ -2315,7 +2861,10 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             },
                             {
                               "id": "5ff22c6b-8d8d-4135-912d-49cf93f2c0f0",
@@ -2326,7 +2875,10 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             },
                             {
                               "id": "b80d9661-332a-4c3e-be8d-35fafc56fff3",
@@ -2337,7 +2889,10 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             },
                             {
                               "id": "6196dc90-41fd-4494-ad51-b8c9fa96851f",
@@ -2348,7 +2903,10 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             },
                             {
                               "id": "cb810a02-00de-40dc-bdfc-67ef868752ee",
@@ -2359,7 +2917,10 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             },
                             {
                               "id": "a8edcb1d-611d-4d94-99f1-958b347123a2",
@@ -2370,21 +2931,30 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             }
                           ],
                           "bulk_extractor_reports": [
 
                           ],
                           "type": "directory",
-                          "puid": ""
+                          "puid": "",
+                          "tags": [
+
+                          ]
                         }
                       ],
                       "bulk_extractor_reports": [
 
                       ],
                       "type": "directory",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "06a98817-da21-46be-8062-b24d213a84df",
@@ -2406,7 +2976,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "8d4d91aa-316f-472f-b966-e701def05a08",
@@ -2417,7 +2990,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "12630596-c19e-45d8-84ac-f9b1ea4f2c3d",
@@ -2428,7 +3004,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "43144f4f-3301-465f-91b8-5c90b152a5ba",
@@ -2439,7 +3018,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "b389f053-a87d-418b-bac2-8b864775ef97",
@@ -2450,7 +3032,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "c1a8777c-3e8a-4e60-b9c4-6b39a1e3d864",
@@ -2461,7 +3046,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "abb2c7fd-7192-4005-942a-e9970e44bb0e",
@@ -2472,7 +3060,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "963b83eb-5e78-4d49-bad7-a4275b23f5fb",
@@ -2483,7 +3074,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "2a3a96f2-0398-4197-b39e-d9de872c5a0c",
@@ -2494,7 +3088,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "5cff93c5-9534-4019-abb2-450e54177333",
@@ -2505,7 +3102,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "b31461ec-3baf-4f20-b557-8f973aeb9d77",
@@ -2516,7 +3116,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "ee10e602-11a6-4e09-bbca-87b7a643c179",
@@ -2527,7 +3130,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "8aa7103c-f139-4a47-af80-da9254c0dd7c",
@@ -2538,7 +3144,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "27f24a9f-7937-4b6b-9e19-119f592e53f1",
@@ -2549,7 +3158,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "3a9792fe-8538-4c0e-aade-86dc5e19d3b9",
@@ -2560,7 +3172,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "e997cc16-a01e-4ce0-aff2-093f36b99055",
@@ -2571,7 +3186,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "20676ce4-29f2-42cf-81df-2e19cf5cb3ab",
@@ -2582,7 +3200,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "493fb126-0d9b-4d78-a579-8d45f74792ee",
@@ -2593,7 +3214,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "be9e0242-3434-4c06-b4bb-55d1e09304c5",
@@ -2604,7 +3228,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "ccf7d3eb-28f0-4701-b314-2c5ed4e024b3",
@@ -2615,7 +3242,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "825d1146-1f8a-4039-9371-598b1fefcabc",
@@ -2626,7 +3256,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "7fa523ad-dbef-4b56-9735-1f9d909240e2",
@@ -2649,7 +3282,10 @@
 
                               ],
                               "type": "file",
-                              "puid": ""
+                              "puid": "",
+                              "tags": [
+
+                              ]
                             },
                             {
                               "id": "395842f5-a575-45c7-abc0-dce0781139a7",
@@ -2660,28 +3296,40 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             }
                           ],
                           "bulk_extractor_reports": [
 
                           ],
                           "type": "directory",
-                          "puid": ""
+                          "puid": "",
+                          "tags": [
+
+                          ]
                         }
                       ],
                       "bulk_extractor_reports": [
 
                       ],
                       "type": "directory",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     }
                   ],
                   "bulk_extractor_reports": [
 
                   ],
                   "type": "directory",
-                  "puid": ""
+                  "puid": "",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "9d66bd11-d039-4463-95f1-0f899e418f07",
@@ -2722,7 +3370,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "b5542de6-a0bd-42f6-afb5-452b536f368e",
@@ -2733,7 +3384,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "a6186720-5430-462a-a28b-eb53e7276512",
@@ -2744,7 +3398,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "a448c397-795a-455b-9cb5-e68c8a3ac677",
@@ -2755,7 +3412,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "ae2a1475-940f-41c2-a66b-224a05e401a0",
@@ -2766,7 +3426,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "8ce1a0d8-8feb-4956-8458-36fb8cb7db72",
@@ -2777,7 +3440,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "edaf7a5a-6cc2-494d-a816-7841e1d9057d",
@@ -2788,7 +3454,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "05fc75fd-6f60-4534-903d-fd4c446c4d0b",
@@ -2799,7 +3468,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "1bdff87b-9632-444f-b909-50b0063f277e",
@@ -2810,7 +3482,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "f48dc0ac-3596-4f5a-915d-925c3d978b13",
@@ -2821,7 +3496,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "89ddb9ea-36cf-45b6-8a0a-690a5e918abf",
@@ -2832,7 +3510,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "eca4896c-f745-47a1-8262-1ac29168b15b",
@@ -2843,7 +3524,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "86144a4a-8602-4d3e-97de-5cf38a2d7b0e",
@@ -2854,7 +3538,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "4d30eaf2-055e-4f73-bc64-74233e73aa7f",
@@ -2865,7 +3552,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "d1fd867a-fda7-45d2-a8ed-f4f44b825f9e",
@@ -2876,7 +3566,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "db28ed82-029d-4c43-9b1d-fa11829a9f24",
@@ -2887,7 +3580,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "63dc34fe-9a1e-4a4f-906c-6ab6a4b34631",
@@ -2898,7 +3594,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "df9e5388-5a0a-49f7-9aee-531f7ccdc7e9",
@@ -2909,7 +3608,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "b2ac4479-96a1-4faf-b0b7-e32bd65a1dc9",
@@ -2920,7 +3622,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "7735175b-a3ae-4c16-a9af-7a55367f0f84",
@@ -2931,7 +3636,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "d4a3ae3a-8a27-4bef-b324-956fe5df8282",
@@ -2942,7 +3650,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "0b106727-712c-46b8-8dce-55cab5518280",
@@ -2953,14 +3664,20 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         }
                       ],
                       "bulk_extractor_reports": [
 
                       ],
                       "type": "directory",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "f9b9190e-42be-4b98-bbe5-c78711a861b8",
@@ -2983,7 +3700,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "a51a71cf-6887-4691-b7d0-945598df2fd5",
@@ -2994,7 +3714,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "1af5ea2f-e411-4f3e-b3e9-d7603ad21e3c",
@@ -3005,7 +3728,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "45e19805-ebd5-4ce8-b7c5-60bf2f1f545f",
@@ -3016,7 +3742,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "39f93859-661a-4ae8-8a00-7be3e81ff16d",
@@ -3027,7 +3756,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "1e2d3c50-e569-46bd-94b4-6be3040136ec",
@@ -3038,7 +3770,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "06d8687e-4e78-4324-adbc-06f6d996ada6",
@@ -3049,7 +3784,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "d207dcf6-3612-4898-9ba0-523b49ffd49f",
@@ -3060,7 +3798,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "189584fd-3b38-49fb-b9dd-d32abfa3c207",
@@ -3071,14 +3812,20 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         }
                       ],
                       "bulk_extractor_reports": [
 
                       ],
                       "type": "directory",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "5554ab06-6e32-410c-b543-cb9202f97f98",
@@ -3099,7 +3846,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "43cf44c1-ccce-4e4f-87fe-88fc3c85debd",
@@ -3110,7 +3860,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "dd25b8c3-bc2f-4aea-ad99-d8dc4057f087",
@@ -3121,7 +3874,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "b6d83d7b-b24b-475e-af9f-9e2311f6df08",
@@ -3132,7 +3888,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "59768f7f-f592-4211-84d6-48298ac409d5",
@@ -3143,14 +3902,20 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         }
                       ],
                       "bulk_extractor_reports": [
 
                       ],
                       "type": "directory",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "4332f40c-5b43-4192-ae9d-ec4396019b88",
@@ -3171,7 +3936,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "ee571b4f-2563-43fd-9268-247e1ce735ab",
@@ -3182,7 +3950,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "ae7960a5-bf2b-4246-a665-de5e864e9b13",
@@ -3193,21 +3964,30 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         }
                       ],
                       "bulk_extractor_reports": [
 
                       ],
                       "type": "directory",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     }
                   ],
                   "bulk_extractor_reports": [
 
                   ],
                   "type": "directory",
-                  "puid": ""
+                  "puid": "",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "941a7160-8063-43bc-bf64-d50d8de6f703",
@@ -3230,7 +4010,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "77e60beb-4896-4f3b-9cf2-36f307136d27",
@@ -3241,7 +4024,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "f0ae0d82-42c0-457a-b8d5-2328521bfe4e",
@@ -3252,7 +4038,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "fbc9698f-0f15-40d8-8206-c92ffb9ac87d",
@@ -3263,7 +4052,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "30b58a1d-8c9e-4fd0-9695-099c5b6717ec",
@@ -3274,21 +4066,30 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     }
                   ],
                   "bulk_extractor_reports": [
 
                   ],
                   "type": "directory",
-                  "puid": ""
+                  "puid": "",
+                  "tags": [
+
+                  ]
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
               "type": "directory",
-              "puid": ""
+              "puid": "",
+              "tags": [
+
+              ]
             },
             {
               "id": "6fa231c1-68ee-40c1-aae0-8e9230541c25",
@@ -3324,7 +4125,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "b8a1356e-4563-4a66-b952-099e03de6f18",
@@ -3335,7 +4139,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "31335337-5557-4658-bc84-45dde970ae17",
@@ -3346,7 +4153,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "4cf9172c-d9e1-4a69-ae76-ab05fe9bd425",
@@ -3357,7 +4167,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "03ca0930-3e51-4f69-a2df-1e598132c380",
@@ -3368,7 +4181,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "5518d947-40cd-4999-b320-06c0a41c21be",
@@ -3379,7 +4195,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "68862e72-c8bc-4c44-a216-7cc527b7a3fc",
@@ -3390,7 +4209,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "84cea3d5-9142-4a66-8880-cff5ddf0deb1",
@@ -3401,7 +4223,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "e8268c00-579d-4c51-aa31-bc8e2c052917",
@@ -3412,7 +4237,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "7b38982a-d607-42f1-b5ec-0ec5401cc98d",
@@ -3423,7 +4251,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "cda74914-1572-429c-af65-7aa061e64b75",
@@ -3434,7 +4265,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "962a887a-9bea-4dd0-b66b-e20a6b1c02bf",
@@ -3445,14 +4279,20 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     }
                   ],
                   "bulk_extractor_reports": [
 
                   ],
                   "type": "directory",
-                  "puid": ""
+                  "puid": "",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "ace7177e-c8b7-4c11-aa88-5fb16c28f6b5",
@@ -3473,7 +4313,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "456f0ea8-b7f7-4b1d-ab87-f86a3b9ff248",
@@ -3484,7 +4327,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "eef8eae4-6f9a-444f-a3d7-13a1d136a191",
@@ -3495,14 +4341,20 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     }
                   ],
                   "bulk_extractor_reports": [
 
                   ],
                   "type": "directory",
-                  "puid": ""
+                  "puid": "",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "f87d69f8-df46-4753-bbfa-751c8d8c9a9a",
@@ -3527,7 +4379,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "7128291d-2bda-467a-baba-5fe7498c9730",
@@ -3538,7 +4393,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "426826a7-5ba2-4fc9-b184-88325d148138",
@@ -3549,7 +4407,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "eb2fd7d9-8615-4461-a9d0-717a09f1248a",
@@ -3561,7 +4422,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "1a075e38-9446-43c3-bc64-c9bbf01bb838",
@@ -3572,7 +4436,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "e9f590c8-8f11-43cc-8cc8-f71d799061c9",
@@ -3583,7 +4450,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "4a0a06e8-5576-4d25-aa84-d97b22ad204d",
@@ -3593,7 +4463,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "99ec6d3c-a1a3-4f08-b300-18c024aaf310",
@@ -3603,7 +4476,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "7d26fa73-8417-42fb-856c-07a7e0841ccc",
@@ -3614,7 +4490,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "dd1f2850-f5b5-4ec5-ae45-9772a62883a9",
@@ -3625,7 +4504,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "bc521ce2-291c-4271-a77b-177997e706ac",
@@ -3636,7 +4518,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "a6467b12-dc28-4435-808a-cac2ae1085c8",
@@ -3647,7 +4532,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "3926c73e-8c1b-496c-9037-593c7d069630",
@@ -3658,7 +4546,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "5f7348ac-8244-49c0-abbe-76a485d37271",
@@ -3669,7 +4560,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "37b59115-4ecd-4d72-be12-9541be2abcb2",
@@ -3680,7 +4574,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "0b5d130f-1aa1-40a8-9a78-8f2a55adcd07",
@@ -3691,7 +4588,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "524bc610-82d8-4e58-ae87-a9953bca8141",
@@ -3702,7 +4602,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "cd8cd995-90df-4989-9dd4-a3ddb02ffd40",
@@ -3713,7 +4616,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "13f743fc-465c-4566-b981-eb9efb0d02d1",
@@ -3724,7 +4630,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "f97d556c-6b14-4324-8903-79773b043695",
@@ -3734,7 +4643,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "d930552a-e387-4a64-baee-3bf94c633fa1",
@@ -3744,7 +4656,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "bb66cc1d-71f1-4c46-ab4e-d196f74d8d6d",
@@ -3754,7 +4669,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "bd2cf859-def3-41d7-bde5-0bb283158284",
@@ -3764,7 +4682,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "7b18e227-cc5e-49ac-9bd6-f48dfc47c772",
@@ -3774,7 +4695,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "589286bf-eb5a-4175-bd90-eb04ab021b75",
@@ -3784,7 +4708,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "482db1d6-50b8-468d-aa3f-05b206de7daa",
@@ -3794,7 +4721,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "ba9754f5-bd67-4a93-9fd0-76885de30112",
@@ -3804,7 +4734,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "18353b0c-0d2b-46be-89bb-a05c7935dde1",
@@ -3815,7 +4748,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "1186c3f5-a462-4634-818e-ae096f84702a",
@@ -3825,7 +4761,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "832bd4a8-c51f-4ca2-b855-04c4651ca66a",
@@ -3835,7 +4774,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "679bb192-689d-44b8-a7da-46249d82d768",
@@ -3846,7 +4788,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "036b6dc6-b6ff-4232-87c7-dcaf4d4e5d90",
@@ -3857,7 +4802,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "6610e54d-2c50-4056-8030-791d79408078",
@@ -3868,7 +4816,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "baa58485-7efc-48e4-b919-27f8e6421d81",
@@ -3879,7 +4830,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "f17bab8f-4293-4255-baf3-c32d56c48601",
@@ -3889,7 +4843,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "f140c613-848e-40bf-925f-6dcd98c31f48",
@@ -3899,7 +4856,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "c46b50a5-40d4-48e6-b6bc-97064be68ce2",
@@ -3909,7 +4869,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "81239a76-a2d8-4ac8-983e-03ef188ba450",
@@ -3919,7 +4882,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "158da30d-a323-41a1-9b49-d780010091a9",
@@ -3929,7 +4895,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "e8d76c2e-2983-4662-ac82-558326469836",
@@ -3939,7 +4908,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "7b80d953-ba5d-4605-a85b-6c84723db310",
@@ -3949,7 +4921,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "18266a11-ff93-4860-82d9-72a5adcb053b",
@@ -3959,7 +4934,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "7402f5b6-c652-4bc0-9e18-00583f51d1a9",
@@ -3969,7 +4947,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "e738d031-4460-43e7-8499-72e755e4e943",
@@ -3979,7 +4960,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "a45dda7f-82e8-42ff-88f8-bdd1532df627",
@@ -3989,7 +4973,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "4dbb101b-0aa9-4c3f-9af8-9c95c4083b67",
@@ -3999,7 +4986,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "eff707a4-e120-4552-ac6b-f5d005965874",
@@ -4009,7 +4999,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "d1f3d7b0-b561-4788-8b0e-c6feb5b0cc36",
@@ -4019,7 +5012,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "fb677ab7-7c9f-49b7-bb30-6c8ffd7f2b8e",
@@ -4029,7 +5025,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "06ffdc7c-8b8e-43f3-a664-6b42ef368ce3",
@@ -4039,7 +5038,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "4866a15f-b943-4c61-b9ee-1cbe594a502d",
@@ -4050,7 +5052,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "8ef7abe1-36e2-4230-b8de-b6dcee4d0cb4",
@@ -4061,7 +5066,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "7a0fe2fb-2a03-4e89-b094-318907f93c27",
@@ -4072,7 +5080,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "34010b68-0542-4977-9e40-636291f718a5",
@@ -4083,7 +5094,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "6b14ca18-343a-4561-bfe3-623a0d7bfdc0",
@@ -4094,7 +5108,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "b42527b5-6684-49ea-86de-c3b71d0e9037",
@@ -4105,7 +5122,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "cf7db69b-9ba4-4656-a828-d834cf0e1681",
@@ -4116,7 +5136,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "9788e6d1-9180-49a8-b03a-b0e1ab919385",
@@ -4127,7 +5150,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "0b394751-85d5-4318-ae0c-92e5db7bb912",
@@ -4138,7 +5164,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "bcb03667-11da-45fe-ab53-3c27c89f8456",
@@ -4149,7 +5178,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "6df4c73c-dae5-4d78-883d-a4e7f6b18088",
@@ -4160,7 +5192,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "ecb7779f-6666-46bd-a59c-9fa1f4cabfc5",
@@ -4171,7 +5206,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "10457f76-9f06-46b0-8902-1840c568858d",
@@ -4182,7 +5220,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "8d830bc1-3b32-4dce-a902-ed67c5d3c114",
@@ -4193,7 +5234,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "ebcecc63-db45-4d04-a971-25e4a0d60228",
@@ -4204,7 +5248,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "b85c5a88-ae47-4bee-9ea1-4cef6c996aaf",
@@ -4215,7 +5262,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "3e167416-a38e-40d9-a4c6-911f19850bf3",
@@ -4226,7 +5276,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "c88390ac-5289-45bc-881e-e4e2a6603361",
@@ -4237,7 +5290,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "e1f232bd-db21-42eb-98e1-9b756c2e20f0",
@@ -4248,7 +5304,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "f573226d-a1c7-4d73-b018-7fe5f8c62518",
@@ -4259,7 +5318,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "22ad29a5-113d-47dc-80d6-413d2def0feb",
@@ -4270,7 +5332,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "21626442-a671-40eb-9083-7d9a27ab3500",
@@ -4281,7 +5346,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "d598a31f-fbe7-4d51-8710-3a71a0af46f2",
@@ -4292,7 +5360,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "b4998d61-f59d-4598-bbf1-cb67feb71a04",
@@ -4303,7 +5374,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "d5a959a3-9f5f-421e-b109-73d59161e322",
@@ -4314,7 +5388,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "6326035e-a98f-4956-8357-dca490452968",
@@ -4325,7 +5402,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "93ffa7c0-a095-4d26-b95b-7abb173e4466",
@@ -4336,7 +5416,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "75a615c4-bce3-409b-9dc7-261f4fc54ab4",
@@ -4347,7 +5430,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "3d5ad885-5abf-47fa-aab2-3fa4e7b29657",
@@ -4358,7 +5444,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "7585c403-b4a9-4609-8f5e-0400a2dd66f9",
@@ -4369,7 +5458,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "691fa6d2-b738-4cce-bdcf-139242882ea9",
@@ -4380,7 +5472,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "c79204e4-c6ec-483d-afb7-3fb00a810620",
@@ -4391,21 +5486,30 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     }
                   ],
                   "bulk_extractor_reports": [
 
                   ],
                   "type": "directory",
-                  "puid": ""
+                  "puid": "",
+                  "tags": [
+
+                  ]
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
               "type": "directory",
-              "puid": ""
+              "puid": "",
+              "tags": [
+
+              ]
             },
             {
               "id": "0871253d-5849-4f78-90ee-2da6526bd726",
@@ -4432,7 +5536,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "1a35801d-573c-433b-908c-da4cd857da33",
@@ -4443,7 +5550,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "104183db-923b-41d0-b1b2-face6543e1f2",
@@ -4454,7 +5564,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "0e8632a7-2721-49aa-9bdd-abf0505d2350",
@@ -4465,7 +5578,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "37eebc6b-e4d0-4cf2-8756-6f2b814bd5c5",
@@ -4476,7 +5592,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "ef72fa90-e94a-4bd5-9dee-5a83d3427100",
@@ -4487,7 +5606,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "8553e67f-31e3-4f41-b1fd-3b58c6ee6fab",
@@ -4498,7 +5620,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "8b35cfb0-d7c6-4373-b395-be3dc5441996",
@@ -4509,7 +5634,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "7bba8e15-1ae9-44a0-a104-19ae94cd84ec",
@@ -4519,7 +5647,10 @@
 
                   ],
                   "type": "file",
-                  "puid": ""
+                  "puid": "",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "8358a4d9-b5d9-4f90-aeeb-1a41cad3dac4",
@@ -4530,7 +5661,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "0efdfb9f-b49e-4925-b3fa-9b44bd775d0c",
@@ -4541,7 +5675,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "cde55a81-8177-4631-ae6b-389f238df034",
@@ -4552,7 +5689,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "51b165cd-3206-4139-852a-7d2ce667802f",
@@ -4563,7 +5703,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "899932ad-4292-4e12-b524-ed9c8e617df9",
@@ -4574,14 +5717,20 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
               "type": "directory",
-              "puid": ""
+              "puid": "",
+              "tags": [
+
+              ]
             },
             {
               "id": "fd45f0d9-f966-428c-af77-59b73a445b84",
@@ -4610,7 +5759,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "e6172444-fa09-42ec-b050-c31c3e391666",
@@ -4621,7 +5773,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "90dc1ac8-973d-4b50-bdcb-57b17fcc7312",
@@ -4632,7 +5787,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "9972b98d-5640-45a7-ada7-584fd7ca0494",
@@ -4643,7 +5801,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "db642396-61f4-4b23-99c1-78437442f133",
@@ -4654,7 +5815,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "ab0cc285-d7d0-427b-8d6a-faf4bf3a46eb",
@@ -4665,7 +5829,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "6719ee5a-e00a-40e3-aed3-c4fe4644c6b2",
@@ -4676,7 +5843,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "7b830f92-93dc-4853-be6b-67d6dbd58ccb",
@@ -4687,7 +5857,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "12fa00be-faaa-43e1-b5d8-b3d974a02757",
@@ -4698,7 +5871,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "fbad70fe-59b8-4bb0-a6d9-3fcd48400fd1",
@@ -4709,7 +5885,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "70f7bc23-7614-4ee0-8e86-f1ba76ec151d",
@@ -4720,7 +5899,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "ed60d665-4666-4a67-a9a8-e842b43c3532",
@@ -4731,7 +5913,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "88248250-c0f7-4ba4-b0fc-767ced819959",
@@ -4742,7 +5927,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "5bc85298-e317-49b3-87a9-3e522bf6be02",
@@ -4753,7 +5941,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "b4447196-2adf-4f6e-a1a8-e2d61b877e92",
@@ -4764,7 +5955,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "f8486360-f4ef-43b2-b5a8-23961763dabd",
@@ -4775,7 +5969,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "96381fd3-0546-4532-a401-f747b57944a7",
@@ -4786,7 +5983,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "d439fca5-a632-4d55-8d82-3a424b40cfdd",
@@ -4797,7 +5997,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "f0cec30a-0e3a-4fba-a96a-cb4960832ea7",
@@ -4808,7 +6011,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "22b8bda5-e1d6-4cb1-81f2-162a83d1a6f4",
@@ -4819,7 +6025,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "8be6703d-0195-4fdf-ae4f-9226ebc9708a",
@@ -4830,7 +6039,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "4833fdf1-23f3-46e0-98a7-6c783872c41d",
@@ -4841,7 +6053,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "6a43227a-e7ce-4eaf-a125-20fbe122fb87",
@@ -4852,7 +6067,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "b34ec5a1-5989-4eb8-9ef5-29490310dcba",
@@ -4863,7 +6081,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "5158bf21-ad8d-41bc-ad09-ab9b06835596",
@@ -4874,7 +6095,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "87860d86-1034-42ee-b18a-1f738cc5894e",
@@ -4885,7 +6109,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "bf250b2c-5155-41bb-ba78-31d8faa76574",
@@ -4896,7 +6123,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "d83f5b19-66ae-448f-9595-b9d293d5924f",
@@ -4907,7 +6137,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "85ca38c6-a756-4855-9758-1835f795cae8",
@@ -4918,7 +6151,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "70b87896-c7ac-4643-a3e4-f8f4ffbb5fb0",
@@ -4929,7 +6165,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "e4ae1d81-6a1a-4b70-b61a-0e8d6c00cfad",
@@ -4940,7 +6179,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "1e84e6b0-0579-4169-8c01-87ff993fe9be",
@@ -4951,7 +6193,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "45b96dff-daf5-4a08-8002-0a1098d78abe",
@@ -4962,7 +6207,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "a8cfc31c-1645-4285-ba20-bd69bf9a8332",
@@ -4973,7 +6221,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "f4024182-1b48-4a49-932a-4f31ce6aca7c",
@@ -4984,7 +6235,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "89d1887b-a0a2-4369-832c-b1b9bc7695fa",
@@ -5013,7 +6267,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "d3ef8d99-8cee-4c30-b5e3-0baf54bbe252",
@@ -5024,7 +6281,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "4d90bd8b-b36a-4475-b67b-014f84ef6c4e",
@@ -5035,7 +6295,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "c5eab27d-37af-4e60-a531-201470bbebea",
@@ -5046,7 +6309,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "cf1076c1-72b9-4241-9631-38d4409b8068",
@@ -5057,7 +6323,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "904e9aff-5b51-424a-addb-6c1214f17cab",
@@ -5068,7 +6337,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "a29234cc-57fa-44bf-a4b0-ab25ad838711",
@@ -5079,7 +6351,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "35a7a1e2-05c2-4eaa-8368-23933da9a30f",
@@ -5090,7 +6365,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "2e768e67-be09-40a1-b608-8ac24470e26e",
@@ -5101,7 +6379,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "9366bc54-f742-4eba-bbcf-d8b19c0376c7",
@@ -5112,7 +6393,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "862cdedb-90a2-4c3d-9d4f-9b8e5ef86e4e",
@@ -5123,7 +6407,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "3fd2135d-fb8d-4d1c-ae2c-fde24cf3881b",
@@ -5134,7 +6421,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "481f2ff7-e4eb-4b24-9bff-b5ca9608606a",
@@ -5145,7 +6435,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "c083a940-d8d0-4ded-972c-ef9c38c6f143",
@@ -5156,7 +6449,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "c595a5d4-e274-4794-a039-c2a0946b36dd",
@@ -5167,7 +6463,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "03bdb447-5b7b-459d-82f6-c9b6647de9b9",
@@ -5178,7 +6477,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "f901219e-abc8-4913-bc3a-cdc9aba6699a",
@@ -5189,7 +6491,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "c5712cd1-ec28-4c08-bf43-4d323c7d82dd",
@@ -5200,7 +6505,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "e28b8207-7c5d-446b-867e-1b0624f39e57",
@@ -5211,7 +6519,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "f861d61e-0a7c-47c0-aed5-902eb13ff453",
@@ -5222,7 +6533,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "3a14ddb6-5653-4868-9611-be023ee7cff4",
@@ -5233,7 +6547,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "c73b7d3b-805c-4236-ae2f-ea83f9583eca",
@@ -5244,7 +6561,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "0d5bfa5d-012e-41bb-acca-77f17571d28e",
@@ -5255,7 +6575,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "bedfa2a1-c98f-408d-a7a1-62559b040672",
@@ -5266,7 +6589,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "d48b614a-ab47-4a15-bce9-ad5671e30ce6",
@@ -5277,7 +6603,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "502a9bdc-8c05-436e-9513-8009837a868f",
@@ -5288,7 +6617,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "0d431223-b9a9-40f7-9439-ba01d9755289",
@@ -5299,7 +6631,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "6d9ea667-a038-48dc-8a02-9014ccaa3a4b",
@@ -5310,7 +6645,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "733fef21-bb68-41cf-a66f-bbe81ef1f6f2",
@@ -5321,7 +6659,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "1a5771ea-bbef-4ab5-950e-f678a6b25af5",
@@ -5332,7 +6673,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "b009ca37-fc92-4d7d-83c0-9f55b1dd6750",
@@ -5343,7 +6687,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "d93de470-c3ef-45cf-a599-be6f9ee30daa",
@@ -5354,7 +6701,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "5acfc44e-348d-4882-9615-3c90fb01ef57",
@@ -5365,21 +6715,30 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     }
                   ],
                   "bulk_extractor_reports": [
 
                   ],
                   "type": "directory",
-                  "puid": ""
+                  "puid": "",
+                  "tags": [
+
+                  ]
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
               "type": "directory",
-              "puid": ""
+              "puid": "",
+              "tags": [
+
+              ]
             },
             {
               "id": "19b4ccb5-841e-40ce-ad93-474d6a812f55",
@@ -5409,7 +6768,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "3da0777a-da75-49f1-862f-b117cd3aae50",
@@ -5438,7 +6800,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "ac5792f8-e310-4fe6-9b27-45f1d16ea3ed",
@@ -5449,7 +6814,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "61641a11-bb43-41e8-8984-df0288efc910",
@@ -5460,7 +6828,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "69517523-890a-4481-b235-6b2a491b35db",
@@ -5471,7 +6842,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "c22aad0d-4379-4f0d-8d22-2d81176a5ae9",
@@ -5482,7 +6856,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "102e3480-1644-4348-bc0e-b2604a25c5e7",
@@ -5493,7 +6870,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "00cc69eb-04f2-472a-9d7f-d36b40c6777d",
@@ -5504,7 +6884,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "a7acdb94-8ced-446e-b826-7390af6194bd",
@@ -5515,7 +6898,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "904e62c7-14eb-434b-a255-461f6ae0913b",
@@ -5526,7 +6912,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "b83512ee-e3b0-4c79-a0af-3565d863bb57",
@@ -5537,7 +6926,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "f0024ccb-d6bb-4ac6-b4c0-7c2ea7765ed0",
@@ -5548,7 +6940,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "61d37a19-802c-4071-b900-2f7cd34fff8c",
@@ -5559,7 +6954,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "345467c7-9a82-40e5-a505-545f3bb287d5",
@@ -5570,7 +6968,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "9c13a4ad-5b78-4899-9db2-4bd1fafbdce7",
@@ -5581,7 +6982,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "1824dcd2-27e8-44f3-84a4-ea16ae226b60",
@@ -5592,7 +6996,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "86a9e61a-73e4-4af5-866f-e4bae5878ed8",
@@ -5603,7 +7010,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "ba8c79af-f69e-4f8e-bef3-e22ea56cf1cd",
@@ -5614,7 +7024,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "a1449bfb-9f7f-46c7-b7c3-cefb2305709d",
@@ -5625,7 +7038,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "96e7105f-d244-4ccb-a5d2-991bd008e458",
@@ -5636,7 +7052,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "6861983c-0dc3-435b-bf13-bf5258f1b654",
@@ -5647,7 +7066,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "10af630a-3245-4843-8e2a-0fba660f5249",
@@ -5658,7 +7080,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "2eff7757-93df-41a3-876f-ff6092661cfb",
@@ -5679,21 +7104,30 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         }
                       ],
                       "bulk_extractor_reports": [
 
                       ],
                       "type": "directory",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     }
                   ],
                   "bulk_extractor_reports": [
 
                   ],
                   "type": "directory",
-                  "puid": ""
+                  "puid": "",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "1eff381b-6a99-4cc7-b16d-c9c3802a8201",
@@ -5731,7 +7165,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "1c8f28de-7e65-4e7e-bd49-745496c32b75",
@@ -5742,7 +7179,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "473283c0-4a89-467d-8d37-3bf63f57d91b",
@@ -5753,7 +7193,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "7e562a1f-8fff-40c0-ab5e-bcbb9a524140",
@@ -5764,7 +7207,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "60622636-d3f5-4a5b-ba3f-4dbb7bcdf8af",
@@ -5775,7 +7221,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "dd6cc36e-fa2a-49eb-abc6-5556f6349078",
@@ -5786,7 +7235,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "d328bcbb-bbc7-47b7-8fce-3d1ff68b5cd4",
@@ -5797,7 +7249,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "66cfe287-47f6-4f3b-a61d-2bae5bf4106f",
@@ -5808,14 +7263,20 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         }
                       ],
                       "bulk_extractor_reports": [
 
                       ],
                       "type": "directory",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "27ee652e-1464-46d0-95fa-5f2751b34b04",
@@ -5843,7 +7304,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "d36476e2-c63a-4f91-9d7d-8492e199fe9a",
@@ -5854,7 +7318,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "27aed5c0-1715-4ede-8759-2bb98854f34f",
@@ -5865,7 +7332,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "a64e4705-c5af-410f-b4c6-310b80d45880",
@@ -5876,7 +7346,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "b464d03c-739d-45f7-a141-4e360d6fd836",
@@ -5887,7 +7360,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "8db78705-2075-4c6e-810d-37920e026eaf",
@@ -5898,7 +7374,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "338064c7-aedf-4c76-889a-8fc23e199b1a",
@@ -5909,7 +7388,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "40f6e155-0a8d-437f-96ba-be43bacb5842",
@@ -5920,7 +7402,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "540e0ee4-2936-4308-8ede-a15c99dad408",
@@ -5931,7 +7416,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "dd55d0a4-0011-4dc8-984a-2b8674fa0fd8",
@@ -5942,7 +7430,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "aaa3cc15-3e6f-48d6-aa8b-70d46d21d221",
@@ -5953,7 +7444,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "660ad288-99c3-4f0d-95ab-6103016f2239",
@@ -5964,7 +7458,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "fbfd2206-c8b6-4581-ae13-4402d0ea8a6a",
@@ -5975,7 +7472,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "cda57011-4b5c-4140-b388-c77447800dfa",
@@ -5986,7 +7486,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "6a2838a4-1305-4a57-a8f3-c7368a258698",
@@ -5997,7 +7500,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "1f74b08b-903b-4b8b-b430-81c624704967",
@@ -6008,7 +7514,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "da685b82-7084-4edc-ba98-2edcda2bca10",
@@ -6019,7 +7528,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "c9d97393-b234-4b30-83c1-f938c4200f76",
@@ -6030,7 +7542,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "49ac3c30-3367-40a4-a9eb-f4ef788f3e01",
@@ -6041,7 +7556,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "3a683e6e-f394-446a-a3ce-4651357d9ec0",
@@ -6052,7 +7570,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "b41adb00-7864-4a0a-8147-954fe12d25e7",
@@ -6063,28 +7584,40 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         }
                       ],
                       "bulk_extractor_reports": [
 
                       ],
                       "type": "directory",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     }
                   ],
                   "bulk_extractor_reports": [
 
                   ],
                   "type": "directory",
-                  "puid": ""
+                  "puid": "",
+                  "tags": [
+
+                  ]
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
               "type": "directory",
-              "puid": ""
+              "puid": "",
+              "tags": [
+
+              ]
             },
             {
               "id": "639257b7-1aef-4fbb-880c-a1de7b16ca2d",
@@ -6115,7 +7648,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "81a9a867-b84c-42c7-ad61-096f2214261a",
@@ -6126,7 +7662,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "7f82324f-f6d4-4e0d-b4b0-aa8aacabe568",
@@ -6137,7 +7676,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "b7dd1e90-a31f-4048-914a-8f89cfa14b58",
@@ -6149,7 +7691,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "7f973d7e-5326-4790-bdd7-f0cf49e5c2a2",
@@ -6160,7 +7705,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "1c1b906c-d774-4f61-b42f-ea66b0fcac7e",
@@ -6171,7 +7719,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "2652b603-226c-49b0-8ca3-0b4325156f2a",
@@ -6182,7 +7733,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "72139d86-8d5c-4288-936d-77916d56e2fd",
@@ -6193,7 +7747,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "bdd54650-671b-455d-a913-083de75614e9",
@@ -6204,7 +7761,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "e6da8025-83db-4c4a-848d-98e9d42a0b27",
@@ -6215,7 +7775,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "77b83820-4efc-4372-a496-8188e8d083c1",
@@ -6226,7 +7789,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "bdaac43e-0680-4f30-999a-a8dece1dab8d",
@@ -6237,7 +7803,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "1c0dc438-27ff-499e-a217-da41542bb3be",
@@ -6248,7 +7817,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "2ac46918-cc89-496c-abc6-f415a6f235c2",
@@ -6259,7 +7831,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "432c49a8-44c9-40e2-b146-db6ed682d455",
@@ -6270,7 +7845,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "1ce24e87-1c60-4e0a-b1ec-c0d324686ce6",
@@ -6281,7 +7859,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "cd26e0c2-fc2a-4541-b2a3-2e3363c17f4c",
@@ -6292,7 +7873,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "a92aef42-d629-4419-be18-0c9bf135a86b",
@@ -6303,7 +7887,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "a6b4a784-38c8-4f5a-b6f4-4be769a9fedb",
@@ -6314,7 +7901,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "718a5a4f-4755-4da9-8632-b4254883fa54",
@@ -6325,7 +7915,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "f7a31308-f7f1-465f-a599-c251b61bcc94",
@@ -6336,7 +7929,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "79b09046-4203-465a-abc3-2f2c24686117",
@@ -6347,7 +7943,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "5f71d23c-ee52-4ab4-a32a-79670456cdb7",
@@ -6358,7 +7957,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "03bb6577-7860-424e-9ddf-f104dfaf19cd",
@@ -6369,7 +7971,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "677d7bb9-a948-4e1a-b9fc-feb0c2a18065",
@@ -6380,7 +7985,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "14866b9f-6b5c-4909-a46a-8b39247e48f5",
@@ -6391,7 +7999,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "cf00c7ea-a6c0-40b6-b2b7-215bafaa53f4",
@@ -6402,7 +8013,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "006a5b70-8c97-4c9c-9507-77018db0aaa5",
@@ -6413,7 +8027,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "c076d0d6-0e9a-4a5f-b472-b4007605ec3b",
@@ -6424,7 +8041,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "139d3054-3cf9-45fd-8afe-840e1201bc34",
@@ -6434,7 +8054,10 @@
 
                   ],
                   "type": "file",
-                  "puid": ""
+                  "puid": "",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "5157e070-d5bd-45b5-9f8a-4ad8165fe20e",
@@ -6445,7 +8068,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "b95af23e-b5de-4fed-8fc5-a8bbf9ebaeaa",
@@ -6456,7 +8082,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "87650036-e9ed-4132-ae97-2940ac2efa34",
@@ -6467,7 +8096,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "6a6ed72c-832f-4bb3-9bc8-17123fb8418d",
@@ -6478,7 +8110,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "d59dca0d-b954-46a4-b70a-d92969a2b1b7",
@@ -6489,7 +8124,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "1977ea9c-9d23-40b7-bdd3-1b4ba7b3e33f",
@@ -6500,7 +8138,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "fc0cc04b-73a5-4f79-ba5b-0de72ad92698",
@@ -6511,7 +8152,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "23bcd60a-b9cd-42a1-a86e-5ce2a41dc5dd",
@@ -6522,7 +8166,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "caab6851-04a2-459f-ade3-5abf8476667a",
@@ -6533,7 +8180,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "5e7d5e1c-1af2-45fd-9587-8c6337198eb9",
@@ -6544,7 +8194,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "0908668b-80ff-4b26-abd5-a720b5fbf613",
@@ -6555,7 +8208,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "c87d42d9-d05f-42d4-a3d7-15cdd0f8b63f",
@@ -6566,7 +8222,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "d1e83d0a-da80-4c99-aecf-e291ee49d9ee",
@@ -6577,7 +8236,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "66eff2e7-e6a3-4a32-ae4c-f72782e6c3a8",
@@ -6588,7 +8250,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "f1be4cc3-6420-4917-ab63-9167427d6e2e",
@@ -6599,7 +8264,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "00c3a866-c9ab-480f-8165-b917ddacc649",
@@ -6610,7 +8278,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "58fd359c-b4b7-4ea2-a54f-5c79fcb5a0d5",
@@ -6621,7 +8292,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "ab22a393-c38e-46f1-acfe-76a4b7c7dcf7",
@@ -6632,7 +8306,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "53ca6598-82c1-4480-af56-5fa5c7d5e7aa",
@@ -6643,7 +8320,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "47c3d83a-ce92-43f3-abd0-9f87ee493508",
@@ -6654,7 +8334,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "72d6153f-575e-4e2f-be5c-6127d8752eed",
@@ -6665,7 +8348,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "06bb5964-6b5e-43fd-863c-882771c44d02",
@@ -6676,7 +8362,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "2cce5c73-8d4c-4788-a38f-d2e6ab6b664b",
@@ -6687,7 +8376,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "2a6efd79-46fb-4276-9456-242315c2ad35",
@@ -6698,7 +8390,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "568967d0-7761-4f22-91df-657e1f9c61c0",
@@ -6709,7 +8404,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "6035924a-4831-4b9f-b2bf-ea62328cbd12",
@@ -6720,7 +8418,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "e333b88e-5f65-4e6a-8363-e672feab53c0",
@@ -6731,7 +8432,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "23bec771-e9c8-463a-9fa0-19dbda0c00b8",
@@ -6742,7 +8446,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "a44eac70-99f7-48f6-8faa-a6f36cdc2542",
@@ -6753,7 +8460,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "d7c7ec19-1495-4842-b4d8-84194476d6b4",
@@ -6764,7 +8474,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "0ea655da-323e-4dc3-9db2-0064c637de02",
@@ -6775,7 +8488,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "0bea6b83-e580-4809-b63b-ec77eb78d8c9",
@@ -6786,7 +8502,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "bcc81641-bf74-46a3-9e59-dd1061e52b17",
@@ -6797,7 +8516,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "da934e38-be1a-48a8-8879-bcd2321eb972",
@@ -6808,7 +8530,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "c816bd40-ad02-45e6-83ea-2d4527ebae5f",
@@ -6819,7 +8544,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "a16e7efa-33d0-4c2a-82a5-42df154f9027",
@@ -6830,7 +8558,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "e2739449-afc2-4b87-ac0c-afebd4da0f89",
@@ -6841,7 +8572,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "8d3463b3-7c92-4b2f-a139-f02ab9168da8",
@@ -6853,7 +8587,10 @@
 
                   ],
                   "type": "file",
-                  "puid": ""
+                  "puid": "",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "cb761ad4-7301-421e-b5d0-8ed33896b328",
@@ -6864,7 +8601,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "7dc10281-d850-4eec-8cf9-31885fe1031e",
@@ -6875,7 +8615,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "91e2f2b0-29a6-4e4d-bbfd-2db8e4479506",
@@ -6886,7 +8629,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "49cb638f-28c9-4413-b596-983d2caf4e64",
@@ -6897,7 +8643,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "07b97d74-ed87-420a-bacf-69a3cb7d27a6",
@@ -6908,7 +8657,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "5599b16c-2c67-41bc-8819-cdff1fcc7786",
@@ -6919,7 +8671,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "3844471b-b7ed-4aab-bee2-064e2e40dae4",
@@ -6930,7 +8685,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "003253d2-3ad2-4110-9ef2-1f731fd9fca7",
@@ -6941,7 +8699,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "721214c2-f7c7-4165-9d90-f424e270fdf1",
@@ -6952,7 +8713,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "e68f3e8c-38c6-420c-9dc0-fc6b63a5132a",
@@ -6963,7 +8727,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "1bb57ef3-0b52-4e0b-ad90-8a9eff20d038",
@@ -6974,7 +8741,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "bd3800fc-ff2e-4358-ba4a-12d03f4ce201",
@@ -6985,7 +8755,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "2be09d3e-1efe-4b42-b474-f63f05fb0e2a",
@@ -6996,7 +8769,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "c9e3614c-0fbc-4937-9258-097089ab6d82",
@@ -7007,7 +8783,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "0d87206e-d5ce-4df7-97a7-957a867b4090",
@@ -7018,7 +8797,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "789a5650-df44-41da-955d-01f07f807447",
@@ -7029,7 +8811,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "ec73e7d5-df56-480d-a70e-45e37e5f72e1",
@@ -7040,7 +8825,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "0bb41e14-62dc-45b1-9eac-585ab25e2c30",
@@ -7051,7 +8839,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "7628249b-9847-48a8-9da1-3ab6ed0b82b4",
@@ -7062,7 +8853,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "fd8c981c-1c90-4da1-a3bf-9944b3753b44",
@@ -7073,7 +8867,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "e1af0433-4248-43de-ab60-da0c3fd47d07",
@@ -7084,7 +8881,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "854c9ac3-1fd8-4df9-b47c-c4ccdc16d1e7",
@@ -7095,7 +8895,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "4d98a0e1-c53b-4bb9-9c13-893d21873787",
@@ -7106,7 +8909,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "4d80ba4c-3e44-4107-9f85-8b940058d344",
@@ -7117,7 +8923,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "4c769be6-8691-428a-b265-8e98ca8cf3fb",
@@ -7128,7 +8937,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "5dfc17ba-bc9e-464f-95d6-d613290a05f0",
@@ -7139,7 +8951,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "c3100b39-3be2-476d-8882-3214b9cb1f63",
@@ -7150,7 +8965,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "c54bd138-115e-4b6d-a1e3-679868419b7f",
@@ -7161,7 +8979,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "3f3ce1cb-7cd0-4872-b18f-8c4d3f29d598",
@@ -7172,7 +8993,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "6c6412e0-e646-4b87-8298-37142d43fc0a",
@@ -7183,7 +9007,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "10fbf7ba-252e-48bb-b35b-ab365d7ddc9f",
@@ -7194,7 +9021,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "f07f481f-e354-40e7-b84b-4be225bfe329",
@@ -7205,7 +9035,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "2ec91ebb-b77e-491f-b33c-317225967700",
@@ -7216,7 +9049,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "82ddeed9-ec25-4db7-874d-332acbc397f9",
@@ -7227,7 +9063,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "7413eebd-ee3c-4e86-bea9-045f680c223d",
@@ -7238,7 +9077,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "bfca29d1-5d17-4aa2-b326-d630b756a966",
@@ -7249,7 +9091,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "09cffaf4-6ddb-43fd-a066-715b96acc94a",
@@ -7260,7 +9105,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "6894ca16-5189-4333-8b9a-c3ba17c671de",
@@ -7271,7 +9119,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "4598e44b-0db9-44b4-91d5-d7122a472796",
@@ -7282,7 +9133,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "2ed0e440-916c-4315-8194-70f9863d0923",
@@ -7293,7 +9147,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "2063bc88-23ba-460c-ac41-d2395cdcad0a",
@@ -7304,7 +9161,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "075a0ba6-471a-4dc4-abc6-d82fb13bb1ac",
@@ -7315,7 +9175,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "5d9e39af-ee3e-4b68-bcef-26c06155097a",
@@ -7326,7 +9189,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "22aa0644-7a59-4f75-ad67-98edf180e46e",
@@ -7337,7 +9203,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "dbb0eb8d-0028-4346-ae2c-f979577d9cfe",
@@ -7348,7 +9217,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "c1a9b55c-4011-4281-a9b2-11c39a0a6b90",
@@ -7359,14 +9231,20 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
               "type": "directory",
-              "puid": ""
+              "puid": "",
+              "tags": [
+
+              ]
             },
             {
               "id": "87995f00-4ad5-433f-8e39-35bbb3e4993e",
@@ -7417,7 +9295,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "777c31be-466d-45e1-a556-fb05abbfbf0d",
@@ -7428,7 +9309,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "3f08d205-63c1-4ffc-ba51-93d71c29e56b",
@@ -7439,7 +9323,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "58e2fb84-4923-4a4b-a65f-b11199345a04",
@@ -7450,7 +9337,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "431d13c9-b60e-47d7-8648-4cee0471896b",
@@ -7461,7 +9351,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "b124c0d7-2d87-4d08-bd46-87d30eda09fc",
@@ -7472,7 +9365,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "5a436c06-b4c7-4c63-af45-3da6c727cd66",
@@ -7483,7 +9379,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "2102f43a-78bb-460e-93ed-ae05f661a3b9",
@@ -7494,7 +9393,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "d81d4a3a-e589-422c-bf10-e30f85b7b82b",
@@ -7505,7 +9407,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "86d23952-106c-41aa-97e9-8b8ecee82698",
@@ -7516,7 +9421,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "b4d4e5aa-4ac6-4b6c-939c-8359c5e59143",
@@ -7527,7 +9435,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "2ffee209-7bcc-4330-9590-8a46582d67a7",
@@ -7538,7 +9449,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "6f0274fe-af95-416e-b4c6-6e89524acf67",
@@ -7549,7 +9463,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "1ca81e00-cd8c-4678-8b78-ae3c0a364441",
@@ -7560,7 +9477,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "f512bc9c-ddf0-46e5-b078-d901768a0c12",
@@ -7571,7 +9491,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "7c2de80d-c45f-449e-971e-1f81cdfabc04",
@@ -7581,7 +9504,10 @@
 
                       ],
                       "type": "file",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "fb9c7a39-c251-41fa-9438-a27cdfa234c9",
@@ -7592,7 +9518,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "470d1831-3543-405a-afee-ed7dfde9cf95",
@@ -7603,7 +9532,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "871a3295-b293-4804-a559-00e53db22a6e",
@@ -7614,7 +9546,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "2c16d1ce-3241-4bfd-b85c-719b0c77eb55",
@@ -7625,7 +9560,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "6878efa1-d7d0-47f8-b11d-89e8d53a5f9b",
@@ -7636,7 +9574,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "ec353763-9962-4c83-a2e0-5c80ddd604bc",
@@ -7647,7 +9588,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "5c8cb018-9a53-4e87-9f18-dd4229846032",
@@ -7658,7 +9602,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "7f33d40e-4078-43cf-b21d-1f4478c181fb",
@@ -7669,7 +9616,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "b4d159a9-3461-4bd4-abb8-ecd8dbc51ed4",
@@ -7680,7 +9630,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "e95dc4a0-43f1-4abe-b3f8-b493c7082934",
@@ -7691,7 +9644,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "03452c9c-8b98-4870-9184-9d4f8df90a46",
@@ -7702,7 +9658,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "899683d5-796f-41da-81f6-69bc7f7e9d77",
@@ -7713,7 +9672,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "dad0094c-6813-4bb7-8fcb-f40b3a0f9976",
@@ -7724,7 +9686,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "c77a7f9c-f8c1-4868-9566-80d547efd1bf",
@@ -7735,7 +9700,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "512f0cef-dcf9-463c-82d6-e148aebd3e07",
@@ -7746,7 +9714,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "047efa98-8a46-4459-aa2b-e5a3e2c1c62b",
@@ -7757,7 +9728,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "9d966a3f-c034-46d0-9c2d-6ce2ef9c0739",
@@ -7768,7 +9742,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "b8067234-b6dc-43c9-97fc-1a546e5c6a25",
@@ -7779,7 +9756,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "a098f84a-4ce6-4d8d-9e24-d1f2024a135d",
@@ -7790,7 +9770,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "d2134aee-87a5-4f8f-95d2-621656e2df09",
@@ -7801,7 +9784,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "80a555b2-b330-4808-aadb-66e6153e3334",
@@ -7812,7 +9798,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "88d90134-53fe-4887-ba73-7b5de7f60141",
@@ -7823,14 +9812,20 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     }
                   ],
                   "bulk_extractor_reports": [
 
                   ],
                   "type": "directory",
-                  "puid": ""
+                  "puid": "",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "2f77b316-5c7e-4c1d-939b-8f4c61cd459b",
@@ -7851,14 +9846,20 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     }
                   ],
                   "bulk_extractor_reports": [
 
                   ],
                   "type": "directory",
-                  "puid": ""
+                  "puid": "",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "debd66ba-e2ad-46c5-af90-d2d0318e6cf8",
@@ -7902,7 +9903,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "0082f86b-163c-4601-9f51-7dda34760993",
@@ -7913,7 +9917,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "57623ea4-3415-47cc-a19e-c42b9d671890",
@@ -7924,7 +9931,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "3fd8157c-2ef8-4e66-a6d5-2b9f606f5105",
@@ -7935,7 +9945,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "8a98f1f1-f1a1-41d5-a3be-487b06499eb4",
@@ -7946,7 +9959,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "acd7d9b4-6dfb-4045-bcf3-b70a66b43b86",
@@ -7957,7 +9973,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "c29ee111-db51-47a6-b3aa-d8d0b3841ff0",
@@ -7968,7 +9987,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "e774dee5-d70c-460f-9fcb-fbc33ebc1542",
@@ -7979,14 +10001,20 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         }
                       ],
                       "bulk_extractor_reports": [
 
                       ],
                       "type": "directory",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "679e63d7-6668-4cd4-a625-34b3c16e8c07",
@@ -8015,7 +10043,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "0ff81300-dc48-4aea-b81e-486fb1e699fc",
@@ -8041,7 +10072,10 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             },
                             {
                               "id": "9722d84a-54d8-4ec6-ad01-c1ea99a6af58",
@@ -8052,7 +10086,10 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             },
                             {
                               "id": "c5220716-d35c-4f10-8b31-90de7cb4363f",
@@ -8063,7 +10100,10 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             },
                             {
                               "id": "4f2c148b-b1fb-40e8-9ee7-0a4048ffc4eb",
@@ -8073,7 +10113,10 @@
 
                               ],
                               "type": "file",
-                              "puid": ""
+                              "puid": "",
+                              "tags": [
+
+                              ]
                             },
                             {
                               "id": "e97a1519-6e6d-404d-941a-50b31baf38ac",
@@ -8084,7 +10127,10 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             },
                             {
                               "id": "6020af21-7b2d-46ab-93fb-576a255f766d",
@@ -8095,7 +10141,10 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             },
                             {
                               "id": "739a6eef-0df1-4390-a446-3e01b070aaad",
@@ -8106,7 +10155,10 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             },
                             {
                               "id": "4dae7d2d-80bd-44dc-8cc7-c8a0560b1581",
@@ -8117,7 +10169,10 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             },
                             {
                               "id": "700af938-facb-4933-b177-60aefd6e9996",
@@ -8128,14 +10183,20 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             }
                           ],
                           "bulk_extractor_reports": [
 
                           ],
                           "type": "directory",
-                          "puid": ""
+                          "puid": "",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "83b975ab-9988-42ba-87a3-90b6dbe60aa3",
@@ -8156,14 +10217,20 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             }
                           ],
                           "bulk_extractor_reports": [
 
                           ],
                           "type": "directory",
-                          "puid": ""
+                          "puid": "",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "92c8fd20-c362-4154-a590-e917c76f54de",
@@ -8187,7 +10254,10 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             },
                             {
                               "id": "cbb5f202-b03b-4d57-89fa-980a59fd830a",
@@ -8198,7 +10268,10 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             },
                             {
                               "id": "90cac1b5-95d0-4280-8dab-c48defe2ced5",
@@ -8209,7 +10282,10 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             },
                             {
                               "id": "e85a95b5-2cea-415e-ade8-5e0c0ff979d8",
@@ -8220,7 +10296,10 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             },
                             {
                               "id": "08fa0000-2332-41a0-a6ab-fa968615d940",
@@ -8231,7 +10310,10 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             },
                             {
                               "id": "a26d413f-7171-43c6-bbf8-77ee12052ea6",
@@ -8242,7 +10324,10 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             },
                             {
                               "id": "e32c8ad5-06b6-4574-9e88-dfa71e53d114",
@@ -8253,7 +10338,10 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             },
                             {
                               "id": "9a161ece-0c41-4b59-a4da-58fbf83c317f",
@@ -8265,7 +10353,10 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             },
                             {
                               "id": "01f4cf81-ce8d-485c-97fa-7aa60b0c731c",
@@ -8276,7 +10367,10 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             },
                             {
                               "id": "3c5f01cd-8c1f-4ff5-a56a-8dba5e1c9b88",
@@ -8287,35 +10381,50 @@
                               "bulk_extractor_reports": [
 
                               ],
-                              "type": "file"
+                              "type": "file",
+                              "tags": [
+
+                              ]
                             }
                           ],
                           "bulk_extractor_reports": [
 
                           ],
                           "type": "directory",
-                          "puid": ""
+                          "puid": "",
+                          "tags": [
+
+                          ]
                         }
                       ],
                       "bulk_extractor_reports": [
 
                       ],
                       "type": "directory",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     }
                   ],
                   "bulk_extractor_reports": [
 
                   ],
                   "type": "directory",
-                  "puid": ""
+                  "puid": "",
+                  "tags": [
+
+                  ]
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
               "type": "directory",
-              "puid": ""
+              "puid": "",
+              "tags": [
+
+              ]
             },
             {
               "id": "d0ea44a3-042a-4f15-b26d-3e8ee087514b",
@@ -8350,7 +10459,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "42ca5547-9289-431f-8f7c-e07616072f98",
@@ -8361,7 +10473,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "43a58620-25c2-4a98-98ca-f25157a92f88",
@@ -8372,7 +10487,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "fe95bf37-aa7e-45ff-aaec-380c2f932fea",
@@ -8383,7 +10501,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "e1a42695-2c6a-4b90-8d65-7c869ceec5a2",
@@ -8394,7 +10515,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "6f8c1413-45b2-410b-b3e3-9ccb0ae1f0df",
@@ -8405,7 +10529,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "576d11e9-1a66-40ed-9450-a69469d988c4",
@@ -8416,7 +10543,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "c791010d-493a-4e16-9a66-235b97b0db0e",
@@ -8427,7 +10557,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "2483f88e-d62d-43f2-9095-65ced01c4728",
@@ -8438,7 +10571,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "fcea0bfa-8e67-4606-8c43-75b1f81d9088",
@@ -8449,7 +10585,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "58b9896c-70be-432d-b804-69dab53eedd4",
@@ -8460,7 +10599,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "c4264495-b595-41c1-8b4b-b9c12f288b45",
@@ -8471,7 +10613,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "c02f719b-e349-489a-8302-65e6fb46a33e",
@@ -8482,7 +10627,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "77933055-9bad-4f1a-9737-729a02f5c54a",
@@ -8493,7 +10641,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "dff2880c-705f-43cf-92e5-0a2e65a2186c",
@@ -8504,7 +10655,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "fc8ab3fc-63e9-4035-9a5f-ad776ea4b7f0",
@@ -8515,7 +10669,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "1d787f99-42c9-4911-8c0c-67840fe13459",
@@ -8526,7 +10683,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "36ec1b1c-8685-4d4e-8c9e-85edf7cc75eb",
@@ -8537,7 +10697,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "3c18c1bd-d1de-497f-8eb8-cc898d96adb2",
@@ -8548,7 +10711,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "181a3b0c-6a8a-442b-8496-7fcbee857e47",
@@ -8559,7 +10725,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "6fadf2ae-99cd-44cb-805c-772d63a48320",
@@ -8570,7 +10739,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "9f497db0-3ae6-4a88-992b-15f1dae7d5c4",
@@ -8581,7 +10753,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "8572787f-bcf5-41df-b720-42b3751e37d0",
@@ -8592,7 +10767,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "50674d8a-daa6-4783-8146-9d98fe998d76",
@@ -8603,7 +10781,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "15dc2741-c74b-4703-b2df-8a518b7a39ac",
@@ -8614,14 +10795,20 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     }
                   ],
                   "bulk_extractor_reports": [
 
                   ],
                   "type": "directory",
-                  "puid": ""
+                  "puid": "",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "aca4b6a9-4f6a-4923-9516-1501eecc3919",
@@ -8642,7 +10829,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "63746990-43b0-4d5a-a4fe-30c1f01e5247",
@@ -8653,7 +10843,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "90f6a55c-d0e9-47d7-bd13-a38dd7626581",
@@ -8664,7 +10857,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "54b1bb93-fa96-4d1c-a3a6-19fcabb5537c",
@@ -8675,7 +10871,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "96f719f8-e76e-4c94-9484-ae85740693c4",
@@ -8686,7 +10885,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "602df535-034a-4dc4-9f9a-c5952ec03140",
@@ -8697,7 +10899,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "32f6cae5-c60c-4328-a7ba-41a160714f1a",
@@ -8708,7 +10913,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "142ef483-1117-4217-8544-25c0d3ad0028",
@@ -8719,7 +10927,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "888326bc-afc7-4236-897e-99ec6bb3d1ae",
@@ -8730,7 +10941,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "8dd14878-8aa1-4dca-9bd5-4c93bcc134ac",
@@ -8741,7 +10955,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "f412d8ac-ffbf-4f05-ba4f-cfbc5998e2a8",
@@ -8752,7 +10969,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "344a8de5-fa9c-4f2e-8e98-a0719c4fe8e2",
@@ -8773,7 +10993,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "b9d7b8ef-5b53-4de5-94f7-cbab34e2493e",
@@ -8784,7 +11007,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "c70aaabb-b48e-490d-9c95-bb8530ee3840",
@@ -8795,7 +11021,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "5286d20f-32e3-49e8-b696-3a4a9138964a",
@@ -8806,7 +11035,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "db3cf8f1-d42f-4b43-a398-d7de26cf7c8b",
@@ -8817,7 +11049,10 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         },
                         {
                           "id": "642899f9-0f6d-49c9-adde-0977ca2fc113",
@@ -8828,28 +11063,40 @@
                           "bulk_extractor_reports": [
 
                           ],
-                          "type": "file"
+                          "type": "file",
+                          "tags": [
+
+                          ]
                         }
                       ],
                       "bulk_extractor_reports": [
 
                       ],
                       "type": "directory",
-                      "puid": ""
+                      "puid": "",
+                      "tags": [
+
+                      ]
                     }
                   ],
                   "bulk_extractor_reports": [
 
                   ],
                   "type": "directory",
-                  "puid": ""
+                  "puid": "",
+                  "tags": [
+
+                  ]
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
               "type": "directory",
-              "puid": ""
+              "puid": "",
+              "tags": [
+
+              ]
             },
             {
               "id": "c818f091-9f65-42ae-8f2f-a4bce9176e30",
@@ -8888,7 +11135,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "ac9340b2-5629-4ede-bb63-d1953698b69d",
@@ -8899,7 +11149,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "3b21f7ce-b61f-4176-a167-4d312b9fb11d",
@@ -8910,7 +11163,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "c3b8e1ec-356c-4293-8a79-1db21ab873a5",
@@ -8921,7 +11177,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "b1a8db6d-317c-48fa-8a81-b1313a152a14",
@@ -8932,7 +11191,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "23e802c7-6947-4948-819d-ebc9949f5144",
@@ -8943,7 +11205,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "b710bc07-b896-483a-988c-3b8d8d85b6cb",
@@ -8954,7 +11219,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "2c594d09-a5eb-472d-8f1b-4640a9caf65c",
@@ -8965,7 +11233,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "11d34b64-c213-4659-b9ad-a812934cdded",
@@ -8976,7 +11247,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "89ac8941-59d9-4f17-a70a-fba0da15f899",
@@ -8987,7 +11261,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "c7a48ba8-8949-4962-8e99-734598e472a7",
@@ -8998,7 +11275,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "b708aaac-165d-4d4b-b88c-db6116405fbe",
@@ -9009,7 +11289,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "c721512e-b340-40bf-9ce1-b30479d97d0a",
@@ -9020,7 +11303,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "c9039a57-22ec-4716-a4ac-998dcd687d64",
@@ -9031,7 +11317,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "e041382f-1c40-4477-b684-226feb410590",
@@ -9042,7 +11331,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "6be703aa-c193-4ea6-8241-de7c781c8515",
@@ -9053,7 +11345,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "b1774bcd-71c0-4740-8668-270f39a15e55",
@@ -9064,7 +11359,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "4735b376-694c-4067-8cf7-196b69e5a110",
@@ -9075,7 +11373,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "3db2e66a-fb8d-420b-88b2-6d5dee296395",
@@ -9086,7 +11387,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "5b59f123-da48-4e42-b946-6643c85b1fa8",
@@ -9097,7 +11401,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "c46e1af0-b258-4c90-a6cd-cc33ab74120e",
@@ -9108,7 +11415,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "f6ce22bb-0afc-4df0-a729-e9920abf0469",
@@ -9119,7 +11429,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "a586640f-b47a-494e-a3e0-c2fa29de4a01",
@@ -9130,7 +11443,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "f4b770d6-6c4e-49eb-b358-554e4c3f53e4",
@@ -9141,7 +11457,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "37b6a833-efea-4f00-a350-709ae580560e",
@@ -9152,7 +11471,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "02f4fafa-60b8-421e-b288-7d16abe9691a",
@@ -9163,7 +11485,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "fc445b29-e398-477b-8515-9cf1f15282a5",
@@ -9174,7 +11499,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "db2bf5d2-8c91-484c-9b6c-f97e0b56beda",
@@ -9185,7 +11513,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "206a7f82-0590-44ae-add7-4c449c02553f",
@@ -9196,14 +11527,20 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     }
                   ],
                   "bulk_extractor_reports": [
 
                   ],
                   "type": "directory",
-                  "puid": ""
+                  "puid": "",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "fa51a383-0e0a-4824-83a7-b71ffa2601c8",
@@ -9230,7 +11567,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "bfb771b8-e7d7-47eb-bd89-2f1079f2e9a7",
@@ -9241,7 +11581,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "17497749-0ccc-4dcb-a2cd-410857c055b1",
@@ -9252,7 +11595,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "ab81254b-45f0-4de2-8118-d30e670693b1",
@@ -9263,7 +11609,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "3625e2d2-0e27-4ffe-9d51-db07bfdcc259",
@@ -9274,7 +11623,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "3d7a9ea6-c626-49f8-a169-e42dae990d5b",
@@ -9285,7 +11637,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "886d1d5b-f228-4566-be95-398dc1b83fd4",
@@ -9296,7 +11651,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "467f9b0f-12db-461d-8bb4-894c6cd55fc6",
@@ -9307,7 +11665,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "db9b741d-d7ae-49ef-b3da-21d59a50fb8f",
@@ -9318,7 +11679,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "cd19f388-0a33-4f9c-806c-600afaea09cf",
@@ -9329,7 +11693,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "3937a42f-2f40-46c2-87b0-9adc62e8e27f",
@@ -9340,7 +11707,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "9bcd1dcd-d451-4ee8-9ba1-de29c17372be",
@@ -9351,7 +11721,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "528a7571-86dd-4a81-b03a-16aed00bf89f",
@@ -9362,7 +11735,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "16312664-8946-4e0d-94cc-2f04b4a4cdf2",
@@ -9373,7 +11749,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "b6cfe345-fae1-4676-a1b2-1668267634ed",
@@ -9384,7 +11763,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "9cdb5bb9-a3be-4d35-9274-72ac1e003d8e",
@@ -9395,7 +11777,10 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     },
                     {
                       "id": "5115ebdd-50a4-4d2f-ada8-9eea06d4da40",
@@ -9406,21 +11791,30 @@
                       "bulk_extractor_reports": [
 
                       ],
-                      "type": "file"
+                      "type": "file",
+                      "tags": [
+
+                      ]
                     }
                   ],
                   "bulk_extractor_reports": [
 
                   ],
                   "type": "directory",
-                  "puid": ""
+                  "puid": "",
+                  "tags": [
+
+                  ]
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
               "type": "directory",
-              "puid": ""
+              "puid": "",
+              "tags": [
+
+              ]
             },
             {
               "id": "7138fb42-8465-4864-a349-a142678fe739",
@@ -9443,7 +11837,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "81d38289-5dd7-4b30-b317-0f140a10e347",
@@ -9454,7 +11851,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "251d1018-4e3f-4a76-ba8e-469040ec2fee",
@@ -9465,7 +11865,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "0be77823-4276-41b3-9032-c58747c848b2",
@@ -9476,7 +11879,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "c86c9da9-c96a-4667-86fb-4ed7d1e459f5",
@@ -9487,7 +11893,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "984b03ba-4b49-4788-9c0d-3e947e1a706e",
@@ -9498,7 +11907,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "a14c9037-48e4-42f7-b8cc-b982c95cdbe9",
@@ -9509,7 +11921,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "7a146662-32e0-4f47-99ab-db45a52ad41f",
@@ -9520,7 +11935,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "9a055d83-0d18-4f4b-9dfb-b4c30d58bba7",
@@ -9531,7 +11949,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "34cb6798-9e1c-48b9-a9fa-44804c7ac05b",
@@ -9542,7 +11963,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "e566a1a5-f8a7-4c46-9769-026e391c56fb",
@@ -9553,7 +11977,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "1358e5f6-312e-4875-a5bb-9cc4cfb6a430",
@@ -9564,7 +11991,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "934cf71f-b74f-417c-bbf1-b6d835589e81",
@@ -9575,7 +12005,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "02a9a091-a16b-4f12-9168-72a4fc4063d9",
@@ -9586,7 +12019,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "9511cd47-3de6-4bca-92b3-291648597f3e",
@@ -9597,7 +12033,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "2a59646a-510f-43d8-9cbb-3811dbc07028",
@@ -9608,7 +12047,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "4077f08e-7759-4dc4-99e7-129981e1eb88",
@@ -9619,7 +12061,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "cf0826bb-02db-4bd7-958f-12bbe7acd143",
@@ -9630,7 +12075,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "98d8a818-04eb-4ea4-a596-8cf0a37f3483",
@@ -9641,7 +12089,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "6fe69727-81b6-45c0-aa23-47c6f8e7e8d8",
@@ -9652,7 +12103,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "bb42cba2-a016-463d-8165-72162a856f36",
@@ -9663,7 +12117,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "0bc1d393-32ab-49fc-86e8-13379eabcc9a",
@@ -9674,7 +12131,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "9a3d1321-3a5e-41b2-8b92-90bf28a64a9f",
@@ -9685,7 +12145,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "c691969e-4aab-4b95-b7b8-ce0b0df934c5",
@@ -9696,7 +12159,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "03ee42c2-a9b8-4f71-b44d-ee769ad3091c",
@@ -9707,7 +12173,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "728b9ec5-8313-42e0-9c76-c80433b5bad2",
@@ -9718,7 +12187,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "8e70c704-ab40-40e9-9995-6c9ba478315d",
@@ -9729,7 +12201,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "f76295ff-f2fd-49b4-8fc0-06e5b41a0e21",
@@ -9740,7 +12215,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "e6c8545b-093e-44eb-8ade-4cc79ee3df98",
@@ -9751,7 +12229,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "a998a205-34e8-4848-945d-837c8803b543",
@@ -9762,7 +12243,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "670c716b-f6ca-47cd-9590-e4f17e355158",
@@ -9773,7 +12257,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "a8499275-22bc-418a-9021-7e29d52e85e2",
@@ -9784,7 +12271,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "40769334-200a-45ac-b226-d063f17931f1",
@@ -9795,7 +12285,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "c4d8ed8f-2bf1-4b05-a82c-f4f57d725f8e",
@@ -9806,7 +12299,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "8ead7e2e-ba40-4aba-9781-0e984e2037de",
@@ -9817,7 +12313,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "879328d6-ec06-4447-b3c4-611204ec71e6",
@@ -9828,7 +12327,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "c3f1f342-873b-46d2-ba35-b207249a0ec2",
@@ -9839,7 +12341,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "7b511d12-7889-4294-b3e5-c84d5f340156",
@@ -9850,7 +12355,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "09a81af7-804c-4008-9e73-8040ebe5cd58",
@@ -9861,28 +12369,40 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
               "type": "directory",
-              "puid": ""
+              "puid": "",
+              "tags": [
+
+              ]
             }
           ],
           "bulk_extractor_reports": [
 
           ],
           "type": "directory",
-          "puid": ""
+          "puid": "",
+          "tags": [
+
+          ]
         }
       ],
       "bulk_extractor_reports": [
 
       ],
       "type": "directory",
-      "puid": ""
+      "puid": "",
+      "tags": [
+
+      ]
     },
     {
       "id": "49a16b4d-beb1-4bbf-ada0-e362d4f32651",
@@ -9944,7 +12464,10 @@
               "bulk_extractor_reports": [
 
               ],
-              "type": "file"
+              "type": "file",
+              "tags": [
+
+              ]
             },
             {
               "id": "c93564d6-306c-400f-9bfe-73508ef1addf",
@@ -9957,7 +12480,10 @@
               "bulk_extractor_reports": [
                 "pii"
               ],
-              "type": "file"
+              "type": "file",
+              "tags": [
+
+              ]
             },
             {
               "id": "7fc27b8f-fd4e-4220-bd6d-9db98fb14c9d",
@@ -9968,7 +12494,10 @@
               "bulk_extractor_reports": [
 
               ],
-              "type": "file"
+              "type": "file",
+              "tags": [
+
+              ]
             },
             {
               "id": "8ca89491-5b9a-45e0-8202-3e1a1357eab4",
@@ -9980,7 +12509,10 @@
               "bulk_extractor_reports": [
 
               ],
-              "type": "file"
+              "type": "file",
+              "tags": [
+
+              ]
             },
             {
               "id": "d2523802-203b-43e5-b5a9-c719985f726b",
@@ -9990,7 +12522,10 @@
 
               ],
               "type": "file",
-              "puid": ""
+              "puid": "",
+              "tags": [
+
+              ]
             },
             {
               "id": "2927af84-d519-41f6-8bda-5c1caec67d0c",
@@ -10000,7 +12535,10 @@
 
               ],
               "type": "file",
-              "puid": ""
+              "puid": "",
+              "tags": [
+
+              ]
             },
             {
               "id": "e198fa44-5958-4039-9273-7239e5c7e571",
@@ -10011,7 +12549,10 @@
               "bulk_extractor_reports": [
 
               ],
-              "type": "file"
+              "type": "file",
+              "tags": [
+
+              ]
             },
             {
               "id": "7fce5968-013c-46f5-9e9b-3774b2aa5cb0",
@@ -10023,7 +12564,10 @@
               "bulk_extractor_reports": [
                 "pii"
               ],
-              "type": "file"
+              "type": "file",
+              "tags": [
+
+              ]
             },
             {
               "id": "a7bf717f-c0bd-4161-9a02-a7cb1674c634",
@@ -10035,7 +12579,10 @@
               "bulk_extractor_reports": [
                 "ccn"
               ],
-              "type": "file"
+              "type": "file",
+              "tags": [
+
+              ]
             },
             {
               "id": "875d8e59-2ff3-4e9e-a4dd-90edd4152305",
@@ -10046,7 +12593,10 @@
               "bulk_extractor_reports": [
 
               ],
-              "type": "file"
+              "type": "file",
+              "tags": [
+
+              ]
             },
             {
               "id": "c233ba1e-014b-4d74-958a-fb05dabc7932",
@@ -10058,7 +12608,10 @@
               "bulk_extractor_reports": [
 
               ],
-              "type": "file"
+              "type": "file",
+              "tags": [
+
+              ]
             },
             {
               "id": "8f5abbd7-046f-40bd-bae6-6646463c2a41",
@@ -10072,7 +12625,10 @@
                 "pii",
                 "ccn"
               ],
-              "type": "file"
+              "type": "file",
+              "tags": [
+
+              ]
             },
             {
               "id": "61f32c21-46b8-442f-9d55-e1828ea788b5",
@@ -10083,7 +12639,10 @@
               "bulk_extractor_reports": [
 
               ],
-              "type": "file"
+              "type": "file",
+              "tags": [
+
+              ]
             },
             {
               "id": "d12aaf8b-1265-47a4-97c3-64ab03fb2c20",
@@ -10105,14 +12664,20 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
               "type": "directory",
-              "puid": ""
+              "puid": "",
+              "tags": [
+
+              ]
             },
             {
               "id": "a2f5cfb5-87eb-47be-9c97-5ae5837f5410",
@@ -10134,7 +12699,10 @@
                   "bulk_extractor_reports": [
 
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 },
                 {
                   "id": "97331076-6932-4e19-ad9a-7c31115493e8",
@@ -10147,14 +12715,20 @@
                   "bulk_extractor_reports": [
                     "ccn"
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
               "type": "directory",
-              "puid": ""
+              "puid": "",
+              "tags": [
+
+              ]
             },
             {
               "id": "184f3861-fd90-4fdb-96da-6d595da56cd7",
@@ -10178,28 +12752,40 @@
                     "pii",
                     "ccn"
                   ],
-                  "type": "file"
+                  "type": "file",
+                  "tags": [
+
+                  ]
                 }
               ],
               "bulk_extractor_reports": [
 
               ],
               "type": "directory",
-              "puid": ""
+              "puid": "",
+              "tags": [
+
+              ]
             }
           ],
           "bulk_extractor_reports": [
 
           ],
           "type": "directory",
-          "puid": ""
+          "puid": "",
+          "tags": [
+
+          ]
         }
       ],
       "bulk_extractor_reports": [
 
       ],
       "type": "directory",
-      "puid": ""
+      "puid": "",
+      "tags": [
+
+      ]
     }
   ]
 }

--- a/app/index.html
+++ b/app/index.html
@@ -44,13 +44,13 @@
       <label for='puid-facet'>PUID</label>
       <select ng-model="puid" class='form-control' id='puid-facet'>
         <option value="">All</option>
-        <option ng-repeat="format in transfers.formats" ng-if="format.puid" value="{{ format.puid }}">{{ format.label }} ({{ format.puid }})</option>
+        <option ng-repeat="format in transfers.formats" ng-if="format.puid" value="{{ format.puid }}">{{ format.title }} ({{ format.puid }})</option>
       </select>
 
       <label for='extension-facet'>File extension</label>
       <select ng-model="extension" class='form-control' id='extension-facet'>
         <option value="">All</option>
-        <option ng-repeat="format in transfers.formats" ng-if="format.extension" value="{{ format.extension }}">{{ format.label }} ({{ format.extension }})</option>
+        <option ng-repeat="format in transfers.formats" ng-if="format.extension" value="{{ format.extension }}">{{ format.title }} ({{ format.extension }})</option>
       </select>
     </fieldset>
 

--- a/app/index.html
+++ b/app/index.html
@@ -85,7 +85,9 @@
         <treecontrol class="tree-classic"
                      tree-model="transfers.data"
                      options="options"
-                     on-selection="track_selected(node, selected)">
+                     on-selection="track_selected(node, selected)"
+                     filter-expression="filter_expression"
+                     filter-comparator="filter_comparator">
           <span tree-draggable helper="helper" uuid="{{ node.id }}">
             {{ node.title }} <span class="tag" ng-repeat="tag in node.tags">{{ tag }} <span ng-click="remove_tag(id, tag)"><i class="fa fa-minus-square"></i></span></span>
           </span>

--- a/app/services/facet.service.js
+++ b/app/services/facet.service.js
@@ -86,17 +86,20 @@
     var filter = function(values) {
       var self = this; // needs to be defined outside the filter function
       return values.filter(function(element, index, array) {
-        var result;
-        for (var key in element) {
-          var value = element[key];
-          result = filter_value.apply(self, [key, value]);
-          if (result === false) {
-            return false;
-          }
-        }
-
-        return true;
+        return self.passes_filters(element);
       });
+    };
+
+    var passes_filters = function(object) {
+      var self = this;
+      var result = true;
+      angular.forEach(object, function(value, key) {
+        if (filter_value.apply(self, [key, value]) === false) {
+          result = false;
+        }
+      });
+
+      return result;
     };
 
     // private
@@ -146,6 +149,7 @@
       remove_by_id: remove_by_id,
       clear: clear,
       filter: filter,
+      passes_filters: passes_filters,
     };
   });
 })();

--- a/app/services/facet.service.js
+++ b/app/services/facet.service.js
@@ -111,6 +111,21 @@
         // no facet for this key
         return true;
       }
+      // if this is a collection, test to see if any of the matches are false
+      if (value.map !== undefined) {
+        // if the collection is empty it cannot possibly match anything
+        if (value.length === 0) {
+          return false;
+        }
+
+        var self = this;
+        var results = value.map(function(element) {
+          return filter_value.apply(self, [key, element]);
+        });
+        // if there are no false elements, return true
+        return results.indexOf(false) === -1;
+      }
+
       for (var i in this.facets[key]) {
         var result;
         var filter = this.facets[key][i].value;

--- a/app/services/facet.service.js
+++ b/app/services/facet.service.js
@@ -91,15 +91,17 @@
     };
 
     var passes_filters = function(object) {
-      var self = this;
-      var result = true;
-      angular.forEach(object, function(value, key) {
-        if (filter_value.apply(self, [key, value]) === false) {
-          result = false;
+      var keys = Object.keys(object);
+      var key, value;
+      for (var i = 0; i < keys.length; i++) {
+        key = keys[i];
+        value = object[key];
+        if (filter_value.apply(this, [key, value]) === false) {
+          return false;
         }
-      });
+      }
 
-      return result;
+      return true;
     };
 
     // private

--- a/app/services/transfer.service.js
+++ b/app/services/transfer.service.js
@@ -1,9 +1,9 @@
 'use strict';
 
 (function() {
-  angular.module('transferService', ['restangular']).
+  angular.module('transferService', ['facetService', 'restangular']).
 
-  factory('Transfer', ['Restangular', function(Restangular) {
+  factory('Transfer', ['Facet', 'Restangular', function(Facet, Restangular) {
     var create_flat_map = function(records, map) {
       if (map === undefined) {
         map = {};
@@ -29,8 +29,19 @@
         var self = this;
         self.all().then(function(data) {
           self.data = data.transfers;
+          self.data[0].version = 0;
           self.formats = data.formats;
           self.id_map = create_flat_map(data.transfers);
+          self.filter();
+        });
+      },
+      filter: function() {
+        angular.forEach(this.id_map, function(file) {
+          if (file.type === 'file') {
+            file.display = Facet.passes_filters(file);
+          } else {
+            file.display = true;
+          }
         });
       },
     };

--- a/app/tree/tree.controller.js
+++ b/app/tree/tree.controller.js
@@ -25,6 +25,8 @@
       },
     };
     $scope.selected = [];
+    $scope.filter_expression = {display: true};
+    $scope.filter_comparator = true;
 
     $scope.remove_tag = function(id, tag) {
       Tag.remove(id, tag);

--- a/test/unit/facetSpec.js
+++ b/test/unit/facetSpec.js
@@ -90,4 +90,15 @@ describe('Facet', function() {
     Facet.add('list_b', '2');
     expect(Facet.facet_list.length).toEqual(2);
   }));
+
+  it('should apply a filter to every element in a list if the value is a list', inject(function(Facet) {
+    Facet.add('key', 'test');
+    expect(Facet.passes_filters({'key': ['test']})).toBe(true);
+    expect(Facet.passes_filters({'key': ['this', 'should', 'fail']})).toBe(false);
+  }));
+
+  it('should consider empty list values to be false', inject(function(Facet) {
+    Facet.add('key', 'test');
+    expect(Facet.passes_filters({'key': []})).toBe(false);
+  }));
 });

--- a/test/unit/facetSpec.js
+++ b/test/unit/facetSpec.js
@@ -53,6 +53,12 @@ describe('Facet', function() {
     expect(Facet.filter([{'date': '1950:1999'}, {'date': '1975:1980'}])).toEqual([{'date': '1975:1980'}]);
   }));
 
+  it('should be able to return a boolean value when filtering a single value', inject(function(Facet) {
+    Facet.add('filename', /\.jpg$/);
+    expect(Facet.passes_filters({'filename': '1.png'})).toBe(false);
+    expect(Facet.passes_filters({'filename': '1.jpg'})).toBe(true);
+  }));
+
   it('should return a unique ID for each newly-added value', inject(function(Facet) {
     var id1 = Facet.add('id', '1');
     var id2 = Facet.add('id', '2');


### PR DESCRIPTION
This adds filtering to the tree view using all currently-selected facets.
- Facet service gains a new convenience method to filter single values, returning a boolean
- Transfer service gains a new method to filter all of the files using the current facets
- Anytime a facet is added or removed, `Transfer.filter()` is called
- The tree view has been given a filter expression and comparator that display or hides individual files depending on the value of the file's `display` property; directories are always rendered
