### PR TITLE
Treeview: fix deselecting child folders

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -120,7 +120,7 @@
                      tree-model="transfers.data"
                      options="options"
                      on-selection="track_selected(node, selected)"
-                     selected-nodes="selected"
+                     selected-nodes="files.selected"
                      filter-expression="filter_expression"
                      filter-comparator="filter_comparator">
           <span tree-draggable helper="helper" uuid="{{ node.id }}">

--- a/app/tree/tree.controller.js
+++ b/app/tree/tree.controller.js
@@ -24,7 +24,6 @@
         li: 'file',
       },
     };
-    $scope.selected = [];
     $scope.filter_expression = {display: true};
     $scope.filter_comparator = true;
 
@@ -34,7 +33,6 @@
 
     var add_file = function(node) {
       SelectedFiles.add(node);
-      $scope.selected.push(node);
       if (node.children) {
         for (var i = 0; i < node.children.length; i++) {
           var child = node.children[i];
@@ -45,7 +43,6 @@
 
     var remove_file = function(node) {
       SelectedFiles.remove(node.id);
-      $scope.selected.pop(node);
       if (node.children) {
         for (var i = 0; i < node.children.length; i++) {
           var child = node.children[i];
@@ -67,7 +64,6 @@
 
     $scope.deselect = function() {
       SelectedFiles.selected = [];
-      $scope.selected = [];
     };
 
     $scope.files = SelectedFiles;


### PR DESCRIPTION
This causes the tree view to bind to SelectedFiles.selected, simplifying the code in the controller and fixing an issue where selecting/deselecting child nodes might work unreliably.
