### PR TITLE
Examine contents: fix setting all_selected using checklist

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -93,12 +93,14 @@ config(['$routeSegmentProvider', function($routeSegmentProvider) {
     segment('examine_contents', {
       templateUrl: 'examine_contents/examine_contents.html',
       controller: 'ExamineContentsController',
+      controllerAs: 'vm',
       dependencies: ['type'],
     }).
     within().
       segment('file_info', {
         templateUrl: 'examine_contents/file_info.html',
         controller: 'ExamineContentsFileController',
+        controllerAs: 'vm',
         dependencies: ['id', 'type'],
       }).
     up().

--- a/app/checklist/checklist.directive.js
+++ b/app/checklist/checklist.directive.js
@@ -9,16 +9,17 @@
       link: function($scope, element, attrs) {
         var get_record = $parse(attrs.ngModel);
         var get_selected = $parse(attrs.selectedList);
+        var get_all_selected = $parse(attrs.allSelected);
         var set_all_selected = $parse(attrs.allSelected).assign;
         var get_record_count = $parse(attrs.recordCount);
 
         element.attr('type', 'checkbox');
 
         element.bind('click', function() {
-          var selected = get_selected($scope.$parent.$parent);
+          var selected = get_selected($scope);
           var record = get_record($scope);
 
-          var index = $scope.selected.indexOf(record.id);
+          var index = selected.indexOf(record.id);
           $scope.$apply(function() {
             // remove from selection
             if (index > -1) {
@@ -27,7 +28,7 @@
               selected.push(record.id);
             }
 
-            set_all_selected($scope.$parent.$parent, !(selected.length < get_record_count($scope)));
+            set_all_selected($scope, !(selected.length < get_record_count($scope)));
           });
         });
       },

--- a/app/examine_contents/examine_contents.controller.js
+++ b/app/examine_contents/examine_contents.controller.js
@@ -3,27 +3,29 @@
 (function() {
   angular.module('examineContentsController', []).
 
-  controller('ExamineContentsController', ['$scope', '$routeSegment', 'FileList', 'SelectedFiles', 'Tag', function($scope, $routeSegment, FileList, SelectedFiles, Tag) {
-    $scope.$routeSegment = $routeSegment;
-    $scope.type = $routeSegment.$routeParams.type;
-    $scope.SelectedFiles = SelectedFiles;
+  controller('ExamineContentsController', ['$routeSegment', 'FileList', 'SelectedFiles', 'Tag', function($routeSegment, FileList, SelectedFiles, Tag) {
+    var vm = this;
 
-    $scope.selected = [];
-    $scope.all_selected = false;
+    vm.$routeSegment = $routeSegment;
+    vm.type = $routeSegment.$routeParams.type;
+    vm.SelectedFiles = SelectedFiles;
 
-    $scope.select_all = function(files) {
-      if (!$scope.all_selected) {
-        $scope.selected = files.map(function(file) {
+    vm.selected = [];
+    vm.all_selected = false;
+
+    vm.select_all = function(files) {
+      if (!vm.all_selected) {
+        vm.selected = files.map(function(file) {
           return file.id;
         });
-        $scope.all_selected = true;
+        vm.all_selected = true;
       } else {
-        $scope.selected = [];
-        $scope.all_selected = false;
+        vm.selected = [];
+        vm.all_selected = false;
       }
     };
 
-    $scope.submit = function(ids) {
+    vm.submit = function(ids) {
       var tag = this.tag;
       if (!tag) {
         return;
@@ -33,18 +35,20 @@
       this.tag = '';
     };
 
-    $scope.add_to_file_list = function(ids) {
+    vm.add_to_file_list = function(ids) {
       FileList.files = SelectedFiles.selected.filter(function(file) {
         return ids.indexOf(file.id) > -1;
       });
     };
   }]).
 
-  controller('ExamineContentsFileController', ['$scope', '$routeSegment', 'File', function($scope, $routeSegment, File) {
-    $scope.id = $routeSegment.$routeParams.id;
-    $scope.type = $routeSegment.$routeParams.type;
-    File.bulk_extractor_info($scope.id).then(function(data) {
-      $scope.file = data;
+  controller('ExamineContentsFileController', ['$routeSegment', 'File', function($routeSegment, File) {
+    var vm = this;
+
+    vm.id = $routeSegment.$routeParams.id;
+    vm.type = $routeSegment.$routeParams.type;
+    File.bulk_extractor_info(vm.id).then(function(data) {
+      vm.file = data;
     });
   }]);
 })();

--- a/app/examine_contents/examine_contents.html
+++ b/app/examine_contents/examine_contents.html
@@ -1,34 +1,34 @@
 <ul class="nav nav-pills">
-  <li ng-class="{ active: type === 'pii' }">
-    <a href="#{{ $routeSegment.getSegmentUrl('examine_contents', {type: 'pii'}) }}">PII</a>
+  <li ng-class="{ active: vm.type === 'pii' }">
+    <a href="#{{ vm.$routeSegment.getSegmentUrl('examine_contents', {type: 'pii'}) }}">PII</a>
   </li>
-  <li ng-class="{ active: type === 'ccn' }">
-    <a href="#{{ $routeSegment.getSegmentUrl('examine_contents', {type: 'ccn'}) }}">Credit card numbers</a>
+  <li ng-class="{ active: vm.type === 'ccn' }">
+    <a href="#{{ vm.$routeSegment.getSegmentUrl('examine_contents', {type: 'ccn'}) }}">Credit card numbers</a>
   </li>
 </ul>
 
-<div ng-if='type'>
-  <h2 ng-if="(SelectedFiles.selected | find_transfers).length != 0">Transfers:</h2>
+<div ng-if='vm.type'>
+  <h2 ng-if="(vm.SelectedFiles.selected | find_transfers).length != 0">Transfers:</h2>
   <ul>
-    <li ng-repeat="record in SelectedFiles.selected | find_transfers">
+    <li ng-repeat="record in vm.SelectedFiles.selected | find_transfers">
     {{ record.title }}:
       <a ng-if="record.original_order" href="{{ record.original_order }}">original order</a>
       <a ng-if="!record.original_order" class="disabled">original order</a>
     </li>
   </ul>
-  <p ng-if='(SelectedFiles.selected | find_transfers).length == 0'>No information found for selected Transfers.</p>
+  <p ng-if='(vm.SelectedFiles.selected | find_transfers).length == 0'>No information found for selected Transfers.</p>
 
-  <div ng-if="(SelectedFiles.selected | find_files).length != 0">
+  <div ng-if="(vm.SelectedFiles.selected | find_files).length != 0">
   <h2>Files</h2>
 
-  <form ng-submit="submit(selected)">
+  <form ng-submit="vm.submit(selected)">
     <input type="text"
            ng-model="tag"
-           ng-disabled="selected.length < 1">
+           ng-disabled="vm.selected.length < 1">
     <input type="submit"
            id="submit-tag"
            value="Add tag to checked files"
-           ng-disabled="selected.length < 1"
+           ng-disabled="vm.selected.length < 1"
            class='btn btn-sm btn-default'>
   </form>
 
@@ -40,28 +40,28 @@
         <input type="checkbox"
                name="checked_files[]"
                value="Select all"
-               ng-checked="all_selected"
-               ng-click="select_all((SelectedFiles.selected | find_files | filter:{bulk_extractor_reports: type}))">
+               ng-checked="vm.all_selected"
+               ng-click="vm.select_all((vm.SelectedFiles.selected | find_files | filter:{bulk_extractor_reports: vm.type}))">
       </th>
       <th>Filename</th>
       <th>Preview</th>
       <th>Bulk Extractor Logs</th>
     </tr>
-    <tr ng-repeat="record in SelectedFiles.selected | find_files | filter:{bulk_extractor_reports: type}">
+    <tr ng-repeat="record in vm.SelectedFiles.selected | find_files | filter:{bulk_extractor_reports: vm.type}">
       <td>
         <input checklist
              name="checked_files[]"
              ng-model="record"
-             ng-checked="selected.indexOf(record.id) > -1"
-             record-count="(SelectedFiles.selected | find_files | filter:{bulk_extractor_reports: type}).length"
-             selected-list="selected"
-             all-selected="all_selected">
+             ng-checked="vm.selected.indexOf(record.id) > -1"
+             record-count="(vm.SelectedFiles.selected | find_files | filter:{bulk_extractor_reports: vm.type}).length"
+             selected-list="vm.selected"
+             all-selected="vm.all_selected">
       </td>
       <td>
-        <a href="#{{ $routeSegment.getSegmentUrl('examine_contents.file_info', {id: record.id, type: type}) }}">{{ record.title }}</a>
+        <a href="#{{ vm.$routeSegment.getSegmentUrl('examine_contents.file_info', {id: record.id, type: vm.type}) }}">{{ record.title }}</a>
       </td>
       <td>
-        <a href="#{{ $routeSegment.getSegmentUrl('preview', {id: record.id}) }}">Preview</a>
+        <a href="#{{ vm.$routeSegment.getSegmentUrl('preview', {id: record.id}) }}">Preview</a>
       </td>
       <td>
         <a ng-if="record.bulk_extractor" href="{{ record.bulk_extractor}}">Bulk Extractor logs</a>
@@ -70,7 +70,7 @@
   </table>
   </div>
 
-  <p ng-if='(SelectedFiles.selected | find_files).length == 0'>No information found for selected files.</p>
+  <p ng-if='(vm.SelectedFiles.selected | find_files).length == 0'>No information found for selected files.</p>
 
   <div app-view-segment="1"></div>
 </div>

--- a/app/examine_contents/examine_contents.html
+++ b/app/examine_contents/examine_contents.html
@@ -53,7 +53,7 @@
              name="checked_files[]"
              ng-model="record"
              ng-checked="selected.indexOf(record.id) > -1"
-             record-count="SelectedFiles.selected.length"
+             record-count="(SelectedFiles.selected | find_files | filter:{bulk_extractor_reports: type}).length"
              selected-list="selected"
              all-selected="all_selected">
       </td>

--- a/app/examine_contents/file_info.html
+++ b/app/examine_contents/file_info.html
@@ -1,9 +1,9 @@
-<table class='table table-striped table-hover table-condensed' ng-if="file[type].length > 0">
+<table class='table table-striped table-hover table-condensed' ng-if="vm.file[vm.type].length > 0">
   <tr>
     <th>Content</th>
     <th>Context</th>
   </tr>
-  <tr ng-repeat="feature in file[type]">
+  <tr ng-repeat="feature in vm.file[vm.type]">
     <td>{{ feature.content }}</td>
     <td>{{ feature.context }}</td>
   </tr>

--- a/app/file_list/file_list.controller.js
+++ b/app/file_list/file_list.controller.js
@@ -4,33 +4,35 @@
   angular.module('fileListController', ['fileListService']).
 
   controller('FileListController', ['$scope', '$routeSegment', 'FileList', 'Tag', function($scope, $routeSegment, FileList, Tag) {
-    $scope.$routeSegment = $routeSegment;
-    $scope.file_list = FileList;
-    $scope.remove_tag = function(id, tag) {
+    var vm = this;
+
+    vm.$routeSegment = $routeSegment;
+    vm.file_list = FileList;
+    vm.remove_tag = function(id, tag) {
       Tag.remove(id, tag);
     };
 
     $scope.$watch('file_list.files', function() {
-      $scope.selected = [];
-      $scope.all_selected = false;
+      vm.selected = [];
+      vm.all_selected = false;
     });
 
-    $scope.selected = [];
-    $scope.all_selected = false;
+    vm.selected = [];
+    vm.all_selected = false;
 
-    $scope.select_all = function() {
-      if (!$scope.all_selected) {
-        $scope.selected = FileList.files.map(function(file) {
+    vm.select_all = function() {
+      if (!vm.all_selected) {
+        vm.selected = FileList.files.map(function(file) {
           return file.id;
         });
-        $scope.all_selected = true;
+        vm.all_selected = true;
       } else {
-        $scope.selected = [];
-        $scope.all_selected = false;
+        vm.selected = [];
+        vm.all_selected = false;
       }
     };
 
-    $scope.submit = function(uuids) {
+    vm.submit = function(uuids) {
       var tag = this.tag;
       if (!tag) {
         return;
@@ -41,19 +43,19 @@
     };
 
     // Sorting related
-    $scope.sort_property = 'title';
-    $scope.sort_reverse = false;
+    vm.sort_property = 'title';
+    vm.sort_reverse = false;
 
-    $scope.set_sort_property = function(property) {
-      if ($scope.sort_property === property) {
-        $scope.sort_reverse = !$scope.sort_reverse;
+    vm.set_sort_property = function(property) {
+      if (vm.sort_property === property) {
+        vm.sort_reverse = !vm.sort_reverse;
       } else {
-        $scope.sort_reverse = false;
-        $scope.sort_property = property;
+        vm.sort_reverse = false;
+        vm.sort_property = property;
       }
     };
 
-    $scope.date_regex = '\\d\\d\\d\\d([-\/]\\d\\d?)?([-\/]\\d\\d?)?';
+    vm.date_regex = '\\d\\d\\d\\d([-\/]\\d\\d?)?([-\/]\\d\\d?)?';
 
     var format_date = function(start, end) {
       var s;
@@ -80,18 +82,18 @@
     var default_filter = function() {
       return true;
     };
-    $scope.facet_filter = default_filter;
+    vm.facet_filter = default_filter;
 
-    $scope.reset_dates = function() {
-      $scope.date_facet = '';
-      $scope.facet_filter = default_filter;
+    vm.reset_dates = function() {
+      vm.date_facet = '';
+      vm.facet_filter = default_filter;
     }
 
-    $scope.set_date_filter = function(start_date, end_date) {
+    vm.set_date_filter = function(start_date, end_date) {
       // Remove the facet immediately, so that the facet is updated if a user
       // enters an invalid date
-      $scope.date_facet = '';
-      $scope.facet_filter = default_filter;
+      vm.date_facet = '';
+      vm.facet_filter = default_filter;
       if (!start_date && !end_date) {
         return;
       }
@@ -106,8 +108,8 @@
         return;
       }
 
-      $scope.date_facet = format_date(start_date, end_date);
-      $scope.facet_filter = function(date) {
+      vm.date_facet = format_date(start_date, end_date);
+      vm.facet_filter = function(date) {
         if (date === undefined) {
           return true;
         }

--- a/app/index.html
+++ b/app/index.html
@@ -151,34 +151,34 @@
       <div class='panel-heading'>
         File List
       </div>
-      <div class='panel-body' ng-controller="FileListController">
-        <div ng-if="file_list.files.length > 0">
+      <div class='panel-body' ng-controller="FileListController as vm">
+        <div ng-if="vm.file_list.files.length > 0">
           <fieldset>
             <label for='start-date-facet'>Date range start</label>
             <input type="text"
-                   ng-model="date_start"
+                   ng-model="vm.date_start"
                    class='form-control'
                    id='start-date-facet'
-                   ng-change="set_date_filter(date_start, date_end)"
-                   ng-pattern="date_regex"/>
+                   ng-change="vm.set_date_filter(vm.date_start, vm.date_end)"
+                   ng-pattern="vm.date_regex"/>
             <label for='end-date-facet'>Date range end</label>
             <input type="text"
-                   ng-model="date_end"
+                   ng-model="vm.date_end"
                    class='form-control'
                    id='end-date-facet'
-                   ng-change="set_date_filter(date_start, date_end)"
-                   ng-pattern="date_regex"/>
+                   ng-change="vm.set_date_filter(vm.date_start, vm.date_end)"
+                   ng-pattern="vm.date_regex"/>
           </fieldset>
-          <span ng-if="date_facet">Dates: {{ date_facet }} <span ng-click="reset_dates();"><i class="fa fa-times"></i></span></span>
+          <span ng-if="vm.date_facet">Dates: {{ vm.date_facet }} <span ng-click="vm.reset_dates();"><i class="fa fa-times"></i></span></span>
 
-          <form ng-submit="submit(selected)">
+          <form ng-submit="vm.submit(vm.selected)">
             <input type="text"
                    ng-model="tag"
-                   ng-disabled="selected.length < 1">
+                   ng-disabled="vm.selected.length < 1">
             <input type="submit"
                    id="submit-tag"
                    value="Add tag to selected files"
-                   ng-disabled="selected.length < 1"
+                   ng-disabled="vm.selected.length < 1"
                    class='btn btn-sm btn-default'>
           </form>
 
@@ -188,27 +188,27 @@
               <input type="checkbox"
                      name="checked_files[]"
                      value="Select all"
-                     ng-checked="all_selected"
-                     ng-click="select_all()">
+                     ng-checked="vm.all_selected"
+                     ng-click="vm.select_all()">
             </th>
-            <th><a ng-click="set_sort_property('title')">Filename</a></th>
-            <th><a ng-click="set_sort_property('size')">Size</a></th>
-            <th><a ng-click="set_sort_property('last_modified')">Last modified</a></th>
+            <th><a ng-click="vm.set_sort_property('title')">Filename</a></th>
+            <th><a ng-click="vm.set_sort_property('size')">Size</a></th>
+            <th><a ng-click="vm.set_sort_property('last_modified')">Last modified</a></th>
             <th>Tags</th>
-            <th><i class="fa fa-minus-square" ng-click="file_list.clear()"></i></th>
+            <th><i class="fa fa-minus-square" ng-click="vm.file_list.clear()"></i></th>
           </tr>
-          <tr ng-repeat="file in file_list.files | filter: {'date': '*'} : facet_filter | orderBy: sort_property : sort_reverse">
+          <tr ng-repeat="file in vm.file_list.files | filter: {'date': '*'} : vm.facet_filter | orderBy: vm.sort_property : vm.sort_reverse">
             <td>
               <input checklist
                    name="checked_files[]"
                    ng-model="file"
-                   ng-checked="selected.indexOf(file.id) > -1"
-                   record-count="file_list.files.length"
-                   selected-list="selected"
-                   all-selected="all_selected">
+                   ng-checked="vm.selected.indexOf(file.id) > -1"
+                   record-count="vm.file_list.files.length"
+                   selected-list="vm.selected"
+                   all-selected="vm.all_selected">
             </td>
             <td>
-              <a href="#{{ $routeSegment.getSegmentUrl('preview', {id: file.id}) }}">{{ file.title }}</a>
+              <a href="#{{ vm.$routeSegment.getSegmentUrl('preview', {id: file.id}) }}">{{ file.title }}</a>
             </td>
             <td>{{ file.size | number}} MB</td>
             <td>{{ file.last_modified }}</td>
@@ -216,12 +216,12 @@
               <span class="tag" ng-repeat="tag in file.tags">{{ tag }} <span ng-click="remove_tag(file.id, tag)"><i class="fa fa-minus-square"></i></span></span>
             </td>
             <td>
-              <i class="fa fa-minus-square" ng-click="file_list.remove(file.id)"></i>
+              <i class="fa fa-minus-square" ng-click="vm.file_list.remove(file.id)"></i>
             </td>
           </tr>
           </table>
         </div>
-        <p ng-if="file_list.files.length === 0">File list is empty.</p>
+        <p ng-if="vm.file_list.files.length === 0">File list is empty.</p>
       </div>
     </div>
   </ui-minimize-panel>


### PR DESCRIPTION
An incorrect all-records-length was being passed to the checklist, causing the checklist to fail to update the `all_selected` binding. It was counting all records, not the filtered subset of records from which the table is built.

Fixes #53.
