### PR TITLE
Analysis: Reports show all formats

### DIFF
--- a/app/filters/aggregation.filter.js
+++ b/app/filters/aggregation.filter.js
@@ -25,6 +25,7 @@
 
         format_data[record.format].count++;
         format_data[record.format].puid = record.puid || '';
+        format_data[record.format].format = record.format;
         format_data[record.format].group = format_info[0].group || 'Unknown';
         format_data[record.format].size += Number.parseFloat(record.size) || 0;
       }
@@ -54,7 +55,7 @@
          readable_name += ' (' + format_data.data.puid + ')';
         }
         data.data.push({
-          puid: format_data.data.puid,
+          format: format_data.format,
           x: readable_name,
           y: [format_data.data.count],
           tooltip: readable_name,
@@ -78,7 +79,7 @@
          readable_name += ' (' + format_data.data.puid + ')';
         }
         data.data.push({
-          puid: format_data.data.puid,
+          format: format_data.format,
           x: readable_name,
           y: [format_data.data.size],
           tooltip: readable_name + ', ' + $filter('number')(format_data.data.size) + ' MB',

--- a/app/report/format.html
+++ b/app/report/format.html
@@ -1,5 +1,4 @@
 <h2>File types</h2>
-<h3>By PUID</h3>
 <table class='table table-striped table-hover table-condensed'>
   <tr>
     <th><a ng-click="set_sort_property('format', 'format_sort_property', 'format_reverse')">Format</a></th>
@@ -8,9 +7,9 @@
     <th><a ng-click="set_sort_property('count', 'format_sort_property', 'format_reverse')">Number of files</a></th>
     <th><a ng-click="set_sort_property('size', 'format_sort_property', 'format_reverse')">Size</a></th>
   </tr>
-  <tr ng-repeat="record in records.selected | facet | puid_data | orderBy: format_sort_fn : format_reverse">
-    <td><a ng-click="set_file_list(record)">{{ record.data.format }}</a></td>
-    <td><a target="_blank" href="http://apps.nationalarchives.gov.uk/pronom/{{ record.puid }}">{{ record.puid }}</a></td>
+  <tr ng-repeat="record in records.selected | facet | format_data | orderBy: format_sort_fn : format_reverse">
+    <td><a ng-click="set_file_list(record)">{{ record.format }}</a></td>
+    <td><a target="_blank" href="http://apps.nationalarchives.gov.uk/pronom/{{ record.data.puid }}">{{ record.data.puid }}</a></td>
     <td>{{ record.data.group }}</td>
     <td><ng-pluralize count="record.data.count" when="{'1': '1 object', 'other': '{} objects'}"></ng-pluralize></td>
     <td>{{ record.data.size | number }} MB</td>

--- a/app/report/report.controller.js
+++ b/app/report/report.controller.js
@@ -38,9 +38,9 @@
     }
 
     $scope.set_file_list = function(record) {
-      var type = record.puid;
+      var type = record.format;
       FileList.files = SelectedFiles.selected.filter(function(file) {
-        return file.puid == type;
+        return file.format == type;
       });
     };
 

--- a/app/visualizations/formats_by_files.html
+++ b/app/visualizations/formats_by_files.html
@@ -1,1 +1,1 @@
-<div ac-chart="puid_chart_type" ac-data="records.selected | facet | puid_data | puid_graph" ac-config="puid_config" class="chart">
+<div ac-chart="format_chart_type" ac-data="records.selected | facet | format_data | format_graph" ac-config="format_config" class="chart">

--- a/app/visualizations/formats_by_size.html
+++ b/app/visualizations/formats_by_size.html
@@ -1,1 +1,1 @@
-<div ac-chart="size_chart_type" ac-data="records.selected | facet | puid_data | size_graph" ac-config="size_config" class="chart">
+<div ac-chart="size_chart_type" ac-data="records.selected | facet | format_data | size_graph" ac-config="size_config" class="chart">

--- a/app/visualizations/visualizations.controller.js
+++ b/app/visualizations/visualizations.controller.js
@@ -11,8 +11,8 @@
     // Displays aggregate information about file formats;
     // the selected record data is filtered/reformatted in the view.
     $scope.records = SelectedFiles;
-    $scope.puid_chart_type = 'pie';
-    $scope.puid_config = {
+    $scope.format_chart_type = 'pie';
+    $scope.format_config = {
       // Formats (total)
       click: function(d) {
         FileList.files = SelectedFiles.selected.filter(function (file) {

--- a/app/visualizations/visualizations.controller.js
+++ b/app/visualizations/visualizations.controller.js
@@ -16,7 +16,7 @@
       // Formats (total)
       click: function(d) {
         FileList.files = SelectedFiles.selected.filter(function (file) {
-          return file.puid === d.data.puid;
+          return file.format === d.data.format;
         });
       },
       tooltips: true,
@@ -33,7 +33,7 @@
       // Formats (by size)
       click: function(d) {
         FileList.files = SelectedFiles.selected.filter(function (file) {
-          return file.puid === d.data.puid;
+          return file.format === d.data.format;
         });
       },
       tooltips: true,

--- a/test/unit/aggregationFiltersSpec.js
+++ b/test/unit/aggregationFiltersSpec.js
@@ -106,22 +106,24 @@ describe('AggregationFilters', function() {
     var aggregate_data = format_data(fmt_91_records);
     expect(aggregate_data.length).toEqual(1);
     expect(aggregate_data[0].format).toEqual('Scalable Vector Graphics 1.0');
-    expect(aggregate_data[0].data.puid).toEqual('fmt/91');
+    expect(aggregate_data[0].data.format).toEqual('Scalable Vector Graphics 1.0');
     expect(aggregate_data[0].data.size).toEqual(7);
     expect(aggregate_data[0].data.count).toEqual(2);
     expect(aggregate_data[0].data.group).toEqual('Image (Vector)');
   });
 
-  it('should produce one entry for each PUID in the source records', function() {
+  it('should produce one entry for each format in the source records', function() {
     var records = fmt_91_records.concat(fmt_11_records);
     var aggregate_data = format_data(records);
     expect(aggregate_data.length).toEqual(2);
     expect(aggregate_data[0].format).toEqual('PNG 1.0');
     expect(aggregate_data[0].data.puid).toEqual('fmt/11');
+    expect(aggregate_data[0].data.format).toEqual('PNG 1.0');
     expect(aggregate_data[0].data.count).toEqual(1);
     expect(aggregate_data[0].data.group).toEqual('Image (Raster)');
     expect(aggregate_data[1].format).toEqual('Scalable Vector Graphics 1.0');
     expect(aggregate_data[1].data.puid).toEqual('fmt/91');
+    expect(aggregate_data[1].data.format).toEqual('Scalable Vector Graphics 1.0');
     expect(aggregate_data[1].data.count).toEqual(2);
     expect(aggregate_data[1].data.group).toEqual('Image (Vector)');
   });
@@ -131,6 +133,7 @@ describe('AggregationFilters', function() {
     expect(aggregate_data.length).toEqual(1);
     expect(aggregate_data[0].format).toEqual('Generic AIFF');
     expect(aggregate_data[0].data.puid).toEqual('');
+    expect(aggregate_data[0].data.format).toEqual('Generic AIFF');
     expect(aggregate_data[0].data.size).toEqual(34);
     expect(aggregate_data[0].data.count).toEqual(1);
     expect(aggregate_data[0].data.group).toEqual('Audio');

--- a/test/unit/aggregationFiltersSpec.js
+++ b/test/unit/aggregationFiltersSpec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 describe('AggregationFilters', function() {
-  var puid_data;
+  var format_data;
   var find_files;
   var find_transfers;
   var tag_count;
@@ -35,6 +35,17 @@ describe('AggregationFilters', function() {
     'bulk_extractor_reports': ['logs.zip'],
     'tags': ['test', 'test2'],
   }];
+  var no_fmt_record = [{
+    'id': 'dc08bcee-c4b9-490e-a98e-a884c4a9973c',
+    'title': 'pptC1.tmp',
+    'format': 'Generic AIFF',
+    'extension': '.aif',
+    'size': 34,
+    'bulk_extractor_reports': [],
+    'type': 'file',
+    'puid': '',
+    'tags': [],
+  }];
   var record_with_no_logs = [{
     'id': 'b2a14653-5fd8-458c-b4ae-ccaab4b46b0c',
     'title': 'lapis_lazuli.tiff',
@@ -55,7 +66,7 @@ describe('AggregationFilters', function() {
     module('transferService');
 
     inject(function($injector) {
-      puid_data = $injector.get('$filter')('puid_data');
+      format_data = $injector.get('$filter')('format_data');
       find_files = $injector.get('$filter')('find_files');
       find_transfers = $injector.get('$filter')('find_transfers');
       tag_count = $injector.get('$filter')('tag_count');
@@ -79,6 +90,11 @@ describe('AggregationFilters', function() {
           'group': 'Image (Raster)',
           'puid': 'fmt/153',
         },
+        {
+          'title': 'Generic AIFF',
+          'group': 'Audio',
+          'puid': '',
+        },
       ],
       'transfers': transfers,
     });
@@ -87,9 +103,10 @@ describe('AggregationFilters', function() {
   }));
 
   it('should aggregate data about multiple files with the same format', function() {
-    var aggregate_data = puid_data(fmt_91_records);
+    var aggregate_data = format_data(fmt_91_records);
     expect(aggregate_data.length).toEqual(1);
-    expect(aggregate_data[0].puid).toEqual('fmt/91');
+    expect(aggregate_data[0].format).toEqual('Scalable Vector Graphics 1.0');
+    expect(aggregate_data[0].data.puid).toEqual('fmt/91');
     expect(aggregate_data[0].data.size).toEqual(7);
     expect(aggregate_data[0].data.count).toEqual(2);
     expect(aggregate_data[0].data.group).toEqual('Image (Vector)');
@@ -97,14 +114,26 @@ describe('AggregationFilters', function() {
 
   it('should produce one entry for each PUID in the source records', function() {
     var records = fmt_91_records.concat(fmt_11_records);
-    var aggregate_data = puid_data(records);
+    var aggregate_data = format_data(records);
     expect(aggregate_data.length).toEqual(2);
-    expect(aggregate_data[0].puid).toEqual('fmt/11');
+    expect(aggregate_data[0].format).toEqual('PNG 1.0');
+    expect(aggregate_data[0].data.puid).toEqual('fmt/11');
     expect(aggregate_data[0].data.count).toEqual(1);
     expect(aggregate_data[0].data.group).toEqual('Image (Raster)');
-    expect(aggregate_data[1].puid).toEqual('fmt/91');
+    expect(aggregate_data[1].format).toEqual('Scalable Vector Graphics 1.0');
+    expect(aggregate_data[1].data.puid).toEqual('fmt/91');
     expect(aggregate_data[1].data.count).toEqual(2);
     expect(aggregate_data[1].data.group).toEqual('Image (Vector)');
+  });
+
+  it('should aggregate data about files with no PUID', function() {
+    var aggregate_data = format_data(no_fmt_record);
+    expect(aggregate_data.length).toEqual(1);
+    expect(aggregate_data[0].format).toEqual('Generic AIFF');
+    expect(aggregate_data[0].data.puid).toEqual('');
+    expect(aggregate_data[0].data.size).toEqual(34);
+    expect(aggregate_data[0].data.count).toEqual(1);
+    expect(aggregate_data[0].data.group).toEqual('Audio');
   });
 
   it('should filter lists of files to contain only files', function() {


### PR DESCRIPTION
Make format table & charts display info from all formats instead of just those with a PUID. Rename filters accordingly.

We originally wanted to have PUID & mimetype & ...? tables for formats, to display diff info.  Since we haven't really done that, I thought the existing format tables/graphs should display all format info.

Thoughts?
