### PR TITLE
Format groups in report

### DIFF
--- a/app/filters/aggregation.filter.js
+++ b/app/filters/aggregation.filter.js
@@ -9,7 +9,7 @@
 
   angular.module('aggregationFilters', []).
 
-  filter('puid_data', function() {
+  filter('puid_data', ['Transfer', function(Transfer) {
     var puid_data_fn = function(records) {
       var puid_data = {};
       for (var i in records) {
@@ -21,9 +21,11 @@
         if (!puid_data[record.puid]) {
           puid_data[record.puid] = {count: 0, size: 0};
         }
+        var format_info = Transfer.formats.filter(function (f) { return f.title === record.format; });
 
         puid_data[record.puid].count++;
         puid_data[record.puid].format = record.format;
+        puid_data[record.puid].group = format_info[0].group || 'Unknown';
         puid_data[record.puid].size += Number.parseFloat(record.size) || 0;
       }
 
@@ -38,7 +40,7 @@
     };
 
     return _.memoize(puid_data_fn, hash_fn);
-  }).
+  }]).
 
   filter('puid_graph', function() {
     var puid_graph_fn = function(records) {

--- a/app/filters/aggregation.filter.js
+++ b/app/filters/aggregation.filter.js
@@ -95,7 +95,7 @@
   filter('find_files', function() {
     var file_fn = function(records) {
       return records.filter(function(el) {
-        return el.type === 'file' && el.bulk_extractor;
+        return el.type === 'file' && el.bulk_extractor_reports;
       });
     };
 

--- a/app/fixtures/transfers.json
+++ b/app/fixtures/transfers.json
@@ -2,109 +2,134 @@
   "formats": [
     {
       "title": "Powerpoint 97-2002",
+      "group": "Presentation",
       "puid": "fmt/126"
     },
     {
       "title": "Windows BItmap 3.0",
+      "group": "Image (Raster)",
       "puid": "fmt/116"
     },
     {
       "title": "JPEG 1.01",
+      "group": "Image (Raster)",
       "puid": "fmt/43"
     },
     {
       "title": "Generic AIFF",
+      "group": "Audio",
       "puid": "",
       "extension": ".aif"
     },
     {
       "title": "Exchangeable Image File Format (Compressed) 2.2",
+      "group": "Image (Raster)",
       "puid": "x-fmt/391"
     },
     {
       "title": "Microsoft Word Document 97-2003",
+      "group": "Word Processing",
       "puid": "fmt/40"
     },
     {
       "title": "Microsoft Word for Windows 2007+",
+      "group": "Word Processing",
       "puid": "fmt/412",
       "extension": ".docx"
     },
     {
       "title": "Excel 97 Workbook",
+      "group": "Spreadsheet",
       "puid": "fmt/61"
     },
     {
       "title": "Excel for Windows 2007+",
+      "group": "Spreadsheet",
       "puid": "fmt/214",
       "extension": ".xlsx"
     },
     {
       "title": "RTF 1.7",
+      "group": "Word Processing",
       "puid": "fmt/52"
     },
     {
       "title": "Macro enabled Microsoft Word Document OOXML",
+      "group": "Word Processing",
       "puid": "fmt/523"
     },
     {
       "title": "JPEG 1.02",
+      "group": "Image (Raster)",
       "puid": "fmt/44"
     },
     {
       "title": "Exchangeable Image File Format (Compressed) 2.1",
+      "group": "Image (Raster)",
       "puid": "x-fmt/390"
     },
     {
       "title": "Acrobat PDF 1.3",
+      "group": "Portable Document Format",
       "puid": "fmt/17"
     },
     {
       "title": "JPEG 1.00",
+      "group": "Image (Raster)",
       "puid": "fmt/42"
     },
     {
       "title": "Powerpoint for Windows 2007+",
+      "group": "Presentation",
       "puid": "fmt/215",
       "extension": ".pptx"
     },
     {
       "title": "Hypertext Markup Language 4.0",
+      "group": "Text (Markup)",
       "puid": "fmt/99"
     },
     {
       "title": "RTF 1.5-1.6",
+      "group": "Word Processing",
       "puid": "fmt/50"
     },
     {
       "title": "1989a",
+      "group": "Image (Raster)",
       "puid": "fmt/4"
     },
     {
       "title": "TIFF",
+      "group": "Image (Raster)",
       "puid": "fmt/353",
       "extension": ".tif"
     },
     {
       "title": "Acrobat PDF 1.5",
+      "group": "Portable Document Format",
       "puid": "fmt/19"
     },
     {
       "title": "Acrobat PDF 1.6",
+      "group": "Portable Document Format",
       "puid": "fmt/20"
     },
     {
       "title": "Comma Separated Values",
+      "group": "Text (Plain)",
       "puid": "x-fmt/18",
       "extension": ".csv"
     },
     {
       "title": "ZIP file",
+      "group": "Package",
       "puid": "x-fmt/263",
       "extension": ".zip"
     },
     {
       "title": "Generic TXT",
+      "group": "Text (Plain)",
       "puid": "x-fmt/111",
       "extension": ".txt"
     }

--- a/app/report/format.html
+++ b/app/report/format.html
@@ -4,12 +4,14 @@
   <tr>
     <th><a ng-click="set_sort_property('format', 'format_sort_property', 'format_reverse')">Format</a></th>
     <th><a ng-click="set_sort_property('puid', 'format_sort_property', 'format_reverse')">PUID</a></th>
+    <th><a ng-click="set_sort_property('group', 'format_sort_property', 'format_reverse')">Group</a></th>
     <th><a ng-click="set_sort_property('count', 'format_sort_property', 'format_reverse')">Number of files</a></th>
     <th><a ng-click="set_sort_property('size', 'format_sort_property', 'format_reverse')">Size</a></th>
   </tr>
   <tr ng-repeat="record in records.selected | facet | puid_data | orderBy: format_sort_fn : format_reverse">
     <td><a ng-click="set_file_list(record)">{{ record.data.format }}</a></td>
     <td><a target="_blank" href="http://apps.nationalarchives.gov.uk/pronom/{{ record.puid }}">{{ record.puid }}</a></td>
+    <td>{{ record.data.group }}</td>
     <td><ng-pluralize count="record.data.count" when="{'1': '1 object', 'other': '{} objects'}"></ng-pluralize></td>
     <td>{{ record.data.size | number }} MB</td>
   </tr>

--- a/test/unit/aggregationFiltersSpec.js
+++ b/test/unit/aggregationFiltersSpec.js
@@ -9,6 +9,7 @@ describe('AggregationFilters', function() {
   var fmt_91_records = [{
     'id': '054a0f2c-79bb-4051-b82b-4b0f14564811',
     'title': 'lion.svg',
+    'format': 'Scalable Vector Graphics 1.0',
     'type': 'file',
     'puid': 'fmt/91',
     'size': 5,
@@ -17,6 +18,7 @@ describe('AggregationFilters', function() {
   }, {
     'id': '7f70d25c-be05-4950-a384-dac159926960',
     'title': 'rose_quartz.svg',
+    'format': 'Scalable Vector Graphics 1.0',
     'type': 'file',
     'puid': 'fmt/91',
     'size': 2,
@@ -26,6 +28,7 @@ describe('AggregationFilters', function() {
   var fmt_11_records = [{
     'id': '4e941898-3914-4add-b1f6-476580862069',
     'title': 'pearl.png',
+    'format': 'PNG 1.0',
     'type': 'file',
     'puid': 'fmt/11',
     'size': 13,
@@ -35,6 +38,7 @@ describe('AggregationFilters', function() {
   var record_with_no_logs = [{
     'id': 'b2a14653-5fd8-458c-b4ae-ccaab4b46b0c',
     'title': 'lapis_lazuli.tiff',
+    'format': 'TIFF for Image Technology (TIFF/IT)',
     'type': 'file',
     'puid': 'fmt/153',
     'size': 89,
@@ -69,10 +73,10 @@ describe('AggregationFilters', function() {
     var records = fmt_91_records.concat(fmt_11_records);
     var aggregate_data = puid_data(records);
     expect(aggregate_data.length).toEqual(2);
-    expect(aggregate_data[0].puid).toEqual('fmt/91');
-    expect(aggregate_data[0].data.count).toEqual(2);
-    expect(aggregate_data[1].puid).toEqual('fmt/11');
-    expect(aggregate_data[1].data.count).toEqual(1);
+    expect(aggregate_data[0].puid).toEqual('fmt/11');
+    expect(aggregate_data[0].data.count).toEqual(1);
+    expect(aggregate_data[1].puid).toEqual('fmt/91');
+    expect(aggregate_data[1].data.count).toEqual(2);
   });
 
   it('should filter lists of files to contain only files', function() {

--- a/test/unit/aggregationFiltersSpec.js
+++ b/test/unit/aggregationFiltersSpec.js
@@ -52,6 +52,7 @@ describe('AggregationFilters', function() {
 
   beforeEach(function() {
     module('aggregationFilters');
+    module('transferService');
 
     inject(function($injector) {
       puid_data = $injector.get('$filter')('puid_data');
@@ -60,6 +61,30 @@ describe('AggregationFilters', function() {
       tag_count = $injector.get('$filter')('tag_count');
     });
   });
+  beforeEach(angular.mock.inject(function(_$httpBackend_, Transfer) {
+    _$httpBackend_.when('GET', '/transfers.json').respond({
+      'formats': [
+        {
+          'title': 'Scalable Vector Graphics 1.0',
+          'group': 'Image (Vector)',
+          'puid': 'fmt/91',
+        },
+        {
+          'title': 'PNG 1.0',
+          'group': 'Image (Raster)',
+          'puid': 'fmt/11',
+        },
+        {
+          'title': 'TIFF for Image Technology (TIFF/IT)',
+          'group': 'Image (Raster)',
+          'puid': 'fmt/153',
+        },
+      ],
+      'transfers': transfers,
+    });
+    Transfer.resolve();
+    _$httpBackend_.flush();
+  }));
 
   it('should aggregate data about multiple files with the same format', function() {
     var aggregate_data = puid_data(fmt_91_records);
@@ -67,6 +92,7 @@ describe('AggregationFilters', function() {
     expect(aggregate_data[0].puid).toEqual('fmt/91');
     expect(aggregate_data[0].data.size).toEqual(7);
     expect(aggregate_data[0].data.count).toEqual(2);
+    expect(aggregate_data[0].data.group).toEqual('Image (Vector)');
   });
 
   it('should produce one entry for each PUID in the source records', function() {
@@ -75,8 +101,10 @@ describe('AggregationFilters', function() {
     expect(aggregate_data.length).toEqual(2);
     expect(aggregate_data[0].puid).toEqual('fmt/11');
     expect(aggregate_data[0].data.count).toEqual(1);
+    expect(aggregate_data[0].data.group).toEqual('Image (Raster)');
     expect(aggregate_data[1].puid).toEqual('fmt/91');
     expect(aggregate_data[1].data.count).toEqual(2);
+    expect(aggregate_data[1].data.group).toEqual('Image (Vector)');
   });
 
   it('should filter lists of files to contain only files', function() {

--- a/test/unit/aggregationFiltersSpec.js
+++ b/test/unit/aggregationFiltersSpec.js
@@ -8,40 +8,40 @@ describe('AggregationFilters', function() {
 
   var fmt_91_records = [{
     'id': '054a0f2c-79bb-4051-b82b-4b0f14564811',
-    'label': 'lion.svg',
+    'title': 'lion.svg',
     'type': 'file',
     'puid': 'fmt/91',
-    'size': '5',
-    'bulk_extractor': 'logs.zip',
+    'size': 5,
+    'bulk_extractor_reports': ['logs.zip'],
     'tags': [],
   }, {
     'id': '7f70d25c-be05-4950-a384-dac159926960',
-    'label': 'rose_quartz.svg',
+    'title': 'rose_quartz.svg',
     'type': 'file',
     'puid': 'fmt/91',
-    'size': '2',
-    'bulk_extractor': 'logs.zip',
+    'size': 2,
+    'bulk_extractor_reports': ['logs.zip'],
     'tags': ['test'],
   }];
   var fmt_11_records = [{
     'id': '4e941898-3914-4add-b1f6-476580862069',
-    'label': 'pearl.png',
+    'title': 'pearl.png',
     'type': 'file',
     'puid': 'fmt/11',
-    'size': '13',
-    'bulk_extractor': 'logs.zip',
+    'size': 13,
+    'bulk_extractor_reports': ['logs.zip'],
     'tags': ['test', 'test2'],
   }];
   var record_with_no_logs = [{
     'id': 'b2a14653-5fd8-458c-b4ae-ccaab4b46b0c',
-    'label': 'lapis_lazuli.tiff',
+    'title': 'lapis_lazuli.tiff',
     'type': 'file',
     'puid': 'fmt/153',
-    'size': '89',
+    'size': 89,
   }];
   var transfers = [{
     'id': 'fb91bf38-3836-4312-a928-699c564865da',
-    'label': 'garnet',
+    'title': 'garnet',
     'type': 'transfer',
     'original_order': '/fixtures/transferdata/fb91bf38-3836-4312-a928-699c564865da/directory_tree.txt',
   }];
@@ -79,7 +79,7 @@ describe('AggregationFilters', function() {
     var records = fmt_91_records.concat(fmt_11_records, transfers);
     var filtered_records = find_files(records);
     expect(filtered_records.length).toEqual(3);
-    expect(filtered_records[0].label).toEqual('lion.svg');
+    expect(filtered_records[0].title).toEqual('lion.svg');
   });
 
   it('should omit files with no bulk_extractor logs', function() {
@@ -87,14 +87,14 @@ describe('AggregationFilters', function() {
     expect(records.length).toEqual(3);
     var filtered_records = find_files(records);
     expect(filtered_records.length).toEqual(2);
-    expect(filtered_records[0].label).toEqual('lion.svg');
+    expect(filtered_records[0].title).toEqual('lion.svg');
   });
 
   it('should filter lists of files to contain only transfers', function() {
     var records = fmt_91_records.concat(fmt_11_records, transfers);
     var filtered_records = find_transfers(records);
     expect(filtered_records.length).toEqual(1);
-    expect(filtered_records[0].label).toEqual('garnet');
+    expect(filtered_records[0].title).toEqual('garnet');
   });
 
   it('should be able to aggregate tag acounts', function() {

--- a/test/unit/facetSpec.js
+++ b/test/unit/facetSpec.js
@@ -62,8 +62,8 @@ describe('Facet', function() {
   it('should return a unique ID for each newly-added value', inject(function(Facet) {
     var id1 = Facet.add('id', '1');
     var id2 = Facet.add('id', '2');
-    expect(id1).toNotBe(undefined);
-    expect(id1).toNotEqual(id2);
+    expect(id1).toBeDefined();
+    expect(id1).not.toEqual(id2);
   }));
 
   it('should allow a facet ID to be specified', inject(function(Facet) {


### PR DESCRIPTION
Display format groups in the formats table.  Add groups to the formats info in fixtures.  Should go in after #45 
