### PR TITLE
Consolidate report tab

### DIFF
--- a/app/analysis/analysis.controller.js
+++ b/app/analysis/analysis.controller.js
@@ -1,0 +1,9 @@
+'use strict';
+
+(function() {
+  angular.module('analysisController', ['route-segment']).
+
+  controller('AnalysisController', ['$scope', '$routeSegment', function($scope, $routeSegment) {
+    $scope.$routeSegment = $routeSegment;
+  }]);
+})();

--- a/app/analysis/analysis.html
+++ b/app/analysis/analysis.html
@@ -1,0 +1,10 @@
+<ul class="nav nav-pills">
+  <li ng-class="{ active: $routeSegment.contains('report') }">
+    <a href="#/analysis/report">Report</a>
+  </li>
+  <li ng-class="{ active: $routeSegment.contains('visualizations') }">
+    <a href="#/analysis/visualizations">Visualizations</a>
+  </li>
+</ul>
+
+<div app-view-segment="1"></div>

--- a/app/analysis/analysis.html
+++ b/app/analysis/analysis.html
@@ -1,9 +1,9 @@
 <ul class="nav nav-pills">
   <li ng-class="{ active: $routeSegment.contains('report') }">
-    <a href="#/analysis/report">Report</a>
+    <a href="#{{ $routeSegment.getSegmentUrl('analysis.report') }}">Report</a>
   </li>
   <li ng-class="{ active: $routeSegment.contains('visualizations') }">
-    <a href="#/analysis/visualizations">Visualizations</a>
+    <a href="#{{ $routeSegment.getSegmentUrl('analysis.visualizations') }}">Visualizations</a>
   </li>
 </ul>
 

--- a/app/app.js
+++ b/app/app.js
@@ -18,6 +18,7 @@ angular.module('appraisalTab', [
   'tagService',
   'facetFilter',
   'aggregationFilters',
+  'analysisController',
   'archivesSpaceController',
   'examineContentsController',
   'facetController',
@@ -38,22 +39,43 @@ config(['$routeSegmentProvider', function($routeSegmentProvider) {
   $routeSegmentProvider.options.strictMode = true;
 
   $routeSegmentProvider.
-    when('/report', 'report').
+    when('/analysis', 'analysis').
+    when('/analysis/report', 'analysis.report').
+    when('/analysis/visualizations', 'analysis.visualizations').
+    when('/analysis/visualizations/files', 'analysis.visualizations.files').
+    when('/analysis/visualizations/size', 'analysis.visualizations.size').
     when('/tag', 'tag').
     when('/contents', 'examine_contents').
     when('/contents/:type', 'examine_contents').
     when('/contents/:id/:type', 'examine_contents.file_info').
-    when('/visualizations', 'visualizations').
-    when('/visualizations/files', 'visualizations.files').
-    when('/visualizations/size', 'visualizations.size').
     when('/preview', 'preview').
     when('/preview/:id', 'preview').
     when('/archivesspace', 'archivesspace').
 
-    segment('report', {
-      templateUrl: 'report/report.html',
-      controller: 'ReportController',
+    segment('analysis', {
+      templateUrl: 'analysis/analysis.html',
+      controller: 'AnalysisController',
     }).
+    within().
+      segment('report', {
+        default: true,
+        templateUrl: 'report/report.html',
+        controller: 'ReportController',
+      }).
+      segment('visualizations', {
+        templateUrl: 'visualizations/visualizations.html',
+        controller: 'VisualizationsController',
+      }).
+      within().
+        segment('files', {
+          default: 'true',
+          templateUrl: 'visualizations/formats_by_files.html',
+        }).
+        segment('size', {
+          templateUrl: 'visualizations/formats_by_size.html',
+        }).
+      up().
+    up().
 
     segment('tag', {
       templateUrl: 'tag/tag.html',
@@ -70,20 +92,6 @@ config(['$routeSegmentProvider', function($routeSegmentProvider) {
         templateUrl: 'examine_contents/file_info.html',
         controller: 'ExamineContentsFileController',
         dependencies: ['id', 'type'],
-      }).
-    up().
-
-    segment('visualizations', {
-      templateUrl: 'visualizations/visualizations.html',
-      controller: 'VisualizationsController',
-    }).
-    within().
-      segment('files', {
-        default: 'true',
-        templateUrl: 'visualizations/formats_by_files.html',
-      }).
-      segment('size', {
-        templateUrl: 'visualizations/formats_by_size.html',
       }).
     up().
 

--- a/app/examine_contents/examine_contents.controller.js
+++ b/app/examine_contents/examine_contents.controller.js
@@ -4,6 +4,7 @@
   angular.module('examineContentsController', []).
 
   controller('ExamineContentsController', ['$scope', '$routeSegment', 'SelectedFiles', function($scope, $routeSegment, SelectedFiles) {
+    $scope.$routeSegment = $routeSegment;
     $scope.type = $routeSegment.$routeParams.type;
     $scope.SelectedFiles = SelectedFiles;
   }]).

--- a/app/examine_contents/examine_contents.html
+++ b/app/examine_contents/examine_contents.html
@@ -1,9 +1,9 @@
 <ul class="nav nav-pills">
   <li ng-class="{ active: type === 'pii' }">
-    <a href="#/contents/pii">PII</a>
+    <a href="#{{ $routeSegment.getSegmentUrl('examine_contents', {type: 'pii'}) }}">PII</a>
   </li>
   <li ng-class="{ active: type === 'ccn' }">
-    <a href="#/contents/ccn">Credit card numbers</a>
+    <a href="#{{ $routeSegment.getSegmentUrl('examine_contents', {type: 'ccn'}) }}">Credit card numbers</a>
   </li>
 </ul>
 

--- a/app/index.html
+++ b/app/index.html
@@ -99,19 +99,19 @@
   <div class='col-md-7' id="right-pane">
     <ul class="nav nav-tabs" role='menu'>
       <li ng-class="{ active: $routeSegment.contains('analysis') }">
-        <a href="#/analysis">Analysis</a>
+        <a href="#{{ $routeSegment.getSegmentUrl('analysis') }}">Analysis</a>
       </li>
       <li ng-class="{ active: $routeSegment.contains('tag') }">
-        <a href="#/tag">Tag</a>
+        <a href="#{{ $routeSegment.getSegmentUrl('tag') }}">Tag</a>
       </li>
       <li ng-class="{ active: $routeSegment.contains('examine_contents') }">
-        <a href="#/contents">Examine contents</a>
+        <a href="#{{ $routeSegment.getSegmentUrl('examine_contents', {type: ''}) }}">Examine contents</a>
       </li>
       <li ng-class="{ active: $routeSegment.contains('preview') }">
-        <a href="#/preview">Preview file</a>
+        <a href="#{{ $routeSegment.getSegmentUrl('preview', {id: ''}) }}">Preview file</a>
       </li>
       <li ng-class="{ active: $routeSegment.contains('archivesspace') }">
-        <a href="#/archivesspace">ArchivesSpace</a>
+        <a href="#{{ $routeSegment.getSegmentUrl('archivesspace') }}">ArchivesSpace</a>
       </li>
     </ul>
     <div class='panel panel-default panel-tab panel-body' app-view-segment="0"></div>

--- a/app/index.html
+++ b/app/index.html
@@ -98,17 +98,14 @@
 
   <div class='col-md-7' id="right-pane">
     <ul class="nav nav-tabs" role='menu'>
-      <li ng-class="{ active: $routeSegment.contains('report') }">
-        <a href="#/report">Report</a>
+      <li ng-class="{ active: $routeSegment.contains('analysis') }">
+        <a href="#/analysis">Analysis</a>
       </li>
       <li ng-class="{ active: $routeSegment.contains('tag') }">
         <a href="#/tag">Tag</a>
       </li>
       <li ng-class="{ active: $routeSegment.contains('examine_contents') }">
         <a href="#/contents">Examine contents</a>
-      </li>
-      <li ng-class="{ active: $routeSegment.contains('visualizations') }">
-        <a href="#/visualizations">Visualizations</a>
       </li>
       <li ng-class="{ active: $routeSegment.contains('preview') }">
         <a href="#/preview">Preview file</a>
@@ -144,6 +141,7 @@
   <script src="filters/aggregation.filter.js"></script>
   <script src="filters/facet.filter.js"></script>
   <script src="archivesspace/archivesspace.controller.js"></script>
+  <script src="analysis/analysis.controller.js"></script>
   <script src="examine_contents/examine_contents.controller.js"></script>
   <script src="facet_selector/facet_selector.controller.js"></script>
   <script src="preview/preview.controller.js"></script>

--- a/app/visualizations/visualizations.html
+++ b/app/visualizations/visualizations.html
@@ -1,11 +1,11 @@
 <ul class="nav nav-pills">
   <li ng-class="{ active: $routeSegment.contains('files') }">
-    <a href="#/visualizations/files">Formats (by total number of files)</a>
+    <a href="#/analysis/visualizations/files">Formats (by total number of files)</a>
   </li>
   <li ng-class="{ active: $routeSegment.contains('size') }">
-    <a href="#/visualizations/size">Formats (by total size of files)</a>
+    <a href="#/analysis/visualizations/size">Formats (by total size of files)</a>
   </li>
 </ul>
 
 <p ng-if='records.selected.length === 0'>No files selected</p>
-<div app-view-segment="1"></div>
+<div app-view-segment="2"></div>

--- a/app/visualizations/visualizations.html
+++ b/app/visualizations/visualizations.html
@@ -1,9 +1,9 @@
 <ul class="nav nav-pills">
   <li ng-class="{ active: $routeSegment.contains('files') }">
-    <a href="#/analysis/visualizations/files">Formats (by total number of files)</a>
+    <a href="#{{ $routeSegment.getSegmentUrl('analysis.visualizations.files') }}">Formats (by total number of files)</a>
   </li>
   <li ng-class="{ active: $routeSegment.contains('size') }">
-    <a href="#/analysis/visualizations/size">Formats (by total size of files)</a>
+    <a href="#{{ $routeSegment.getSegmentUrl('analysis.visualizations.size') }}">Formats (by total size of files)</a>
   </li>
 </ul>
 


### PR DESCRIPTION
As requested by the client, this consolidates the "report" and "visualizations" tabs into subtabs of a single "analysis" tab.

This also makes some routing changes, by updating URLs to use `$routeSegment`'s reverses instead of hardcoding.
