### PR TITLE
Send files to file list by format group

### DIFF
--- a/app/filters/aggregation.filter.js
+++ b/app/filters/aggregation.filter.js
@@ -9,7 +9,7 @@
 
   angular.module('aggregationFilters', []).
 
-  filter('format_data', ['Transfer', function(Transfer) {
+  filter('format_data', function() {
     var format_data_fn = function(records) {
       var format_data = {};
       for (var i in records) {
@@ -21,12 +21,11 @@
         if (!format_data[record.format]) {
           format_data[record.format] = {count: 0, size: 0};
         }
-        var format_info = Transfer.formats.filter(function (f) { return f.title === record.format; });
 
         format_data[record.format].count++;
         format_data[record.format].puid = record.puid || '';
         format_data[record.format].format = record.format;
-        format_data[record.format].group = format_info[0].group || 'Unknown';
+        format_data[record.format].group = record.group;
         format_data[record.format].size += Number.parseFloat(record.size) || 0;
       }
 
@@ -41,7 +40,7 @@
     };
 
     return _.memoize(format_data_fn, hash_fn);
-  }]).
+  }).
 
   filter('format_graph', function() {
     var format_graph_fn = function(records) {

--- a/app/fixtures/transfers.json
+++ b/app/fixtures/transfers.json
@@ -221,13 +221,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 34.27294921875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "fba05cf5-5eb2-4051-b7ce-4db43c97f9fc",
@@ -235,13 +232,10 @@
                   "format": "Windows BItmap 3.0",
                   "puid": "fmt/116",
                   "size": 8.077878952026367,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Image (Raster)"
                 },
                 {
                   "id": "fd54a7dd-6d40-4257-9be5-13df0b3e9a09",
@@ -249,13 +243,10 @@
                   "format": "JPEG 1.01",
                   "puid": "fmt/43",
                   "size": 0.32271575927734375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Image (Raster)"
                 },
                 {
                   "id": "b1ed33b9-ba6b-41e0-9063-00099f809d57",
@@ -263,13 +254,10 @@
                   "format": "Windows BItmap 3.0",
                   "puid": "fmt/116",
                   "size": 4.162527084350586,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Image (Raster)"
                 },
                 {
                   "id": "7c7af5e8-0b61-4490-a30d-cb414d1b7303",
@@ -277,13 +265,10 @@
                   "format": "JPEG 1.01",
                   "puid": "fmt/43",
                   "size": 0.15170955657958984,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Image (Raster)"
                 },
                 {
                   "id": "e2f8e0fe-8620-4814-abc0-e50dfd7872de",
@@ -295,9 +280,8 @@
                     "ccn"
                   ],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Image (Raster)"
                 },
                 {
                   "id": "980c54d1-b4f2-41c9-b0f2-5556512f26ed",
@@ -305,13 +289,10 @@
                   "format": "JPEG 1.01",
                   "puid": "fmt/43",
                   "size": 0.3149404525756836,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Image (Raster)"
                 },
                 {
                   "id": "cb5ab84e-52d0-473c-896b-c380cc41fb05",
@@ -319,13 +300,10 @@
                   "format": "Windows BItmap 3.0",
                   "puid": "fmt/116",
                   "size": 5.125577926635742,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Image (Raster)"
                 },
                 {
                   "id": "3b80e783-3ad3-4fca-9c66-d5cae4b649bd",
@@ -333,13 +311,10 @@
                   "format": "Windows BItmap 3.0",
                   "puid": "fmt/116",
                   "size": 5.125577926635742,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Image (Raster)"
                 },
                 {
                   "id": "404a4e1f-abb5-4d14-86cd-6f2f9ea72189",
@@ -351,9 +326,8 @@
                     "ccn"
                   ],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Image (Raster)"
                 },
                 {
                   "id": "0d09569d-e6e3-4207-94dd-3c9cbd5a153f",
@@ -361,13 +335,10 @@
                   "format": "JPEG 1.01",
                   "puid": "fmt/43",
                   "size": 0.3166322708129883,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Image (Raster)"
                 },
                 {
                   "id": "939a1545-91ee-484b-9d87-af3b61b13758",
@@ -375,13 +346,10 @@
                   "format": "Windows BItmap 3.0",
                   "puid": "fmt/116",
                   "size": 1.299734115600586,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Image (Raster)"
                 },
                 {
                   "id": "594719c0-b8d6-4dc6-9fa9-3e03154d5e90",
@@ -389,13 +357,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 1.625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "e72a068d-c634-4194-8910-ba474d001427",
@@ -403,13 +368,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 34.27294921875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "dc08bcee-c4b9-490e-a98e-a884c4a9973c",
@@ -417,24 +379,17 @@
                   "format": "Generic AIFF",
                   "extension": ".aif",
                   "size": 34.27294921875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
                   "puid": "",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Audio"
                 }
               ],
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "directory",
               "puid": "",
-              "tags": [
-
-              ]
+              "tags": []
             },
             {
               "id": "c7d10d01-a6e6-4942-9d5e-6b7022308536",
@@ -452,23 +407,16 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 2.423828125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 }
               ],
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "directory",
               "puid": "",
-              "tags": [
-
-              ]
+              "tags": []
             },
             {
               "id": "24732795-8715-452a-9309-5cae7da81dfb",
@@ -498,13 +446,10 @@
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
                       "size": 0.08105278015136719,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "497d3903-a7d2-4645-8033-14842ff7725f",
@@ -512,13 +457,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8009662628173828,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "be9f817f-c17d-4475-b735-2bd898bce100",
@@ -526,13 +468,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.814112663269043,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "7ff32b8d-bd5e-4aaf-83bb-42d86a0feafd",
@@ -540,13 +479,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7834558486938477,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "132c18e8-a1fa-4f01-b1ca-469e037d06f5",
@@ -554,13 +490,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.781224250793457,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "f7985dea-9e3f-428e-933a-0f410bc70c06",
@@ -568,13 +501,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7889175415039062,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "e3407b7a-9fdc-4e2f-b976-2a0140a7df62",
@@ -582,13 +512,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7830429077148438,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "761d4f12-6cee-4c99-b8c8-49ba5728357e",
@@ -596,13 +523,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7952718734741211,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "3eb7a763-a55c-4149-af48-84d8ad0755d0",
@@ -610,13 +534,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8044652938842773,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "05e38971-f835-4828-b643-f74396a073b7",
@@ -624,13 +545,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8060264587402344,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "20961c83-a976-4bed-909d-41fe82938325",
@@ -638,13 +556,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8330612182617188,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "50928d0f-7855-4775-82d7-f5b9db3654cc",
@@ -652,13 +567,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7969169616699219,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "ebb8345f-80e8-45d3-8470-338c66931f5c",
@@ -666,13 +578,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7953319549560547,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "5c14dc3f-93ed-4bd7-b234-ec4e8299cd1c",
@@ -680,13 +589,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7913856506347656,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "7cbd68c0-a33c-4987-aedd-2af406fd69c3",
@@ -694,13 +600,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7980022430419922,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "e56b9643-24db-4adf-85ca-cdde977abfb0",
@@ -708,13 +611,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.755314826965332,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "2e31051c-965c-4b91-b882-0cc23d939d17",
@@ -722,13 +622,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7527074813842773,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "d476f3a5-1071-44c3-87ba-eb2bed302492",
@@ -736,13 +633,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7618980407714844,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "22397de5-7ff3-4c65-8e00-d02123df2cdc",
@@ -750,13 +644,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7491569519042969,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "de8c868d-9f68-43f6-a104-31b225095714",
@@ -764,13 +655,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8187351226806641,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "a9dea238-a58c-4e47-bb4d-20cd4e968daf",
@@ -778,13 +666,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7689790725708008,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "d7822633-b99e-40c2-a789-f9ff4bed50b4",
@@ -792,13 +677,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.747706413269043,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "76b49be6-2ef0-40a6-afcd-55e037324ffd",
@@ -806,13 +688,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8688259124755859,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "e3abf244-378b-42f5-9bb0-52de529aadb6",
@@ -820,13 +699,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7807531356811523,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "5596a7cc-1152-4c4e-9242-6af68f959970",
@@ -834,13 +710,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7750053405761719,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "8483d5f9-d52f-453f-a728-fd4532f1124f",
@@ -848,13 +721,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7576465606689453,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "a5c6d5ff-1a07-497a-b1e2-cb3818a191aa",
@@ -862,13 +732,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8059453964233398,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "65fecb74-0db3-425b-81be-756a28b65333",
@@ -876,13 +743,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7613468170166016,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "c04d9251-771a-49ee-8f81-4da082779d34",
@@ -890,13 +754,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.782597541809082,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "dc76634e-8f65-4f32-9002-7877b2e7bc82",
@@ -904,13 +765,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8213558197021484,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "5b6e53ac-cf5c-4317-869e-f2e5d53b15df",
@@ -918,13 +776,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7818355560302734,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "84e9b639-4e73-4251-a199-eba0e0175b70",
@@ -932,13 +787,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.763340950012207,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "785efffc-ab11-43b3-84ae-f529e6a5bc0e",
@@ -946,13 +798,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8000144958496094,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "f79b20ae-8afe-4a97-b5cd-7f3fc44e917a",
@@ -960,13 +809,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.772007942199707,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "cc87baf1-ca3c-4ec5-890f-f8d78b300b9f",
@@ -974,13 +820,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.793736457824707,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "157988d8-da8b-42e3-b27b-da3cd84c5036",
@@ -988,13 +831,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7690486907958984,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "0142ab23-7ad4-4e4d-a40a-f727f2e8b9c1",
@@ -1002,13 +842,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7751045227050781,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "f3501517-d363-435f-a5de-b2d6374ce4f3",
@@ -1016,13 +853,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7689371109008789,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "88192250-59c0-4f9d-b21f-05102e8b36b1",
@@ -1030,13 +864,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7914190292358398,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "0793f544-83b5-49cc-8862-3d0b8fcde3d8",
@@ -1044,13 +875,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7871770858764648,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "1f63a706-cf3e-4a8d-8569-5092e6edc2c4",
@@ -1058,13 +886,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8139705657958984,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "f5bed50d-ec8b-4bc5-8f78-08bd81db830f",
@@ -1072,13 +897,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7992067337036133,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "0d650bbc-c323-429c-9720-74262580d356",
@@ -1086,13 +908,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7871217727661133,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "9d970656-204e-4536-85c5-e6fbbc859082",
@@ -1100,13 +919,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7658786773681641,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "461668df-7cab-44ca-a530-dbc82216b478",
@@ -1114,13 +930,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7848920822143555,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "f756d45f-c4fe-4181-b7d4-932edb79c0b0",
@@ -1128,13 +941,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7803659439086914,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "a0cf623f-11b8-43c0-bc55-8039fed63465",
@@ -1142,13 +952,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7725648880004883,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "24e38fd3-4e53-48c1-84cc-a4c36cc1fa53",
@@ -1156,13 +963,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8094930648803711,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "d40562b8-160e-45b2-a722-4c0a66b6757d",
@@ -1170,13 +974,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7844257354736328,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "88a5bb2e-f97e-4ab5-aed5-cebbdd8a956e",
@@ -1184,13 +985,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7758417129516602,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "9b77a50f-21bd-4b1e-9bc8-bc7401efb524",
@@ -1198,13 +996,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8068809509277344,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "faaae401-3b69-4529-bf01-ead46223e9da",
@@ -1212,13 +1007,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8430023193359375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "7197e739-68ef-4475-b4ff-b0b380da4f83",
@@ -1226,13 +1018,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7767734527587891,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "cb5503b7-b8e7-422f-bd71-b8a18cc87908",
@@ -1240,13 +1029,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8145170211791992,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "f43e7a56-c3a0-4d75-9ccb-68884d226b5c",
@@ -1254,13 +1040,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7862424850463867,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "68083f0f-b8a6-4f42-9511-bc56d6bb82fb",
@@ -1268,13 +1051,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7979192733764648,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "f97697b1-4f9f-4ff9-a458-56467c85f884",
@@ -1282,13 +1062,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7981901168823242,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "30c43413-e0aa-418c-b0c4-42a7c86afda2",
@@ -1296,13 +1073,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7796869277954102,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "dd34d12d-b14b-417c-977d-7b136f1e755e",
@@ -1310,13 +1084,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.765960693359375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "8397474d-5c4b-440f-9121-2c5650003aec",
@@ -1324,13 +1095,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8168249130249023,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "48c5e31d-8c51-4708-a6ef-cd6e4c78d609",
@@ -1338,13 +1106,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8315887451171875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "501f0542-c4e1-48c2-b2ed-1fe8a1da198a",
@@ -1352,13 +1117,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7961263656616211,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "3672bbea-ac24-464a-849f-3fcc2ba167dd",
@@ -1366,13 +1128,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8884744644165039,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "99de286e-324c-4e88-964f-75c6c8c84d60",
@@ -1380,13 +1139,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8134365081787109,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "2eb3b488-b691-4f99-bf96-97d4acaa054f",
@@ -1394,13 +1150,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7922048568725586,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "efc67149-fbad-440a-b2fe-4319feec5d55",
@@ -1408,13 +1161,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7921237945556641,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "c6d3e75b-a371-4d2f-a79f-1e79c592a140",
@@ -1422,13 +1172,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7933330535888672,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "70f65deb-9e7a-4f92-a99c-0fdf294f7fdd",
@@ -1436,13 +1183,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8035268783569336,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "f54243ae-a4f5-4ac6-8202-30d30a91261c",
@@ -1450,13 +1194,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8170976638793945,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "ab51e1b5-fccd-4b6e-b3f1-b88f9251b07a",
@@ -1464,13 +1205,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.800572395324707,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "6d906217-6458-439d-b739-9d6f6ed5de1a",
@@ -1478,13 +1216,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7927703857421875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "25826c3f-6644-4560-ad1d-90d63d16b977",
@@ -1492,13 +1227,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8036422729492188,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "d3c0df7e-7e21-4a2f-8347-7b7d34144551",
@@ -1506,13 +1238,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8312406539916992,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "b3e2ab77-273e-412b-8c02-6807f12f8ae9",
@@ -1520,13 +1249,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8409929275512695,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "060bda3a-654c-4f72-ac8e-16aaddf4a7e1",
@@ -1534,13 +1260,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8118019104003906,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "c23823a9-42c4-4546-aeb6-1507a38b9236",
@@ -1548,13 +1271,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8356647491455078,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "be421136-a8dd-457d-9537-3e8154647824",
@@ -1562,13 +1282,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7507753372192383,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "77ef26ef-a5e5-49b2-a7fb-0742c5f848b2",
@@ -1576,13 +1293,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7954301834106445,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "5b80a6a3-e73a-4366-b130-287aa002f237",
@@ -1590,13 +1304,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7864618301391602,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "7c090df9-afbc-4ebd-9832-ef8da3d44c04",
@@ -1604,13 +1315,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7706813812255859,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "6d72b786-4718-4d80-a50a-9286ec23c628",
@@ -1618,13 +1326,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.9040975570678711,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "0e0f4919-f21e-49db-8f91-44bad02fb9e7",
@@ -1632,13 +1337,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8049325942993164,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "940238cc-aa0c-441a-8a41-35364728e429",
@@ -1646,13 +1348,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8940935134887695,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "a5a04280-8846-4c91-9a3f-135cacd737b5",
@@ -1660,13 +1359,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7748327255249023,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "086be05e-e97c-402e-b5f8-901142fade2f",
@@ -1674,13 +1370,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.828333854675293,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "1fb3558a-ae76-4149-af0d-eec945782861",
@@ -1688,13 +1381,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8012609481811523,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "14b07096-9ea6-48a7-a2e5-271aed872474",
@@ -1702,33 +1392,22 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.8071603775024414,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     }
                   ],
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "directory",
                   "puid": "",
-                  "tags": [
-
-                  ]
+                  "tags": []
                 }
               ],
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "directory",
               "puid": "",
-              "tags": [
-
-              ]
+              "tags": []
             },
             {
               "id": "8168bac8-ae50-4914-a515-b778518ab675",
@@ -1748,13 +1427,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.04345703125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "6e6000f2-bb3c-4e1f-900f-b5366a6c6770",
@@ -1762,13 +1438,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.01318359375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "7c1e12e1-740a-4cdb-9b6a-c66a4d0d425f",
@@ -1776,13 +1449,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.01708984375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "6f4b530e-6a43-4631-8784-ef5bedfbfa76",
@@ -1790,23 +1460,16 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.02978515625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 }
               ],
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "directory",
               "puid": "",
-              "tags": [
-
-              ]
+              "tags": []
             },
             {
               "id": "6136fc85-4d42-45bc-affd-5f521c1db4ee",
@@ -1828,13 +1491,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.0517578125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "17454352-a46e-4515-84ca-067da09d3615",
@@ -1842,13 +1502,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.02490234375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "7b8c218c-e209-491b-91b2-1b24887a823f",
@@ -1856,13 +1513,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.033203125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "81f6924c-40df-4ce5-9511-d8c73da3f8e4",
@@ -1870,13 +1524,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.02734375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "3039bd86-cb4a-4897-b273-93b4a3980434",
@@ -1884,13 +1535,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.03466796875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "2508bef1-0161-4505-b0bc-0769b99a44e2",
@@ -1898,13 +1546,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 8.13134765625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "3e88bdf3-eb30-4789-9682-30d208971048",
@@ -1912,13 +1557,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.033203125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "032b31d6-5850-4fd7-8cbd-7367b0553a1a",
@@ -1926,13 +1568,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 7.2451171875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "6dd14b4a-e174-439f-a13a-629a0ec14956",
@@ -1940,13 +1579,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 11.59326171875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "b64fef12-3e74-4f15-ae77-d77c308fface",
@@ -1954,13 +1590,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 3.40283203125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "2d421c3a-c412-4f5c-93c6-a24c88b707f2",
@@ -1968,13 +1601,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 1.287109375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "938b88fd-83d3-4be6-aa32-71a19b74a0b1",
@@ -1982,13 +1612,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.19482421875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "f057bc7a-5805-4a67-8ca2-3821c0707449",
@@ -1996,13 +1623,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.0205078125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "88468acc-c3ef-480f-8172-c396f5d70649",
@@ -2010,13 +1634,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.04833984375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "58092af3-d330-42ff-87c9-9792f2cd0b09",
@@ -2024,13 +1645,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.04541015625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "540b03c1-d170-4846-9139-7b51b540107d",
@@ -2038,13 +1656,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.01904296875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "1a9fca5e-dc8a-43eb-84b4-c4fa24a59797",
@@ -2052,13 +1667,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.0341796875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "5edd8fe9-0dd3-4ce0-a3ca-b0cd7b459481",
@@ -2066,13 +1678,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.0263671875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "e6121271-2e44-4d6b-8c8b-c7157b942e19",
@@ -2080,13 +1689,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.02001953125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "9a847fe6-33cc-4f8c-81fd-9c42619744ac",
@@ -2094,13 +1700,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.0615234375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "dafc2bc7-2081-4882-8763-2cce2ae59f4b",
@@ -2108,13 +1711,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.025390625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "b839983f-3b05-4ae3-8831-d4b0f012b76b",
@@ -2122,13 +1722,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.03662109375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "557195d2-7554-4581-9957-e00278d3af2e",
@@ -2136,13 +1733,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.037109375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "25fbad5c-1043-4539-a9b7-1600c1bfbc7c",
@@ -2150,13 +1744,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.03125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "6f196df8-8612-40be-9882-e15a8ac6aec5",
@@ -2164,23 +1755,16 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.0390625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 }
               ],
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "directory",
               "puid": "",
-              "tags": [
-
-              ]
+              "tags": []
             },
             {
               "id": "a9d7da66-e504-4b9a-ad02-63efeaaaaef6",
@@ -2218,13 +1802,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.021484375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "16d6595e-4675-4e5a-9d10-06c317e602cd",
@@ -2232,13 +1813,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.03125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "48712dd2-bb58-4716-80ad-e8e839afe59b",
@@ -2246,13 +1824,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.03466796875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "1dd6fb3c-5bb5-4610-b8e6-9cabb580c24f",
@@ -2260,13 +1835,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.03857421875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "cdf81782-ec5a-4ded-bd2a-074a011fd53f",
@@ -2274,23 +1846,16 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.056640625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     }
                   ],
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "directory",
                   "puid": "",
-                  "tags": [
-
-                  ]
+                  "tags": []
                 },
                 {
                   "id": "117e99f6-c8f3-4380-87ce-65709d9da571",
@@ -2331,13 +1896,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.0283203125,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "6da5567a-a26f-4aa3-8712-e8cb91c99ee0",
@@ -2345,13 +1907,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.03173828125,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "228cd181-73ab-4abd-a951-cb526816581c",
@@ -2359,13 +1918,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.0263671875,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "561fe044-c4d3-49f1-ac2b-9a48c9750715",
@@ -2373,13 +1929,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.02197265625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "bce0b0e4-3226-43f2-ac93-9bb1bbb50368",
@@ -2387,13 +1940,10 @@
                           "format": "Exchangeable Image File Format (Compressed) 2.2",
                           "puid": "x-fmt/391",
                           "size": 0.18732166290283203,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Image (Raster)"
                         },
                         {
                           "id": "86489154-8ac4-4c70-893e-7217d90581fe",
@@ -2401,13 +1951,10 @@
                           "format": "Exchangeable Image File Format (Compressed) 2.2",
                           "puid": "x-fmt/391",
                           "size": 0.3082914352416992,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Image (Raster)"
                         },
                         {
                           "id": "adee224e-683d-40a9-8d40-dca105407d92",
@@ -2415,13 +1962,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.02978515625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "996feff5-173c-4b68-84d3-93ea53f214c3",
@@ -2429,13 +1973,10 @@
                           "format": "RTF 1.7",
                           "puid": "fmt/52",
                           "size": 0.026185989379882812,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "75ea4441-a3ba-4c66-aec9-30c1a2f81a34",
@@ -2443,13 +1984,10 @@
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
                           "size": 0.03125,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Spreadsheet"
                         },
                         {
                           "id": "7fcc13da-e5d2-47d1-9917-e1914c8f83cc",
@@ -2457,13 +1995,10 @@
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
                           "size": 0.03125,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Spreadsheet"
                         },
                         {
                           "id": "14a87165-ba8b-4642-af58-a78941518598",
@@ -2471,13 +2006,10 @@
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
                           "size": 0.02880859375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Spreadsheet"
                         },
                         {
                           "id": "69443f0e-6891-4b77-afbe-69714d4b9c05",
@@ -2485,13 +2017,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.02978515625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "dbb284aa-48d1-40de-9d5c-f73bf2a61619",
@@ -2499,13 +2028,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.0263671875,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "f60a55aa-dd28-42f9-a9e6-f4ef552d7090",
@@ -2513,13 +2039,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.03369140625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "f7e605d7-5302-424e-9c69-864c6bd7dc9a",
@@ -2527,13 +2050,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.201171875,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "d2d8260f-1a38-40e2-9ca5-d4d376f28f9b",
@@ -2541,23 +2061,16 @@
                           "format": "Macro enabled Microsoft Word Document OOXML",
                           "puid": "fmt/523",
                           "size": 0.09428215026855469,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         }
                       ],
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "directory",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "22ca959a-b4da-42ae-aed4-4de86ba3c7b1",
@@ -2578,13 +2091,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.0283203125,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "d9c5a5ee-6d48-4449-ba27-d012ba7b8351",
@@ -2592,13 +2102,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.02099609375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "adaf98fb-8b4e-4f1c-8cf3-18026cd192ed",
@@ -2606,13 +2113,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.02197265625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "c796e845-7cf5-493d-a369-00e580bc7f3b",
@@ -2620,13 +2124,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.021484375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "cde87da1-3981-45ce-9e64-a6272bc150a1",
@@ -2634,13 +2135,10 @@
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
                           "size": 0.0283203125,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Spreadsheet"
                         },
                         {
                           "id": "9e20a2fe-18cc-4d1e-a2f4-430feae7ab46",
@@ -2648,13 +2146,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.02099609375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "04579e84-0073-450a-b551-5f97e5302733",
@@ -2662,13 +2157,10 @@
                           "format": "RTF 1.7",
                           "puid": "fmt/52",
                           "size": 0.02553844451904297,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "e60ef089-94e8-4261-9a50-33d5a9ca35dc",
@@ -2676,13 +2168,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.021484375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "f546db3f-e04e-40db-9b3e-fd226ebf6e2d",
@@ -2690,13 +2179,10 @@
                           "format": "RTF 1.7",
                           "puid": "fmt/52",
                           "size": 0.029611587524414062,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "f1345d7c-3f39-470f-b945-da091d8b5f84",
@@ -2704,13 +2190,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.02197265625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "d33bb877-b513-46ce-91a8-02f4c52441ed",
@@ -2718,13 +2201,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.0224609375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "00a94dd2-4a7e-43dc-ab38-ca2601b4eafe",
@@ -2732,13 +2212,10 @@
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
                           "size": 0.02001953125,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Spreadsheet"
                         },
                         {
                           "id": "cf1d1a63-b7e9-4498-8e92-7804bc144c44",
@@ -2746,13 +2223,10 @@
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
                           "size": 0.02001953125,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Spreadsheet"
                         },
                         {
                           "id": "995878a4-48e2-4685-bfe1-254aaeb04132",
@@ -2760,13 +2234,10 @@
                           "format": "RTF 1.7",
                           "puid": "fmt/52",
                           "size": 0.09092235565185547,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "741b89ad-afcf-4e78-bbf4-d3445d973b94",
@@ -2774,13 +2245,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.03662109375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "0d6d11f5-cb26-45ad-85ef-a42f81c9de60",
@@ -2788,13 +2256,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.0283203125,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "ed5e4a1e-f8f6-4511-98e3-87e19d99f6a2",
@@ -2802,13 +2267,10 @@
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
                           "size": 0.0146484375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Spreadsheet"
                         },
                         {
                           "id": "af96037d-13ec-4e8c-8087-64a06e186c96",
@@ -2816,13 +2278,10 @@
                           "format": "RTF 1.7",
                           "puid": "fmt/52",
                           "size": 0.024362564086914062,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "cdf0d9a1-8e9c-4a2f-bed0-cdf8897053cb",
@@ -2830,13 +2289,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.02587890625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "6f8389e8-5af4-40f1-9dbc-e7db0ffdf548",
@@ -2855,13 +2311,10 @@
                               "format": "Microsoft Word Document 97-2003",
                               "puid": "fmt/40",
                               "size": 0.02197265625,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Word Processing"
                             },
                             {
                               "id": "9892f551-2d10-416c-a2a8-2a03035ae93a",
@@ -2869,13 +2322,10 @@
                               "format": "Microsoft Word Document 97-2003",
                               "puid": "fmt/40",
                               "size": 0.021484375,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Word Processing"
                             },
                             {
                               "id": "6e5234ab-1901-46b8-883e-75cef99cc59a",
@@ -2883,13 +2333,10 @@
                               "format": "RTF 1.7",
                               "puid": "fmt/52",
                               "size": 0.021958351135253906,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Word Processing"
                             },
                             {
                               "id": "5ff22c6b-8d8d-4135-912d-49cf93f2c0f0",
@@ -2897,13 +2344,10 @@
                               "format": "RTF 1.7",
                               "puid": "fmt/52",
                               "size": 0.027553558349609375,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Word Processing"
                             },
                             {
                               "id": "b80d9661-332a-4c3e-be8d-35fafc56fff3",
@@ -2911,13 +2355,10 @@
                               "format": "Microsoft Word Document 97-2003",
                               "puid": "fmt/40",
                               "size": 0.02197265625,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Word Processing"
                             },
                             {
                               "id": "6196dc90-41fd-4494-ad51-b8c9fa96851f",
@@ -2925,13 +2366,10 @@
                               "format": "RTF 1.7",
                               "puid": "fmt/52",
                               "size": 0.09070301055908203,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Word Processing"
                             },
                             {
                               "id": "cb810a02-00de-40dc-bdfc-67ef868752ee",
@@ -2939,13 +2377,10 @@
                               "format": "RTF 1.7",
                               "puid": "fmt/52",
                               "size": 0.019263267517089844,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Word Processing"
                             },
                             {
                               "id": "a8edcb1d-611d-4d94-99f1-958b347123a2",
@@ -2953,33 +2388,22 @@
                               "format": "Microsoft Word Document 97-2003",
                               "puid": "fmt/40",
                               "size": 0.02587890625,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Word Processing"
                             }
                           ],
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "directory",
                           "puid": "",
-                          "tags": [
-
-                          ]
+                          "tags": []
                         }
                       ],
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "directory",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "06a98817-da21-46be-8062-b24d213a84df",
@@ -2998,13 +2422,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.033203125,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "8d4d91aa-316f-472f-b966-e701def05a08",
@@ -3012,13 +2433,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.02783203125,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "12630596-c19e-45d8-84ac-f9b1ea4f2c3d",
@@ -3026,13 +2444,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.09228515625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "43144f4f-3301-465f-91b8-5c90b152a5ba",
@@ -3040,13 +2455,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.07666015625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "b389f053-a87d-418b-bac2-8b864775ef97",
@@ -3054,13 +2466,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.02978515625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "c1a8777c-3e8a-4e60-b9c4-6b39a1e3d864",
@@ -3068,13 +2477,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.0458984375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "abb2c7fd-7192-4005-942a-e9970e44bb0e",
@@ -3082,13 +2488,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.166015625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "963b83eb-5e78-4d49-bad7-a4275b23f5fb",
@@ -3096,13 +2499,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.02490234375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "2a3a96f2-0398-4197-b39e-d9de872c5a0c",
@@ -3110,13 +2510,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.0283203125,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "5cff93c5-9534-4019-abb2-450e54177333",
@@ -3124,13 +2521,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.03369140625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "b31461ec-3baf-4f20-b557-8f973aeb9d77",
@@ -3138,13 +2532,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.03662109375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "ee10e602-11a6-4e09-bbca-87b7a643c179",
@@ -3152,13 +2543,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.02587890625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "8aa7103c-f139-4a47-af80-da9254c0dd7c",
@@ -3166,13 +2554,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.0302734375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "27f24a9f-7937-4b6b-9e19-119f592e53f1",
@@ -3180,13 +2565,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.0244140625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "3a9792fe-8538-4c0e-aade-86dc5e19d3b9",
@@ -3194,13 +2576,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.03076171875,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "e997cc16-a01e-4ce0-aff2-093f36b99055",
@@ -3208,13 +2587,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.03564453125,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "20676ce4-29f2-42cf-81df-2e19cf5cb3ab",
@@ -3222,13 +2598,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.0400390625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "493fb126-0d9b-4d78-a579-8d45f74792ee",
@@ -3236,13 +2609,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.025390625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "be9e0242-3434-4c06-b4bb-55d1e09304c5",
@@ -3250,13 +2620,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.0244140625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "ccf7d3eb-28f0-4701-b314-2c5ed4e024b3",
@@ -3264,13 +2631,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.0322265625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "825d1146-1f8a-4039-9371-598b1fefcabc",
@@ -3278,13 +2642,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.0322265625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "7fa523ad-dbef-4b56-9735-1f9d909240e2",
@@ -3303,14 +2664,11 @@
                               "format": "Generic AIFF",
                               "extension": ".aif",
                               "size": 0.076171875,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
                               "puid": "",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Audio"
                             },
                             {
                               "id": "395842f5-a575-45c7-abc0-dce0781139a7",
@@ -3318,43 +2676,28 @@
                               "format": "Microsoft Word Document 97-2003",
                               "puid": "fmt/40",
                               "size": 0.0419921875,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Word Processing"
                             }
                           ],
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "directory",
                           "puid": "",
-                          "tags": [
-
-                          ]
+                          "tags": []
                         }
                       ],
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "directory",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     }
                   ],
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "directory",
                   "puid": "",
-                  "tags": [
-
-                  ]
+                  "tags": []
                 },
                 {
                   "id": "9d66bd11-d039-4463-95f1-0f899e418f07",
@@ -3392,13 +2735,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.029296875,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "b5542de6-a0bd-42f6-afb5-452b536f368e",
@@ -3406,13 +2746,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.0302734375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "a6186720-5430-462a-a28b-eb53e7276512",
@@ -3420,13 +2757,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.029296875,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "a448c397-795a-455b-9cb5-e68c8a3ac677",
@@ -3434,13 +2768,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.2744140625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "ae2a1475-940f-41c2-a66b-224a05e401a0",
@@ -3448,13 +2779,10 @@
                           "format": "Powerpoint 97-2002",
                           "puid": "fmt/126",
                           "size": 0.52001953125,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Presentation"
                         },
                         {
                           "id": "8ce1a0d8-8feb-4956-8458-36fb8cb7db72",
@@ -3462,13 +2790,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.08056640625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "edaf7a5a-6cc2-494d-a816-7841e1d9057d",
@@ -3476,13 +2801,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.02685546875,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "05fc75fd-6f60-4534-903d-fd4c446c4d0b",
@@ -3490,13 +2812,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.04833984375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "1bdff87b-9632-444f-b909-50b0063f277e",
@@ -3504,13 +2823,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.037109375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "f48dc0ac-3596-4f5a-915d-925c3d978b13",
@@ -3518,13 +2834,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.04248046875,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "89ddb9ea-36cf-45b6-8a0a-690a5e918abf",
@@ -3532,13 +2845,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.03076171875,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "eca4896c-f745-47a1-8262-1ac29168b15b",
@@ -3546,13 +2856,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.04638671875,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "86144a4a-8602-4d3e-97de-5cf38a2d7b0e",
@@ -3560,13 +2867,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.0810546875,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "4d30eaf2-055e-4f73-bc64-74233e73aa7f",
@@ -3574,13 +2878,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.02001953125,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "d1fd867a-fda7-45d2-a8ed-f4f44b825f9e",
@@ -3588,13 +2889,10 @@
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
                           "size": 0.4102621078491211,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Image (Raster)"
                         },
                         {
                           "id": "db28ed82-029d-4c43-9b1d-fa11829a9f24",
@@ -3602,13 +2900,10 @@
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
                           "size": 0.2659187316894531,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Image (Raster)"
                         },
                         {
                           "id": "63dc34fe-9a1e-4a4f-906c-6ab6a4b34631",
@@ -3616,13 +2911,10 @@
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
                           "size": 0.3942089080810547,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Image (Raster)"
                         },
                         {
                           "id": "df9e5388-5a0a-49f7-9aee-531f7ccdc7e9",
@@ -3630,13 +2922,10 @@
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
                           "size": 0.3028888702392578,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Image (Raster)"
                         },
                         {
                           "id": "b2ac4479-96a1-4faf-b0b7-e32bd65a1dc9",
@@ -3644,13 +2933,10 @@
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
                           "size": 0.2250232696533203,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Image (Raster)"
                         },
                         {
                           "id": "7735175b-a3ae-4c16-a9af-7a55367f0f84",
@@ -3658,13 +2944,10 @@
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
                           "size": 0.2515392303466797,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Image (Raster)"
                         },
                         {
                           "id": "d4a3ae3a-8a27-4bef-b324-956fe5df8282",
@@ -3672,13 +2955,10 @@
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
                           "size": 0.3233680725097656,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Image (Raster)"
                         },
                         {
                           "id": "0b106727-712c-46b8-8dce-55cab5518280",
@@ -3686,23 +2966,16 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.041015625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         }
                       ],
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "directory",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "f9b9190e-42be-4b98-bbe5-c78711a861b8",
@@ -3722,13 +2995,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.025390625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "a51a71cf-6887-4691-b7d0-945598df2fd5",
@@ -3736,13 +3006,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.03759765625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "1af5ea2f-e411-4f3e-b3e9-d7603ad21e3c",
@@ -3750,13 +3017,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.02685546875,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "45e19805-ebd5-4ce8-b7c5-60bf2f1f545f",
@@ -3764,13 +3028,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.0400390625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "39f93859-661a-4ae8-8a00-7be3e81ff16d",
@@ -3778,13 +3039,10 @@
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
                           "size": 0.0166015625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Spreadsheet"
                         },
                         {
                           "id": "1e2d3c50-e569-46bd-94b4-6be3040136ec",
@@ -3792,13 +3050,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.04052734375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "06d8687e-4e78-4324-adbc-06f6d996ada6",
@@ -3806,13 +3061,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.03759765625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "d207dcf6-3612-4898-9ba0-523b49ffd49f",
@@ -3820,13 +3072,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.02392578125,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "189584fd-3b38-49fb-b9dd-d32abfa3c207",
@@ -3834,23 +3083,16 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.02294921875,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         }
                       ],
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "directory",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "5554ab06-6e32-410c-b543-cb9202f97f98",
@@ -3868,13 +3110,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.02587890625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "43cf44c1-ccce-4e4f-87fe-88fc3c85debd",
@@ -3882,13 +3121,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.02294921875,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "dd25b8c3-bc2f-4aea-ad99-d8dc4057f087",
@@ -3896,13 +3132,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.02294921875,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "b6d83d7b-b24b-475e-af9f-9e2311f6df08",
@@ -3910,13 +3143,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.23486328125,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "59768f7f-f592-4211-84d6-48298ac409d5",
@@ -3924,23 +3154,16 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.04443359375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         }
                       ],
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "directory",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "4332f40c-5b43-4192-ae9d-ec4396019b88",
@@ -3958,13 +3181,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.03076171875,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "ee571b4f-2563-43fd-9268-247e1ce735ab",
@@ -3972,13 +3192,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.0263671875,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "ae7960a5-bf2b-4246-a665-de5e864e9b13",
@@ -3986,33 +3203,22 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.0283203125,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         }
                       ],
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "directory",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     }
                   ],
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "directory",
                   "puid": "",
-                  "tags": [
-
-                  ]
+                  "tags": []
                 },
                 {
                   "id": "941a7160-8063-43bc-bf64-d50d8de6f703",
@@ -4032,13 +3238,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02001953125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "77e60beb-4896-4f3b-9cf2-36f307136d27",
@@ -4046,13 +3249,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.63134765625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "f0ae0d82-42c0-457a-b8d5-2328521bfe4e",
@@ -4060,13 +3260,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.0302734375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "fbc9698f-0f15-40d8-8206-c92ffb9ac87d",
@@ -4074,13 +3271,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.08203125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "30b58a1d-8c9e-4fd0-9695-099c5b6717ec",
@@ -4088,33 +3282,22 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0224609375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     }
                   ],
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "directory",
                   "puid": "",
-                  "tags": [
-
-                  ]
+                  "tags": []
                 }
               ],
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "directory",
               "puid": "",
-              "tags": [
-
-              ]
+              "tags": []
             },
             {
               "id": "6fa231c1-68ee-40c1-aae0-8e9230541c25",
@@ -4147,13 +3330,10 @@
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
                       "size": 0.09985733032226562,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "b8a1356e-4563-4a66-b952-099e03de6f18",
@@ -4161,13 +3341,10 @@
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
                       "size": 2.651556968688965,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "31335337-5557-4658-bc84-45dde970ae17",
@@ -4175,13 +3352,10 @@
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
                       "size": 3.1488656997680664,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "4cf9172c-d9e1-4a69-ae76-ab05fe9bd425",
@@ -4189,13 +3363,10 @@
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
                       "size": 0.08105278015136719,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "03ca0930-3e51-4f69-a2df-1e598132c380",
@@ -4203,13 +3374,10 @@
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
                       "size": 0.06903934478759766,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "5518d947-40cd-4999-b320-06c0a41c21be",
@@ -4217,13 +3385,10 @@
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
                       "size": 2.8761367797851562,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "68862e72-c8bc-4c44-a216-7cc527b7a3fc",
@@ -4231,13 +3396,10 @@
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
                       "size": 2.986827850341797,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "84cea3d5-9142-4a66-8880-cff5ddf0deb1",
@@ -4245,13 +3407,10 @@
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
                       "size": 2.8685474395751953,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "e8268c00-579d-4c51-aa31-bc8e2c052917",
@@ -4259,13 +3418,10 @@
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
                       "size": 2.816020965576172,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "7b38982a-d607-42f1-b5ec-0ec5401cc98d",
@@ -4273,13 +3429,10 @@
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
                       "size": 2.466215133666992,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "cda74914-1572-429c-af65-7aa061e64b75",
@@ -4287,13 +3440,10 @@
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
                       "size": 2.4286623001098633,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "962a887a-9bea-4dd0-b66b-e20a6b1c02bf",
@@ -4301,23 +3451,16 @@
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
                       "size": 0.03153800964355469,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     }
                   ],
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "directory",
                   "puid": "",
-                  "tags": [
-
-                  ]
+                  "tags": []
                 },
                 {
                   "id": "ace7177e-c8b7-4c11-aa88-5fb16c28f6b5",
@@ -4335,13 +3478,10 @@
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
                       "size": 0.06311321258544922,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "456f0ea8-b7f7-4b1d-ab87-f86a3b9ff248",
@@ -4349,13 +3489,10 @@
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
                       "size": 0.19769001007080078,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "eef8eae4-6f9a-444f-a3d7-13a1d136a191",
@@ -4363,23 +3500,16 @@
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
                       "size": 0.07115650177001953,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     }
                   ],
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "directory",
                   "puid": "",
-                  "tags": [
-
-                  ]
+                  "tags": []
                 },
                 {
                   "id": "f87d69f8-df46-4753-bbfa-751c8d8c9a9a",
@@ -4401,13 +3531,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.26255130767822266,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "7128291d-2bda-467a-baba-5fe7498c9730",
@@ -4415,13 +3542,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.1508474349975586,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "426826a7-5ba2-4fc9-b184-88325d148138",
@@ -4429,13 +3553,10 @@
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
                       "size": 1.6122140884399414,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "eb2fd7d9-8615-4461-a9d0-717a09f1248a",
@@ -4443,14 +3564,11 @@
                       "format": "Generic AIFF",
                       "extension": ".aif",
                       "size": 1.546875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Audio"
                     },
                     {
                       "id": "1a075e38-9446-43c3-bc64-c9bbf01bb838",
@@ -4458,13 +3576,10 @@
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
                       "size": 1.310537338256836,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "e9f590c8-8f11-43cc-8cc8-f71d799061c9",
@@ -4472,39 +3587,28 @@
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
                       "size": 0.4252357482910156,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "4a0a06e8-5576-4d25-aa84-d97b22ad204d",
                       "title": "DI-00337-033.JPG",
                       "size": 1.6778106689453125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "99ec6d3c-a1a3-4f08-b300-18c024aaf310",
                       "title": "DI-00337-034.JPG",
                       "size": 1.690093994140625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "7d26fa73-8417-42fb-856c-07a7e0841ccc",
@@ -4512,13 +3616,10 @@
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
                       "size": 0.45624446868896484,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "dd1f2850-f5b5-4ec5-ae45-9772a62883a9",
@@ -4526,13 +3627,10 @@
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
                       "size": 0.4790630340576172,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "bc521ce2-291c-4271-a77b-177997e706ac",
@@ -4540,13 +3638,10 @@
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
                       "size": 0.46386051177978516,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "a6467b12-dc28-4435-808a-cac2ae1085c8",
@@ -4554,13 +3649,10 @@
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
                       "size": 0.3663969039916992,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "3926c73e-8c1b-496c-9037-593c7d069630",
@@ -4568,13 +3660,10 @@
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
                       "size": 0.32360172271728516,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "5f7348ac-8244-49c0-abbe-76a485d37271",
@@ -4582,13 +3671,10 @@
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
                       "size": 0.34370899200439453,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "37b59115-4ecd-4d72-be12-9541be2abcb2",
@@ -4596,13 +3682,10 @@
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
                       "size": 0.41729068756103516,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "0b5d130f-1aa1-40a8-9a78-8f2a55adcd07",
@@ -4610,13 +3693,10 @@
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
                       "size": 0.44594573974609375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "524bc610-82d8-4e58-ae87-a9953bca8141",
@@ -4624,13 +3704,10 @@
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
                       "size": 0.43531322479248047,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "cd8cd995-90df-4989-9dd4-a3ddb02ffd40",
@@ -4638,13 +3715,10 @@
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
                       "size": 0.4439363479614258,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "13f743fc-465c-4566-b981-eb9efb0d02d1",
@@ -4652,117 +3726,82 @@
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
                       "size": 0.4545326232910156,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "f97d556c-6b14-4324-8903-79773b043695",
                       "title": "DSC-0020.JPG",
                       "size": 2.4220075607299805,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "d930552a-e387-4a64-baee-3bf94c633fa1",
                       "title": "DSC-0026.JPG",
                       "size": 2.373368263244629,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "bb66cc1d-71f1-4c46-ab4e-d196f74d8d6d",
                       "title": "DSC-0027.JPG",
                       "size": 2.2718429565429688,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "bd2cf859-def3-41d7-bde5-0bb283158284",
                       "title": "DSC-0029.JPG",
                       "size": 2.2628393173217773,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "7b18e227-cc5e-49ac-9bd6-f48dfc47c772",
                       "title": "DSC-0031.JPG",
                       "size": 2.668882369995117,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "589286bf-eb5a-4175-bd90-eb04ab021b75",
                       "title": "DSC-0041.JPG",
                       "size": 2.673015594482422,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "482db1d6-50b8-468d-aa3f-05b206de7daa",
                       "title": "DSC-0071.JPG",
                       "size": 2.633615493774414,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "ba9754f5-bd67-4a93-9fd0-76885de30112",
                       "title": "DSC-0076.JPG",
                       "size": 2.455699920654297,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "18353b0c-0d2b-46be-89bb-a05c7935dde1",
@@ -4770,39 +3809,28 @@
                       "format": "JPEG 1.02",
                       "puid": "fmt/44",
                       "size": 3.08640193939209,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "1186c3f5-a462-4634-818e-ae096f84702a",
                       "title": "DSC-0083.JPG",
                       "size": 2.7744016647338867,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "832bd4a8-c51f-4ca2-b855-04c4651ca66a",
                       "title": "DSC-0084.JPG",
                       "size": 2.270421028137207,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "679bb192-689d-44b8-a7da-46249d82d768",
@@ -4810,13 +3838,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.1",
                       "puid": "x-fmt/390",
                       "size": 0.2032642364501953,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "036b6dc6-b6ff-4232-87c7-dcaf4d4e5d90",
@@ -4824,13 +3849,10 @@
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
                       "size": 1.377579689025879,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "6610e54d-2c50-4056-8030-791d79408078",
@@ -4838,13 +3860,10 @@
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
                       "size": 1.6088199615478516,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "baa58485-7efc-48e4-b919-27f8e6421d81",
@@ -4852,221 +3871,154 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.14389705657958984,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "f17bab8f-4293-4255-baf3-c32d56c48601",
                       "title": "IMG-5274-fix.jpg",
                       "size": 0.1832447052001953,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "f140c613-848e-40bf-925f-6dcd98c31f48",
                       "title": "IMG-5274.jpg",
                       "size": 0.13155460357666016,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "c46b50a5-40d4-48e6-b6bc-97064be68ce2",
                       "title": "IMG-5279.jpg",
                       "size": 0.12340450286865234,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "81239a76-a2d8-4ac8-983e-03ef188ba450",
                       "title": "IMG-5287.jpg",
                       "size": 0.11258602142333984,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "158da30d-a323-41a1-9b49-d780010091a9",
                       "title": "IMG-5297.jpg",
                       "size": 0.1011962890625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "e8d76c2e-2983-4662-ac82-558326469836",
                       "title": "IMG-5313.jpg",
                       "size": 0.10376358032226562,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "7b80d953-ba5d-4605-a85b-6c84723db310",
                       "title": "IMG-5319-Fix.jpg",
                       "size": 0.13099384307861328,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "18266a11-ff93-4860-82d9-72a5adcb053b",
                       "title": "IMG-5323.jpg",
                       "size": 0.1215972900390625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "7402f5b6-c652-4bc0-9e18-00583f51d1a9",
                       "title": "IMG-5327.jpg",
                       "size": 0.11837291717529297,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "e738d031-4460-43e7-8499-72e755e4e943",
                       "title": "IMG-5332.jpg",
                       "size": 0.1204996109008789,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "a45dda7f-82e8-42ff-88f8-bdd1532df627",
                       "title": "IMG-5351.jpg",
                       "size": 0.09708595275878906,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "4dbb101b-0aa9-4c3f-9af8-9c95c4083b67",
                       "title": "IMG-5360.jpg",
                       "size": 0.10139942169189453,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "eff707a4-e120-4552-ac6b-f5d005965874",
                       "title": "IMG-5372.jpg",
                       "size": 0.10463619232177734,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "d1f3d7b0-b561-4788-8b0e-c6feb5b0cc36",
                       "title": "IMG-5380-fix.jpg",
                       "size": 0.13574981689453125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "fb677ab7-7c9f-49b7-bb30-6c8ffd7f2b8e",
                       "title": "IMG-5387.jpg",
                       "size": 0.14077186584472656,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "06ffdc7c-8b8e-43f3-a664-6b42ef368ce3",
                       "title": "IMG-5398.jpg",
                       "size": 0.12474918365478516,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "4866a15f-b943-4c61-b9ee-1cbe594a502d",
@@ -5074,13 +4026,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.7818355560302734,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "8ef7abe1-36e2-4230-b8de-b6dcee4d0cb4",
@@ -5088,13 +4037,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.763340950012207,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "7a0fe2fb-2a03-4e89-b094-318907f93c27",
@@ -5102,13 +4048,10 @@
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
                       "size": 3.209157943725586,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "34010b68-0542-4977-9e40-636291f718a5",
@@ -5116,13 +4059,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.17055892944335938,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "6b14ca18-343a-4561-bfe3-623a0d7bfdc0",
@@ -5130,13 +4070,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.1499309539794922,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "b42527b5-6684-49ea-86de-c3b71d0e9037",
@@ -5144,13 +4081,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.31831836700439453,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "cf7db69b-9ba4-4656-a828-d834cf0e1681",
@@ -5158,13 +4092,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.21117401123046875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "9788e6d1-9180-49a8-b03a-b0e1ab919385",
@@ -5172,13 +4103,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.28608131408691406,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "0b394751-85d5-4318-ae0c-92e5db7bb912",
@@ -5186,13 +4114,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.2673311233520508,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "bcb03667-11da-45fe-ab53-3c27c89f8456",
@@ -5200,13 +4125,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.27196598052978516,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "6df4c73c-dae5-4d78-883d-a4e7f6b18088",
@@ -5214,13 +4136,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.2172842025756836,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "ecb7779f-6666-46bd-a59c-9fa1f4cabfc5",
@@ -5228,13 +4147,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.1890125274658203,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "10457f76-9f06-46b0-8902-1840c568858d",
@@ -5242,13 +4158,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.21115779876708984,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "8d830bc1-3b32-4dce-a902-ed67c5d3c114",
@@ -5256,13 +4169,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.2390613555908203,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "ebcecc63-db45-4d04-a971-25e4a0d60228",
@@ -5270,13 +4180,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.3374481201171875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "b85c5a88-ae47-4bee-9ea1-4cef6c996aaf",
@@ -5284,13 +4191,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.30179500579833984,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "3e167416-a38e-40d9-a4c6-911f19850bf3",
@@ -5298,13 +4202,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.17090320587158203,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "c88390ac-5289-45bc-881e-e4e2a6603361",
@@ -5312,13 +4213,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.17932510375976562,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "e1f232bd-db21-42eb-98e1-9b756c2e20f0",
@@ -5326,13 +4224,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.19205665588378906,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "f573226d-a1c7-4d73-b018-7fe5f8c62518",
@@ -5340,13 +4235,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.15217113494873047,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "22ad29a5-113d-47dc-80d6-413d2def0feb",
@@ -5354,13 +4246,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.17298507690429688,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "21626442-a671-40eb-9083-7d9a27ab3500",
@@ -5368,13 +4257,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.20209980010986328,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "d598a31f-fbe7-4d51-8710-3a71a0af46f2",
@@ -5382,13 +4268,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.2320108413696289,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "b4998d61-f59d-4598-bbf1-cb67feb71a04",
@@ -5396,13 +4279,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.23481273651123047,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "d5a959a3-9f5f-421e-b109-73d59161e322",
@@ -5410,13 +4290,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.2750892639160156,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "6326035e-a98f-4956-8357-dca490452968",
@@ -5424,13 +4301,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.18602752685546875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "93ffa7c0-a095-4d26-b95b-7abb173e4466",
@@ -5438,13 +4312,10 @@
                       "format": "Exchangeable Image File Format (Compressed) 2.2",
                       "puid": "x-fmt/391",
                       "size": 0.19728374481201172,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "75a615c4-bce3-409b-9dc7-261f4fc54ab4",
@@ -5452,13 +4323,10 @@
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
                       "size": 1.415628433227539,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "3d5ad885-5abf-47fa-aab2-3fa4e7b29657",
@@ -5466,13 +4334,10 @@
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
                       "size": 0.03112316131591797,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "7585c403-b4a9-4609-8f5e-0400a2dd66f9",
@@ -5480,13 +4345,10 @@
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
                       "size": 1.7589893341064453,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "691fa6d2-b738-4cce-bdcf-139242882ea9",
@@ -5494,13 +4356,10 @@
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
                       "size": 0.8100271224975586,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "c79204e4-c6ec-483d-afb7-3fb00a810620",
@@ -5508,33 +4367,22 @@
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
                       "size": 2.6764650344848633,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     }
                   ],
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "directory",
                   "puid": "",
-                  "tags": [
-
-                  ]
+                  "tags": []
                 }
               ],
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "directory",
               "puid": "",
-              "tags": [
-
-              ]
+              "tags": []
             },
             {
               "id": "0871253d-5849-4f78-90ee-2da6526bd726",
@@ -5558,13 +4406,10 @@
                   "format": "Exchangeable Image File Format (Compressed) 2.2",
                   "puid": "x-fmt/391",
                   "size": 0.14422321319580078,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Image (Raster)"
                 },
                 {
                   "id": "1a35801d-573c-433b-908c-da4cd857da33",
@@ -5572,13 +4417,10 @@
                   "format": "Exchangeable Image File Format (Compressed) 2.2",
                   "puid": "x-fmt/391",
                   "size": 0.18732166290283203,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Image (Raster)"
                 },
                 {
                   "id": "104183db-923b-41d0-b1b2-face6543e1f2",
@@ -5586,13 +4428,10 @@
                   "format": "Exchangeable Image File Format (Compressed) 2.2",
                   "puid": "x-fmt/391",
                   "size": 0.16927814483642578,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Image (Raster)"
                 },
                 {
                   "id": "0e8632a7-2721-49aa-9bdd-abf0505d2350",
@@ -5600,13 +4439,10 @@
                   "format": "Exchangeable Image File Format (Compressed) 2.2",
                   "puid": "x-fmt/391",
                   "size": 0.28711509704589844,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Image (Raster)"
                 },
                 {
                   "id": "37eebc6b-e4d0-4cf2-8756-6f2b814bd5c5",
@@ -5614,13 +4450,10 @@
                   "format": "Exchangeable Image File Format (Compressed) 2.2",
                   "puid": "x-fmt/391",
                   "size": 0.2734041213989258,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Image (Raster)"
                 },
                 {
                   "id": "ef72fa90-e94a-4bd5-9dee-5a83d3427100",
@@ -5628,13 +4461,10 @@
                   "format": "Exchangeable Image File Format (Compressed) 2.2",
                   "puid": "x-fmt/391",
                   "size": 0.20899200439453125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Image (Raster)"
                 },
                 {
                   "id": "8553e67f-31e3-4f41-b1fd-3b58c6ee6fab",
@@ -5642,13 +4472,10 @@
                   "format": "Exchangeable Image File Format (Compressed) 2.2",
                   "puid": "x-fmt/391",
                   "size": 0.33354949951171875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Image (Raster)"
                 },
                 {
                   "id": "8b35cfb0-d7c6-4373-b395-be3dc5441996",
@@ -5656,26 +4483,19 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.03271484375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "7bba8e15-1ae9-44a0-a104-19ae94cd84ec",
                   "title": "Inaugural-Invite-List-2.xls",
                   "size": 0.04345703125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
                   "puid": "",
-                  "tags": [
-
-                  ]
+                  "tags": []
                 },
                 {
                   "id": "8358a4d9-b5d9-4f90-aeeb-1a41cad3dac4",
@@ -5683,13 +4503,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.02783203125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "0efdfb9f-b49e-4925-b3fa-9b44bd775d0c",
@@ -5697,13 +4514,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.03955078125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "cde55a81-8177-4631-ae6b-389f238df034",
@@ -5711,13 +4525,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.04248046875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "51b165cd-3206-4139-852a-7d2ce667802f",
@@ -5725,13 +4536,10 @@
                   "format": "JPEG 1.01",
                   "puid": "fmt/43",
                   "size": 0.8100271224975586,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Image (Raster)"
                 },
                 {
                   "id": "899932ad-4292-4e12-b524-ed9c8e617df9",
@@ -5739,23 +4547,16 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 4.3955078125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 }
               ],
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "directory",
               "puid": "",
-              "tags": [
-
-              ]
+              "tags": []
             },
             {
               "id": "fd45f0d9-f966-428c-af77-59b73a445b84",
@@ -5781,13 +4582,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.01708984375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "e6172444-fa09-42ec-b050-c31c3e391666",
@@ -5795,13 +4593,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.1650390625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "90dc1ac8-973d-4b50-bdcb-57b17fcc7312",
@@ -5809,13 +4604,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.03125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "9972b98d-5640-45a7-ada7-584fd7ca0494",
@@ -5823,13 +4615,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.0341796875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "db642396-61f4-4b23-99c1-78437442f133",
@@ -5837,13 +4626,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.0341796875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "ab0cc285-d7d0-427b-8d6a-faf4bf3a46eb",
@@ -5851,13 +4637,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.02001953125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "6719ee5a-e00a-40e3-aed3-c4fe4644c6b2",
@@ -5865,13 +4648,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.0205078125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "7b830f92-93dc-4853-be6b-67d6dbd58ccb",
@@ -5879,13 +4659,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.107421875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "12fa00be-faaa-43e1-b5d8-b3d974a02757",
@@ -5893,13 +4670,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.02001953125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "fbad70fe-59b8-4bb0-a6d9-3fcd48400fd1",
@@ -5907,13 +4681,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.0205078125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "70f7bc23-7614-4ee0-8e86-f1ba76ec151d",
@@ -5921,13 +4692,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.0322265625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "ed60d665-4666-4a67-a9a8-e842b43c3532",
@@ -5935,13 +4703,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.7734375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "88248250-c0f7-4ba4-b0fc-767ced819959",
@@ -5949,13 +4714,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.01513671875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "5bc85298-e317-49b3-87a9-3e522bf6be02",
@@ -5963,13 +4725,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.052734375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "b4447196-2adf-4f6e-a1a8-e2d61b877e92",
@@ -5977,13 +4736,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.0810546875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "f8486360-f4ef-43b2-b5a8-23961763dabd",
@@ -5991,13 +4747,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.07958984375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "96381fd3-0546-4532-a401-f747b57944a7",
@@ -6005,13 +4758,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.08447265625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "d439fca5-a632-4d55-8d82-3a424b40cfdd",
@@ -6019,13 +4769,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.0908203125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "f0cec30a-0e3a-4fba-a96a-cb4960832ea7",
@@ -6033,13 +4780,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.09033203125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "22b8bda5-e1d6-4cb1-81f2-162a83d1a6f4",
@@ -6047,13 +4791,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.02001953125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "8be6703d-0195-4fdf-ae4f-9226ebc9708a",
@@ -6061,13 +4802,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.0205078125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "4833fdf1-23f3-46e0-98a7-6c783872c41d",
@@ -6075,13 +4813,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.02197265625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "6a43227a-e7ce-4eaf-a125-20fbe122fb87",
@@ -6089,13 +4824,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.0244140625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "b34ec5a1-5989-4eb8-9ef5-29490310dcba",
@@ -6103,13 +4835,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.08544921875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "5158bf21-ad8d-41bc-ad09-ab9b06835596",
@@ -6117,13 +4846,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.0478515625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "87860d86-1034-42ee-b18a-1f738cc5894e",
@@ -6131,13 +4857,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.06640625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "bf250b2c-5155-41bb-ba78-31d8faa76574",
@@ -6145,13 +4868,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.03125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "d83f5b19-66ae-448f-9595-b9d293d5924f",
@@ -6159,13 +4879,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.046875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "85ca38c6-a756-4855-9758-1835f795cae8",
@@ -6173,13 +4890,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.02978515625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "70b87896-c7ac-4643-a3e4-f8f4ffbb5fb0",
@@ -6187,13 +4901,10 @@
                   "format": "JPEG 1.01",
                   "puid": "fmt/43",
                   "size": 1.4146223068237305,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Image (Raster)"
                 },
                 {
                   "id": "e4ae1d81-6a1a-4b70-b61a-0e8d6c00cfad",
@@ -6201,13 +4912,10 @@
                   "format": "Acrobat PDF 1.3",
                   "puid": "fmt/17",
                   "size": 0.25935840606689453,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Portable Document Format"
                 },
                 {
                   "id": "1e84e6b0-0579-4169-8c01-87ff993fe9be",
@@ -6215,13 +4923,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.03369140625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "45b96dff-daf5-4a08-8002-0a1098d78abe",
@@ -6229,13 +4934,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.02294921875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "a8cfc31c-1645-4285-ba20-bd69bf9a8332",
@@ -6243,13 +4945,10 @@
                   "format": "JPEG 1.01",
                   "puid": "fmt/43",
                   "size": 0.18114852905273438,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Image (Raster)"
                 },
                 {
                   "id": "f4024182-1b48-4a49-932a-4f31ce6aca7c",
@@ -6257,13 +4956,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.03076171875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "89d1887b-a0a2-4369-832c-b1b9bc7695fa",
@@ -6289,13 +4985,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.01708984375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "d3ef8d99-8cee-4c30-b5e3-0baf54bbe252",
@@ -6303,13 +4996,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.1650390625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "4d90bd8b-b36a-4475-b67b-014f84ef6c4e",
@@ -6317,13 +5007,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.03125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "c5eab27d-37af-4e60-a531-201470bbebea",
@@ -6331,13 +5018,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.0341796875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "cf1076c1-72b9-4241-9631-38d4409b8068",
@@ -6345,13 +5029,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.0341796875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "904e9aff-5b51-424a-addb-6c1214f17cab",
@@ -6359,13 +5040,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.02001953125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "a29234cc-57fa-44bf-a4b0-ab25ad838711",
@@ -6373,13 +5051,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.0205078125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "35a7a1e2-05c2-4eaa-8368-23933da9a30f",
@@ -6387,13 +5062,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.107421875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "2e768e67-be09-40a1-b608-8ac24470e26e",
@@ -6401,13 +5073,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.02001953125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "9366bc54-f742-4eba-bbcf-d8b19c0376c7",
@@ -6415,13 +5084,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.0205078125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "862cdedb-90a2-4c3d-9d4f-9b8e5ef86e4e",
@@ -6429,13 +5095,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.0322265625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "3fd2135d-fb8d-4d1c-ae2c-fde24cf3881b",
@@ -6443,13 +5106,10 @@
                       "format": "Powerpoint 97-2002",
                       "puid": "fmt/126",
                       "size": 0.7734375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Presentation"
                     },
                     {
                       "id": "481f2ff7-e4eb-4b24-9bff-b5ca9608606a",
@@ -6457,13 +5117,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.01513671875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "c083a940-d8d0-4ded-972c-ef9c38c6f143",
@@ -6471,13 +5128,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.052734375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "c595a5d4-e274-4794-a039-c2a0946b36dd",
@@ -6485,13 +5139,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.0810546875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "03bdb447-5b7b-459d-82f6-c9b6647de9b9",
@@ -6499,13 +5150,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.07958984375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "f901219e-abc8-4913-bc3a-cdc9aba6699a",
@@ -6513,13 +5161,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.0908203125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "c5712cd1-ec28-4c08-bf43-4d323c7d82dd",
@@ -6527,13 +5172,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.09033203125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "e28b8207-7c5d-446b-867e-1b0624f39e57",
@@ -6541,13 +5183,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.02001953125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "f861d61e-0a7c-47c0-aed5-902eb13ff453",
@@ -6555,13 +5194,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.0205078125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "3a14ddb6-5653-4868-9611-be023ee7cff4",
@@ -6569,13 +5205,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.0244140625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "c73b7d3b-805c-4236-ae2f-ea83f9583eca",
@@ -6583,13 +5216,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.08544921875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "0d5bfa5d-012e-41bb-acca-77f17571d28e",
@@ -6597,13 +5227,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0478515625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "bedfa2a1-c98f-408d-a7a1-62559b040672",
@@ -6611,13 +5238,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.06640625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "d48b614a-ab47-4a15-bce9-ad5671e30ce6",
@@ -6625,13 +5249,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.03125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "502a9bdc-8c05-436e-9513-8009837a868f",
@@ -6639,13 +5260,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.046875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "0d431223-b9a9-40f7-9439-ba01d9755289",
@@ -6653,13 +5271,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02978515625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "6d9ea667-a038-48dc-8a02-9014ccaa3a4b",
@@ -6667,13 +5282,10 @@
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
                       "size": 1.4146223068237305,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "733fef21-bb68-41cf-a66f-bbe81ef1f6f2",
@@ -6681,13 +5293,10 @@
                       "format": "Acrobat PDF 1.3",
                       "puid": "fmt/17",
                       "size": 0.25935840606689453,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Portable Document Format"
                     },
                     {
                       "id": "1a5771ea-bbef-4ab5-950e-f678a6b25af5",
@@ -6695,13 +5304,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.03369140625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "b009ca37-fc92-4d7d-83c0-9f55b1dd6750",
@@ -6709,13 +5315,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02294921875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "d93de470-c3ef-45cf-a599-be6f9ee30daa",
@@ -6723,13 +5326,10 @@
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
                       "size": 0.18114852905273438,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "5acfc44e-348d-4882-9615-3c90fb01ef57",
@@ -6737,33 +5337,22 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.03076171875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     }
                   ],
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "directory",
                   "puid": "",
-                  "tags": [
-
-                  ]
+                  "tags": []
                 }
               ],
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "directory",
               "puid": "",
-              "tags": [
-
-              ]
+              "tags": []
             },
             {
               "id": "19b4ccb5-841e-40ce-ad93-474d6a812f55",
@@ -6790,13 +5379,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 6.14501953125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "3da0777a-da75-49f1-862f-b117cd3aae50",
@@ -6822,13 +5408,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.01953125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "ac5792f8-e310-4fe6-9b27-45f1d16ea3ed",
@@ -6836,13 +5419,10 @@
                       "format": "Acrobat PDF 1.3",
                       "puid": "fmt/17",
                       "size": 0.25484752655029297,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Portable Document Format"
                     },
                     {
                       "id": "61641a11-bb43-41e8-8984-df0288efc910",
@@ -6850,13 +5430,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0244140625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "69517523-890a-4481-b235-6b2a491b35db",
@@ -6864,13 +5441,10 @@
                       "format": "Powerpoint 97-2002",
                       "puid": "fmt/126",
                       "size": 7.5048828125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Presentation"
                     },
                     {
                       "id": "c22aad0d-4379-4f0d-8d22-2d81176a5ae9",
@@ -6878,13 +5452,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.0146484375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "102e3480-1644-4348-bc0e-b2604a25c5e7",
@@ -6892,13 +5463,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.0166015625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "00cc69eb-04f2-472a-9d7f-d36b40c6777d",
@@ -6906,13 +5474,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.0146484375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "a7acdb94-8ced-446e-b826-7390af6194bd",
@@ -6920,13 +5485,10 @@
                       "format": "Powerpoint 97-2002",
                       "puid": "fmt/126",
                       "size": 1.66796875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Presentation"
                     },
                     {
                       "id": "904e62c7-14eb-434b-a255-461f6ae0913b",
@@ -6934,13 +5496,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0302734375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "b83512ee-e3b0-4c79-a0af-3565d863bb57",
@@ -6948,13 +5507,10 @@
                       "format": "JPEG 1.00",
                       "puid": "fmt/42",
                       "size": 0.008736610412597656,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "f0024ccb-d6bb-4ac6-b4c0-7c2ea7765ed0",
@@ -6962,13 +5518,10 @@
                       "format": "Powerpoint 97-2002",
                       "puid": "fmt/126",
                       "size": 6.24169921875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Presentation"
                     },
                     {
                       "id": "61d37a19-802c-4071-b900-2f7cd34fff8c",
@@ -6976,13 +5529,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.0166015625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "345467c7-9a82-40e5-a505-545f3bb287d5",
@@ -6990,13 +5540,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.0166015625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "9c13a4ad-5b78-4899-9db2-4bd1fafbdce7",
@@ -7004,13 +5551,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.01513671875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "1824dcd2-27e8-44f3-84a4-ea16ae226b60",
@@ -7018,13 +5562,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.0712890625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "86a9e61a-73e4-4af5-866f-e4bae5878ed8",
@@ -7032,13 +5573,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.0166015625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "ba8c79af-f69e-4f8e-bef3-e22ea56cf1cd",
@@ -7046,13 +5584,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.05908203125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "a1449bfb-9f7f-46c7-b7c3-cefb2305709d",
@@ -7060,13 +5595,10 @@
                       "format": "Powerpoint 97-2002",
                       "puid": "fmt/126",
                       "size": 6.5654296875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Presentation"
                     },
                     {
                       "id": "96e7105f-d244-4ccb-a5d2-991bd008e458",
@@ -7074,13 +5606,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.01318359375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "6861983c-0dc3-435b-bf13-bf5258f1b654",
@@ -7088,13 +5617,10 @@
                       "format": "Acrobat PDF 1.3",
                       "puid": "fmt/17",
                       "size": 0.25981807708740234,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Portable Document Format"
                     },
                     {
                       "id": "10af630a-3245-4843-8e2a-0fba660f5249",
@@ -7102,13 +5628,10 @@
                       "format": "Powerpoint 97-2002",
                       "puid": "fmt/126",
                       "size": 6.142578125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Presentation"
                     },
                     {
                       "id": "2eff7757-93df-41a3-876f-ff6092661cfb",
@@ -7126,33 +5649,22 @@
                           "format": "Powerpoint 97-2002",
                           "puid": "fmt/126",
                           "size": 6.14501953125,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Presentation"
                         }
                       ],
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "directory",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     }
                   ],
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "directory",
                   "puid": "",
-                  "tags": [
-
-                  ]
+                  "tags": []
                 },
                 {
                   "id": "1eff381b-6a99-4cc7-b16d-c9c3802a8201",
@@ -7187,13 +5699,10 @@
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
                           "size": 0.0146484375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Spreadsheet"
                         },
                         {
                           "id": "1c8f28de-7e65-4e7e-bd49-745496c32b75",
@@ -7201,13 +5710,10 @@
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
                           "size": 0.0166015625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Spreadsheet"
                         },
                         {
                           "id": "473283c0-4a89-467d-8d37-3bf63f57d91b",
@@ -7215,13 +5721,10 @@
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
                           "size": 0.0166015625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Spreadsheet"
                         },
                         {
                           "id": "7e562a1f-8fff-40c0-ab5e-bcbb9a524140",
@@ -7229,13 +5732,10 @@
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
                           "size": 0.0166015625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Spreadsheet"
                         },
                         {
                           "id": "60622636-d3f5-4a5b-ba3f-4dbb7bcdf8af",
@@ -7243,13 +5743,10 @@
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
                           "size": 0.01708984375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Spreadsheet"
                         },
                         {
                           "id": "dd6cc36e-fa2a-49eb-abc6-5556f6349078",
@@ -7257,13 +5754,10 @@
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
                           "size": 0.05859375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Spreadsheet"
                         },
                         {
                           "id": "d328bcbb-bbc7-47b7-8fce-3d1ff68b5cd4",
@@ -7271,13 +5765,10 @@
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
                           "size": 0.0166015625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Spreadsheet"
                         },
                         {
                           "id": "66cfe287-47f6-4f3b-a61d-2bae5bf4106f",
@@ -7285,23 +5776,16 @@
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
                           "size": 0.01318359375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Spreadsheet"
                         }
                       ],
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "directory",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "27ee652e-1464-46d0-95fa-5f2751b34b04",
@@ -7326,13 +5810,10 @@
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
                           "size": 0.0166015625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Spreadsheet"
                         },
                         {
                           "id": "d36476e2-c63a-4f91-9d7d-8492e199fe9a",
@@ -7340,13 +5821,10 @@
                           "format": "JPEG 1.00",
                           "puid": "fmt/42",
                           "size": 0.013105392456054688,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Image (Raster)"
                         },
                         {
                           "id": "27aed5c0-1715-4ede-8759-2bb98854f34f",
@@ -7354,13 +5832,10 @@
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
                           "size": 0.016592979431152344,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Image (Raster)"
                         },
                         {
                           "id": "a64e4705-c5af-410f-b4c6-310b80d45880",
@@ -7368,13 +5843,10 @@
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
                           "size": 0.01318359375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Spreadsheet"
                         },
                         {
                           "id": "b464d03c-739d-45f7-a141-4e360d6fd836",
@@ -7382,13 +5854,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.02587890625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "8db78705-2075-4c6e-810d-37920e026eaf",
@@ -7396,13 +5865,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.12109375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "338064c7-aedf-4c76-889a-8fc23e199b1a",
@@ -7410,13 +5876,10 @@
                           "format": "Powerpoint 97-2002",
                           "puid": "fmt/126",
                           "size": 1.435546875,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Presentation"
                         },
                         {
                           "id": "40f6e155-0a8d-437f-96ba-be43bacb5842",
@@ -7424,13 +5887,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.029296875,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "540e0ee4-2936-4308-8ede-a15c99dad408",
@@ -7438,13 +5898,10 @@
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
                           "size": 0.00270843505859375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Image (Raster)"
                         },
                         {
                           "id": "dd55d0a4-0011-4dc8-984a-2b8674fa0fd8",
@@ -7452,13 +5909,10 @@
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
                           "size": 0.01318359375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Spreadsheet"
                         },
                         {
                           "id": "aaa3cc15-3e6f-48d6-aa8b-70d46d21d221",
@@ -7466,13 +5920,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.16357421875,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "660ad288-99c3-4f0d-95ab-6103016f2239",
@@ -7480,13 +5931,10 @@
                           "format": "JPEG 1.00",
                           "puid": "fmt/42",
                           "size": 0.008736610412597656,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Image (Raster)"
                         },
                         {
                           "id": "fbfd2206-c8b6-4581-ae13-4402d0ea8a6a",
@@ -7494,13 +5942,10 @@
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
                           "size": 0.024092674255371094,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Image (Raster)"
                         },
                         {
                           "id": "cda57011-4b5c-4140-b388-c77447800dfa",
@@ -7508,13 +5953,10 @@
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
                           "size": 0.015050888061523438,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Image (Raster)"
                         },
                         {
                           "id": "6a2838a4-1305-4a57-a8f3-c7368a258698",
@@ -7522,13 +5964,10 @@
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
                           "size": 0.021584510803222656,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Image (Raster)"
                         },
                         {
                           "id": "1f74b08b-903b-4b8b-b430-81c624704967",
@@ -7536,13 +5975,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.53662109375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "da685b82-7084-4edc-ba98-2edcda2bca10",
@@ -7550,13 +5986,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.0859375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "c9d97393-b234-4b30-83c1-f938c4200f76",
@@ -7564,13 +5997,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.02783203125,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "49ac3c30-3367-40a4-a9eb-f4ef788f3e01",
@@ -7578,13 +6008,10 @@
                           "format": "Powerpoint 97-2002",
                           "puid": "fmt/126",
                           "size": 5.6044921875,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Presentation"
                         },
                         {
                           "id": "3a683e6e-f394-446a-a3ce-4651357d9ec0",
@@ -7592,13 +6019,10 @@
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
                           "size": 0.04587841033935547,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Image (Raster)"
                         },
                         {
                           "id": "b41adb00-7864-4a0a-8147-954fe12d25e7",
@@ -7606,43 +6030,28 @@
                           "format": "JPEG 1.01",
                           "puid": "fmt/43",
                           "size": 0.02455902099609375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Image (Raster)"
                         }
                       ],
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "directory",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     }
                   ],
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "directory",
                   "puid": "",
-                  "tags": [
-
-                  ]
+                  "tags": []
                 }
               ],
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "directory",
               "puid": "",
-              "tags": [
-
-              ]
+              "tags": []
             },
             {
               "id": "639257b7-1aef-4fbb-880c-a1de7b16ca2d",
@@ -7670,13 +6079,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.23974609375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "81a9a867-b84c-42c7-ad61-096f2214261a",
@@ -7684,42 +6090,33 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 1.79296875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "7f82324f-f6d4-4e0d-b4b0-aa8aacabe568",
-                  "title": "2007-GOVERNOR’S-UPPER-PENINSULA-INAUGURAL.ppt",
+                  "title": "2007-GOVERNOR\u2019S-UPPER-PENINSULA-INAUGURAL.ppt",
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 36.5107421875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "b7dd1e90-a31f-4048-914a-8f89cfa14b58",
-                  "title": "2007-GOVERNOR’S-UPPER-PENINSULA-INAUGURAL.pptx",
+                  "title": "2007-GOVERNOR\u2019S-UPPER-PENINSULA-INAUGURAL.pptx",
                   "format": "Powerpoint for Windows 2007+",
                   "puid": "fmt/215",
                   "extension": ".pptx",
                   "size": 36.08389949798584,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "7f973d7e-5326-4790-bdd7-f0cf49e5c2a2",
@@ -7727,13 +6124,10 @@
                   "format": "Acrobat PDF 1.3",
                   "puid": "fmt/17",
                   "size": 0.058150291442871094,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Portable Document Format"
                 },
                 {
                   "id": "1c1b906c-d774-4f61-b42f-ea66b0fcac7e",
@@ -7741,13 +6135,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 6.87353515625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "2652b603-226c-49b0-8ca3-0b4325156f2a",
@@ -7755,13 +6146,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.037109375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "72139d86-8d5c-4288-936d-77916d56e2fd",
@@ -7769,13 +6157,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 3.18896484375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "bdd54650-671b-455d-a913-083de75614e9",
@@ -7783,13 +6168,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.064453125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "e6da8025-83db-4c4a-848d-98e9d42a0b27",
@@ -7797,13 +6179,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.02490234375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "77b83820-4efc-4372-a496-8188e8d083c1",
@@ -7811,13 +6190,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 8.68115234375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "bdaac43e-0680-4f30-999a-a8dece1dab8d",
@@ -7825,13 +6201,10 @@
                   "format": "JPEG 1.01",
                   "puid": "fmt/43",
                   "size": 0.528172492980957,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Image (Raster)"
                 },
                 {
                   "id": "1c0dc438-27ff-499e-a217-da41542bb3be",
@@ -7839,13 +6212,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.01513671875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "2ac46918-cc89-496c-abc6-f415a6f235c2",
@@ -7853,13 +6223,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 2.91552734375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "432c49a8-44c9-40e2-b146-db6ed682d455",
@@ -7867,13 +6234,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 12.71728515625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "1ce24e87-1c60-4e0a-b1ec-c0d324686ce6",
@@ -7881,13 +6245,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.00927734375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "cd26e0c2-fc2a-4541-b2a3-2e3363c17f4c",
@@ -7895,13 +6256,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 6.9580078125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "a92aef42-d629-4419-be18-0c9bf135a86b",
@@ -7909,13 +6267,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.974609375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "a6b4a784-38c8-4f5a-b6f4-4be769a9fedb",
@@ -7923,13 +6278,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.017578125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "718a5a4f-4755-4da9-8632-b4254883fa54",
@@ -7937,13 +6289,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 9.3583984375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "f7a31308-f7f1-465f-a599-c251b61bcc94",
@@ -7951,13 +6300,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 4.2080078125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "79b09046-4203-465a-abc3-2f2c24686117",
@@ -7965,13 +6311,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.08349609375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "5f71d23c-ee52-4ab4-a32a-79670456cdb7",
@@ -7979,13 +6322,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.0537109375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "03bb6577-7860-424e-9ddf-f104dfaf19cd",
@@ -7993,13 +6333,10 @@
                   "format": "JPEG 1.01",
                   "puid": "fmt/43",
                   "size": 0.9645919799804688,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Image (Raster)"
                 },
                 {
                   "id": "677d7bb9-a948-4e1a-b9fc-feb0c2a18065",
@@ -8007,13 +6344,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 10.7734375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "14866b9f-6b5c-4909-a46a-8b39247e48f5",
@@ -8021,13 +6355,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 4.22119140625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "cf00c7ea-a6c0-40b6-b2b7-215bafaa53f4",
@@ -8035,13 +6366,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 18.5,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "006a5b70-8c97-4c9c-9507-77018db0aaa5",
@@ -8049,13 +6377,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.07421875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "c076d0d6-0e9a-4a5f-b472-b4007605ec3b",
@@ -8063,26 +6388,19 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.10888671875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "139d3054-3cf9-45fd-8afe-840e1201bc34",
                   "title": "Fair-Registration.xls",
                   "size": 0.0361328125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
                   "puid": "",
-                  "tags": [
-
-                  ]
+                  "tags": []
                 },
                 {
                   "id": "5157e070-d5bd-45b5-9f8a-4ad8165fe20e",
@@ -8090,13 +6408,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 14.638671875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "b95af23e-b5de-4fed-8fc5-a8bbf9ebaeaa",
@@ -8104,13 +6419,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 3.47998046875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "87650036-e9ed-4132-ae97-2940ac2efa34",
@@ -8118,13 +6430,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.0458984375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "6a6ed72c-832f-4bb3-9bc8-17123fb8418d",
@@ -8132,13 +6441,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.439453125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "d59dca0d-b954-46a4-b70a-d92969a2b1b7",
@@ -8146,13 +6452,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 2.44775390625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "1977ea9c-9d23-40b7-bdd3-1b4ba7b3e33f",
@@ -8160,13 +6463,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 16.63623046875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "fc0cc04b-73a5-4f79-ba5b-0de72ad92698",
@@ -8174,13 +6474,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 4.9072265625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "23bcd60a-b9cd-42a1-a86e-5ce2a41dc5dd",
@@ -8188,13 +6485,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 1.35595703125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "caab6851-04a2-459f-ade3-5abf8476667a",
@@ -8202,13 +6496,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 11.96728515625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "5e7d5e1c-1af2-45fd-9587-8c6337198eb9",
@@ -8216,13 +6507,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 11.58447265625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "0908668b-80ff-4b26-abd5-a720b5fbf613",
@@ -8230,13 +6518,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 13.8837890625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "c87d42d9-d05f-42d4-a3d7-15cdd0f8b63f",
@@ -8244,13 +6529,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.9775390625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "d1e83d0a-da80-4c99-aecf-e291ee49d9ee",
@@ -8258,13 +6540,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 1.39599609375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "66eff2e7-e6a3-4a32-ae4c-f72782e6c3a8",
@@ -8272,13 +6551,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 15.2744140625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "f1be4cc3-6420-4917-ab63-9167427d6e2e",
@@ -8286,13 +6562,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 3.4033203125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "00c3a866-c9ab-480f-8165-b917ddacc649",
@@ -8300,13 +6573,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 15.572265625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "58fd359c-b4b7-4ea2-a54f-5c79fcb5a0d5",
@@ -8314,13 +6584,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 15.56787109375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "ab22a393-c38e-46f1-acfe-76a4b7c7dcf7",
@@ -8328,13 +6595,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 16.1064453125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "53ca6598-82c1-4480-af56-5fa5c7d5e7aa",
@@ -8342,13 +6606,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.43798828125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "47c3d83a-ce92-43f3-abd0-9f87ee493508",
@@ -8356,13 +6617,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.30322265625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "72d6153f-575e-4e2f-be5c-6127d8752eed",
@@ -8370,13 +6628,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 1.3486328125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "06bb5964-6b5e-43fd-863c-882771c44d02",
@@ -8384,13 +6639,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.3564453125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "2cce5c73-8d4c-4788-a38f-d2e6ab6b664b",
@@ -8398,13 +6650,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 2.31201171875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "2a6efd79-46fb-4276-9456-242315c2ad35",
@@ -8412,13 +6661,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 1.11328125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "568967d0-7761-4f22-91df-657e1f9c61c0",
@@ -8426,13 +6672,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 5.9345703125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "6035924a-4831-4b9f-b2bf-ea62328cbd12",
@@ -8440,13 +6683,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 8.70263671875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "e333b88e-5f65-4e6a-8363-e672feab53c0",
@@ -8454,13 +6694,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 15.89501953125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "23bec771-e9c8-463a-9fa0-19dbda0c00b8",
@@ -8468,13 +6705,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.05224609375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "a44eac70-99f7-48f6-8faa-a6f36cdc2542",
@@ -8482,13 +6716,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.017578125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "d7c7ec19-1495-4842-b4d8-84194476d6b4",
@@ -8496,13 +6727,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 6.47509765625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "0ea655da-323e-4dc3-9db2-0064c637de02",
@@ -8510,13 +6738,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 3.89013671875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "0bea6b83-e580-4809-b63b-ec77eb78d8c9",
@@ -8524,13 +6749,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 10.88134765625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "bcc81641-bf74-46a3-9e59-dd1061e52b17",
@@ -8538,13 +6760,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 2.1484375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "da934e38-be1a-48a8-8879-bcd2321eb972",
@@ -8552,13 +6771,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.11279296875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "c816bd40-ad02-45e6-83ea-2d4527ebae5f",
@@ -8566,13 +6782,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 16.72216796875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "a16e7efa-33d0-4c2a-82a5-42df154f9027",
@@ -8580,13 +6793,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 10.5029296875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "e2739449-afc2-4b87-ac0c-afebd4da0f89",
@@ -8594,13 +6804,10 @@
                   "format": "JPEG 1.01",
                   "puid": "fmt/43",
                   "size": 0.19284820556640625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Image (Raster)"
                 },
                 {
                   "id": "8d3463b3-7c92-4b2f-a139-f02ab9168da8",
@@ -8608,14 +6815,11 @@
                   "format": "Generic AIFF",
                   "extension": ".aif",
                   "size": 0.04685211181640625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
                   "puid": "",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Audio"
                 },
                 {
                   "id": "cb761ad4-7301-421e-b5d0-8ed33896b328",
@@ -8623,13 +6827,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.1728515625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "7dc10281-d850-4eec-8cf9-31885fe1031e",
@@ -8637,13 +6838,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 1.26220703125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "91e2f2b0-29a6-4e4d-bbfd-2db8e4479506",
@@ -8651,13 +6849,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.1162109375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "49cb638f-28c9-4413-b596-983d2caf4e64",
@@ -8665,13 +6860,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 1.373046875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "07b97d74-ed87-420a-bacf-69a3cb7d27a6",
@@ -8679,13 +6871,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 3.91259765625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "5599b16c-2c67-41bc-8819-cdff1fcc7786",
@@ -8693,13 +6882,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 4.02294921875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "3844471b-b7ed-4aab-bee2-064e2e40dae4",
@@ -8707,13 +6893,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.4638671875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "003253d2-3ad2-4110-9ef2-1f731fd9fca7",
@@ -8721,13 +6904,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 3.0341796875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "721214c2-f7c7-4165-9d90-f424e270fdf1",
@@ -8735,13 +6915,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "e68f3e8c-38c6-420c-9dc0-fc6b63a5132a",
@@ -8749,13 +6926,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 1.82958984375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "1bb57ef3-0b52-4e0b-ad90-8a9eff20d038",
@@ -8763,13 +6937,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 1.59423828125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "bd3800fc-ff2e-4358-ba4a-12d03f4ce201",
@@ -8777,13 +6948,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 1.73193359375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "2be09d3e-1efe-4b42-b474-f63f05fb0e2a",
@@ -8791,13 +6959,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 20.294921875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "c9e3614c-0fbc-4937-9258-097089ab6d82",
@@ -8805,13 +6970,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.0224609375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "0d87206e-d5ce-4df7-97a7-957a867b4090",
@@ -8819,13 +6981,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 4.03515625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "789a5650-df44-41da-955d-01f07f807447",
@@ -8833,13 +6992,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 4.1181640625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "ec73e7d5-df56-480d-a70e-45e37e5f72e1",
@@ -8847,13 +7003,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 3.25439453125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "0bb41e14-62dc-45b1-9eac-585ab25e2c30",
@@ -8861,13 +7014,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 1.51513671875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "7628249b-9847-48a8-9da1-3ab6ed0b82b4",
@@ -8875,13 +7025,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 1.67333984375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "fd8c981c-1c90-4da1-a3bf-9944b3753b44",
@@ -8889,13 +7036,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.06298828125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "e1af0433-4248-43de-ab60-da0c3fd47d07",
@@ -8903,13 +7047,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 1.029296875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "854c9ac3-1fd8-4df9-b47c-c4ccdc16d1e7",
@@ -8917,13 +7058,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.06201171875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "4d98a0e1-c53b-4bb9-9c13-893d21873787",
@@ -8931,13 +7069,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 1.3466796875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "4d80ba4c-3e44-4107-9f85-8b940058d344",
@@ -8945,13 +7080,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.06396484375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "4c769be6-8691-428a-b265-8e98ca8cf3fb",
@@ -8959,13 +7091,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 1.62744140625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "5dfc17ba-bc9e-464f-95d6-d613290a05f0",
@@ -8973,13 +7102,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.03515625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "c3100b39-3be2-476d-8882-3214b9cb1f63",
@@ -8987,13 +7113,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 11.04248046875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "c54bd138-115e-4b6d-a1e3-679868419b7f",
@@ -9001,13 +7124,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.15673828125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "3f3ce1cb-7cd0-4872-b18f-8c4d3f29d598",
@@ -9015,13 +7135,10 @@
                   "format": "JPEG 1.01",
                   "puid": "fmt/43",
                   "size": 1.7736444473266602,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Image (Raster)"
                 },
                 {
                   "id": "6c6412e0-e646-4b87-8298-37142d43fc0a",
@@ -9029,13 +7146,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 19.42333984375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "10fbf7ba-252e-48bb-b35b-ab365d7ddc9f",
@@ -9043,13 +7157,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.021484375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "f07f481f-e354-40e7-b84b-4be225bfe329",
@@ -9057,13 +7168,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 6.4892578125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "2ec91ebb-b77e-491f-b33c-317225967700",
@@ -9071,13 +7179,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.61279296875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "82ddeed9-ec25-4db7-874d-332acbc397f9",
@@ -9085,13 +7190,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 3.07958984375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "7413eebd-ee3c-4e86-bea9-045f680c223d",
@@ -9099,13 +7201,10 @@
                   "format": "JPEG 1.01",
                   "puid": "fmt/43",
                   "size": 1.1215858459472656,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Image (Raster)"
                 },
                 {
                   "id": "bfca29d1-5d17-4aa2-b326-d630b756a966",
@@ -9113,13 +7212,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.07080078125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "09cffaf4-6ddb-43fd-a066-715b96acc94a",
@@ -9127,13 +7223,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.85595703125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "6894ca16-5189-4333-8b9a-c3ba17c671de",
@@ -9141,13 +7234,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.01318359375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "4598e44b-0db9-44b4-91d5-d7122a472796",
@@ -9155,13 +7245,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 1.26611328125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "2ed0e440-916c-4315-8194-70f9863d0923",
@@ -9169,13 +7256,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.0693359375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "2063bc88-23ba-460c-ac41-d2395cdcad0a",
@@ -9183,13 +7267,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 4.673828125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "075a0ba6-471a-4dc4-abc6-d82fb13bb1ac",
@@ -9197,13 +7278,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.0400390625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "5d9e39af-ee3e-4b68-bcef-26c06155097a",
@@ -9211,13 +7289,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 7.51708984375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "22aa0644-7a59-4f75-ad67-98edf180e46e",
@@ -9225,13 +7300,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 10.6787109375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "dbb0eb8d-0028-4346-ae2c-f979577d9cfe",
@@ -9239,13 +7311,10 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 0.3095703125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 },
                 {
                   "id": "c1a9b55c-4011-4281-a9b2-11c39a0a6b90",
@@ -9253,23 +7322,16 @@
                   "format": "Powerpoint 97-2002",
                   "puid": "fmt/126",
                   "size": 4.5419921875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Presentation"
                 }
               ],
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "directory",
               "puid": "",
-              "tags": [
-
-              ]
+              "tags": []
             },
             {
               "id": "87995f00-4ad5-433f-8e39-35bbb3e4993e",
@@ -9317,13 +7379,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.01904296875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "777c31be-466d-45e1-a556-fb05abbfbf0d",
@@ -9331,13 +7390,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02392578125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "3f08d205-63c1-4ffc-ba51-93d71c29e56b",
@@ -9345,13 +7401,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02392578125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "58e2fb84-4923-4a4b-a65f-b11199345a04",
@@ -9359,13 +7412,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0322265625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "431d13c9-b60e-47d7-8648-4cee0471896b",
@@ -9373,13 +7423,10 @@
                       "format": "Powerpoint 97-2002",
                       "puid": "fmt/126",
                       "size": 3.8642578125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Presentation"
                     },
                     {
                       "id": "b124c0d7-2d87-4d08-bd46-87d30eda09fc",
@@ -9387,13 +7434,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02294921875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "5a436c06-b4c7-4c63-af45-3da6c727cd66",
@@ -9401,13 +7445,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.10498046875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "2102f43a-78bb-460e-93ed-ae05f661a3b9",
@@ -9415,13 +7456,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.16796875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "d81d4a3a-e589-422c-bf10-e30f85b7b82b",
@@ -9429,13 +7467,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.107421875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "86d23952-106c-41aa-97e9-8b8ecee82698",
@@ -9443,13 +7478,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0234375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "b4d4e5aa-4ac6-4b6c-939c-8359c5e59143",
@@ -9457,13 +7489,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.037109375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "2ffee209-7bcc-4330-9590-8a46582d67a7",
@@ -9471,13 +7500,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.021484375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "6f0274fe-af95-416e-b4c6-6e89524acf67",
@@ -9485,13 +7511,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02294921875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "1ca81e00-cd8c-4678-8b78-ae3c0a364441",
@@ -9499,13 +7522,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0234375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "f512bc9c-ddf0-46e5-b078-d901768a0c12",
@@ -9513,26 +7533,19 @@
                       "format": "Powerpoint 97-2002",
                       "puid": "fmt/126",
                       "size": 0.0859375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Presentation"
                     },
                     {
                       "id": "7c2de80d-c45f-449e-971e-1f81cdfabc04",
                       "title": "New-Microsoft-Access-Application.mdb",
                       "size": 0.09375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "fb9c7a39-c251-41fa-9438-a27cdfa234c9",
@@ -9540,13 +7553,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.01025390625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "470d1831-3543-405a-afee-ed7dfde9cf95",
@@ -9554,13 +7564,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02685546875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "871a3295-b293-4804-a559-00e53db22a6e",
@@ -9568,13 +7575,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.0390625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "2c16d1ce-3241-4bfd-b85c-719b0c77eb55",
@@ -9582,13 +7586,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.05126953125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "6878efa1-d7d0-47f8-b11d-89e8d53a5f9b",
@@ -9596,13 +7597,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02490234375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "ec353763-9962-4c83-a2e0-5c80ddd604bc",
@@ -9610,13 +7608,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.01708984375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "5c8cb018-9a53-4e87-9f18-dd4229846032",
@@ -9624,13 +7619,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.017578125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "7f33d40e-4078-43cf-b21d-1f4478c181fb",
@@ -9638,13 +7630,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0341796875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "b4d159a9-3461-4bd4-abb8-ecd8dbc51ed4",
@@ -9652,13 +7641,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0517578125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "e95dc4a0-43f1-4abe-b3f8-b493c7082934",
@@ -9666,13 +7652,10 @@
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
                       "size": 0.03262042999267578,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "03452c9c-8b98-4870-9184-9d4f8df90a46",
@@ -9680,13 +7663,10 @@
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
                       "size": 0.028840065002441406,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "899683d5-796f-41da-81f6-69bc7f7e9d77",
@@ -9694,13 +7674,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02392578125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "dad0094c-6813-4bb7-8fcb-f40b3a0f9976",
@@ -9708,13 +7685,10 @@
                       "format": "JPEG 1.01",
                       "puid": "fmt/43",
                       "size": 0.03153800964355469,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Image (Raster)"
                     },
                     {
                       "id": "c77a7f9c-f8c1-4868-9566-80d547efd1bf",
@@ -9722,13 +7696,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02392578125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "512f0cef-dcf9-463c-82d6-e148aebd3e07",
@@ -9736,13 +7707,10 @@
                       "format": "Powerpoint 97-2002",
                       "puid": "fmt/126",
                       "size": 0.6708984375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Presentation"
                     },
                     {
                       "id": "047efa98-8a46-4459-aa2b-e5a3e2c1c62b",
@@ -9750,13 +7718,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.03173828125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "9d966a3f-c034-46d0-9c2d-6ce2ef9c0739",
@@ -9764,13 +7729,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0244140625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "b8067234-b6dc-43c9-97fc-1a546e5c6a25",
@@ -9778,13 +7740,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.04052734375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "a098f84a-4ce6-4d8d-9e24-d1f2024a135d",
@@ -9792,13 +7751,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0400390625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "d2134aee-87a5-4f8f-95d2-621656e2df09",
@@ -9806,13 +7762,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0380859375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "80a555b2-b330-4808-aadb-66e6153e3334",
@@ -9820,13 +7773,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02294921875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "88d90134-53fe-4887-ba73-7b5de7f60141",
@@ -9834,23 +7784,16 @@
                       "format": "Powerpoint 97-2002",
                       "puid": "fmt/126",
                       "size": 0.30322265625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Presentation"
                     }
                   ],
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "directory",
                   "puid": "",
-                  "tags": [
-
-                  ]
+                  "tags": []
                 },
                 {
                   "id": "2f77b316-5c7e-4c1d-939b-8f4c61cd459b",
@@ -9868,23 +7811,16 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.05419921875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     }
                   ],
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "directory",
                   "puid": "",
-                  "tags": [
-
-                  ]
+                  "tags": []
                 },
                 {
                   "id": "debd66ba-e2ad-46c5-af90-d2d0318e6cf8",
@@ -9925,13 +7861,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.02197265625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "0082f86b-163c-4601-9f51-7dda34760993",
@@ -9939,13 +7872,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.02197265625,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "57623ea4-3415-47cc-a19e-c42b9d671890",
@@ -9953,13 +7883,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.021484375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "3fd8157c-2ef8-4e66-a6d5-2b9f606f5105",
@@ -9967,13 +7894,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.021484375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "8a98f1f1-f1a1-41d5-a3be-487b06499eb4",
@@ -9981,13 +7905,10 @@
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
                           "size": 0.0146484375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Spreadsheet"
                         },
                         {
                           "id": "acd7d9b4-6dfb-4045-bcf3-b70a66b43b86",
@@ -9995,13 +7916,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.02490234375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "c29ee111-db51-47a6-b3aa-d8d0b3841ff0",
@@ -10009,13 +7927,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.0224609375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "e774dee5-d70c-460f-9fcb-fbc33ebc1542",
@@ -10023,23 +7938,16 @@
                           "format": "Excel 97 Workbook",
                           "puid": "fmt/61",
                           "size": 0.013671875,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Spreadsheet"
                         }
                       ],
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "directory",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     },
                     {
                       "id": "679e63d7-6668-4cd4-a625-34b3c16e8c07",
@@ -10065,13 +7973,10 @@
                           "format": "Hypertext Markup Language 4.0",
                           "puid": "fmt/99",
                           "size": 0.0017805099487304688,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Text (Markup)"
                         },
                         {
                           "id": "0ff81300-dc48-4aea-b81e-486fb1e699fc",
@@ -10094,13 +7999,10 @@
                               "format": "JPEG 1.01",
                               "puid": "fmt/43",
                               "size": 0.09985733032226562,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Image (Raster)"
                             },
                             {
                               "id": "9722d84a-54d8-4ec6-ad01-c1ea99a6af58",
@@ -10108,13 +8010,10 @@
                               "format": "JPEG 1.01",
                               "puid": "fmt/43",
                               "size": 0.0044155120849609375,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Image (Raster)"
                             },
                             {
                               "id": "c5220716-d35c-4f10-8b31-90de7cb4363f",
@@ -10122,26 +8021,19 @@
                               "format": "JPEG 1.01",
                               "puid": "fmt/43",
                               "size": 0.026022911071777344,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Image (Raster)"
                             },
                             {
                               "id": "4f2c148b-b1fb-40e8-9ee7-0a4048ffc4eb",
                               "title": "Desktop.ini",
                               "size": 0.00010204315185546875,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
                               "puid": "",
-                              "tags": [
-
-                              ]
+                              "tags": []
                             },
                             {
                               "id": "e97a1519-6e6d-404d-941a-50b31baf38ac",
@@ -10149,13 +8041,10 @@
                               "format": "JPEG 1.01",
                               "puid": "fmt/43",
                               "size": 0.006748199462890625,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Image (Raster)"
                             },
                             {
                               "id": "6020af21-7b2d-46ab-93fb-576a255f766d",
@@ -10163,13 +8052,10 @@
                               "format": "RTF 1.5-1.6",
                               "puid": "fmt/50",
                               "size": 0.7602930068969727,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Word Processing"
                             },
                             {
                               "id": "739a6eef-0df1-4390-a446-3e01b070aaad",
@@ -10177,13 +8063,10 @@
                               "format": "JPEG 1.02",
                               "puid": "fmt/44",
                               "size": 0.04015159606933594,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Image (Raster)"
                             },
                             {
                               "id": "4dae7d2d-80bd-44dc-8cc7-c8a0560b1581",
@@ -10191,13 +8074,10 @@
                               "format": "1989a",
                               "puid": "fmt/4",
                               "size": 0.004961967468261719,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Image (Raster)"
                             },
                             {
                               "id": "700af938-facb-4933-b177-60aefd6e9996",
@@ -10205,23 +8085,16 @@
                               "format": "JPEG 1.01",
                               "puid": "fmt/43",
                               "size": 0.012227058410644531,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Image (Raster)"
                             }
                           ],
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "directory",
                           "puid": "",
-                          "tags": [
-
-                          ]
+                          "tags": []
                         },
                         {
                           "id": "83b975ab-9988-42ba-87a3-90b6dbe60aa3",
@@ -10239,23 +8112,16 @@
                               "format": "1989a",
                               "puid": "fmt/4",
                               "size": 0.02887439727783203,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Image (Raster)"
                             }
                           ],
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "directory",
                           "puid": "",
-                          "tags": [
-
-                          ]
+                          "tags": []
                         },
                         {
                           "id": "92c8fd20-c362-4154-a590-e917c76f54de",
@@ -10276,13 +8142,10 @@
                               "format": "JPEG 1.02",
                               "puid": "fmt/44",
                               "size": 0.007403373718261719,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Image (Raster)"
                             },
                             {
                               "id": "cbb5f202-b03b-4d57-89fa-980a59fd830a",
@@ -10290,13 +8153,10 @@
                               "format": "JPEG 1.01",
                               "puid": "fmt/43",
                               "size": 0.013245582580566406,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Image (Raster)"
                             },
                             {
                               "id": "90cac1b5-95d0-4280-8dab-c48defe2ced5",
@@ -10304,13 +8164,10 @@
                               "format": "JPEG 1.02",
                               "puid": "fmt/44",
                               "size": 0.005615234375,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Image (Raster)"
                             },
                             {
                               "id": "e85a95b5-2cea-415e-ade8-5e0c0ff979d8",
@@ -10318,13 +8175,10 @@
                               "format": "JPEG 1.02",
                               "puid": "fmt/44",
                               "size": 0.05019664764404297,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Image (Raster)"
                             },
                             {
                               "id": "08fa0000-2332-41a0-a6ab-fa968615d940",
@@ -10332,13 +8186,10 @@
                               "format": "JPEG 1.02",
                               "puid": "fmt/44",
                               "size": 0.05620861053466797,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Image (Raster)"
                             },
                             {
                               "id": "a26d413f-7171-43c6-bbf8-77ee12052ea6",
@@ -10346,13 +8197,10 @@
                               "format": "JPEG 1.02",
                               "puid": "fmt/44",
                               "size": 0.059363365173339844,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Image (Raster)"
                             },
                             {
                               "id": "e32c8ad5-06b6-4574-9e88-dfa71e53d114",
@@ -10360,13 +8208,10 @@
                               "format": "JPEG 1.02",
                               "puid": "fmt/44",
                               "size": 0.009907722473144531,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Image (Raster)"
                             },
                             {
                               "id": "9a161ece-0c41-4b59-a4da-58fbf83c317f",
@@ -10375,13 +8220,10 @@
                               "puid": "fmt/353",
                               "extension": ".tif",
                               "size": 4.756345748901367,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Image (Raster)"
                             },
                             {
                               "id": "01f4cf81-ce8d-485c-97fa-7aa60b0c731c",
@@ -10389,13 +8231,10 @@
                               "format": "JPEG 1.01",
                               "puid": "fmt/43",
                               "size": 0.020229339599609375,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Image (Raster)"
                             },
                             {
                               "id": "3c5f01cd-8c1f-4ff5-a56a-8dba5e1c9b88",
@@ -10403,53 +8242,34 @@
                               "format": "1989a",
                               "puid": "fmt/4",
                               "size": 0.0064105987548828125,
-                              "bulk_extractor_reports": [
-
-                              ],
+                              "bulk_extractor_reports": [],
                               "type": "file",
-                              "tags": [
-
-                              ]
+                              "tags": [],
+                              "group": "Image (Raster)"
                             }
                           ],
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "directory",
                           "puid": "",
-                          "tags": [
-
-                          ]
+                          "tags": []
                         }
                       ],
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "directory",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     }
                   ],
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "directory",
                   "puid": "",
-                  "tags": [
-
-                  ]
+                  "tags": []
                 }
               ],
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "directory",
               "puid": "",
-              "tags": [
-
-              ]
+              "tags": []
             },
             {
               "id": "d0ea44a3-042a-4f15-b26d-3e8ee087514b",
@@ -10481,13 +8301,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0302734375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "42ca5547-9289-431f-8f7c-e07616072f98",
@@ -10495,13 +8312,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.03515625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "43a58620-25c2-4a98-98ca-f25157a92f88",
@@ -10509,13 +8323,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.01953125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "fe95bf37-aa7e-45ff-aaec-380c2f932fea",
@@ -10523,13 +8334,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0283203125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "e1a42695-2c6a-4b90-8d65-7c869ceec5a2",
@@ -10537,13 +8345,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.03173828125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "6f8c1413-45b2-410b-b3e3-9ccb0ae1f0df",
@@ -10551,13 +8356,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.03173828125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "576d11e9-1a66-40ed-9450-a69469d988c4",
@@ -10565,13 +8367,10 @@
                       "format": "Acrobat PDF 1.3",
                       "puid": "fmt/17",
                       "size": 0.0376129150390625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Portable Document Format"
                     },
                     {
                       "id": "c791010d-493a-4e16-9a66-235b97b0db0e",
@@ -10579,13 +8378,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.021484375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "2483f88e-d62d-43f2-9095-65ced01c4728",
@@ -10593,13 +8389,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02783203125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "fcea0bfa-8e67-4606-8c43-75b1f81d9088",
@@ -10607,13 +8400,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0302734375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "58b9896c-70be-432d-b804-69dab53eedd4",
@@ -10621,13 +8411,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0283203125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "c4264495-b595-41c1-8b4b-b9c12f288b45",
@@ -10635,13 +8422,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02685546875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "c02f719b-e349-489a-8302-65e6fb46a33e",
@@ -10649,13 +8433,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.03173828125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "77933055-9bad-4f1a-9737-729a02f5c54a",
@@ -10663,13 +8444,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0234375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "dff2880c-705f-43cf-92e5-0a2e65a2186c",
@@ -10677,13 +8455,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0302734375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "fc8ab3fc-63e9-4035-9a5f-ad776ea4b7f0",
@@ -10691,13 +8466,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02978515625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "1d787f99-42c9-4911-8c0c-67840fe13459",
@@ -10705,13 +8477,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.1455078125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "36ec1b1c-8685-4d4e-8c9e-85edf7cc75eb",
@@ -10719,13 +8488,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.13623046875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "3c18c1bd-d1de-497f-8eb8-cc898d96adb2",
@@ -10733,13 +8499,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.44873046875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "181a3b0c-6a8a-442b-8496-7fcbee857e47",
@@ -10747,13 +8510,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.064453125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "6fadf2ae-99cd-44cb-805c-772d63a48320",
@@ -10761,13 +8521,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.033203125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "9f497db0-3ae6-4a88-992b-15f1dae7d5c4",
@@ -10775,13 +8532,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02490234375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "8572787f-bcf5-41df-b720-42b3751e37d0",
@@ -10789,13 +8543,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0283203125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "50674d8a-daa6-4783-8146-9d98fe998d76",
@@ -10803,13 +8554,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0283203125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "15dc2741-c74b-4703-b2df-8a518b7a39ac",
@@ -10817,23 +8565,16 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.029296875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     }
                   ],
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "directory",
                   "puid": "",
-                  "tags": [
-
-                  ]
+                  "tags": []
                 },
                 {
                   "id": "aca4b6a9-4f6a-4923-9516-1501eecc3919",
@@ -10851,13 +8592,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0322265625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "63746990-43b0-4d5a-a4fe-30c1f01e5247",
@@ -10865,13 +8603,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.03173828125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "90f6a55c-d0e9-47d7-bd13-a38dd7626581",
@@ -10879,13 +8614,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.033203125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "54b1bb93-fa96-4d1c-a3a6-19fcabb5537c",
@@ -10893,13 +8625,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02783203125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "96f719f8-e76e-4c94-9484-ae85740693c4",
@@ -10907,13 +8636,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.03076171875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "602df535-034a-4dc4-9f9a-c5952ec03140",
@@ -10921,13 +8647,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.08984375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "32f6cae5-c60c-4328-a7ba-41a160714f1a",
@@ -10935,13 +8658,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0322265625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "142ef483-1117-4217-8544-25c0d3ad0028",
@@ -10949,13 +8669,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0302734375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "888326bc-afc7-4236-897e-99ec6bb3d1ae",
@@ -10963,13 +8680,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.03173828125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "8dd14878-8aa1-4dca-9bd5-4c93bcc134ac",
@@ -10977,13 +8691,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0322265625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "f412d8ac-ffbf-4f05-ba4f-cfbc5998e2a8",
@@ -10991,13 +8702,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.083984375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "344a8de5-fa9c-4f2e-8e98-a0719c4fe8e2",
@@ -11015,13 +8723,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.03173828125,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "b9d7b8ef-5b53-4de5-94f7-cbab34e2493e",
@@ -11029,13 +8734,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.03076171875,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "c70aaabb-b48e-490d-9c95-bb8530ee3840",
@@ -11043,13 +8745,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.0302734375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "5286d20f-32e3-49e8-b696-3a4a9138964a",
@@ -11057,13 +8756,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.03173828125,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "db3cf8f1-d42f-4b43-a398-d7de26cf7c8b",
@@ -11071,13 +8767,10 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.03173828125,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         },
                         {
                           "id": "642899f9-0f6d-49c9-adde-0977ca2fc113",
@@ -11085,43 +8778,28 @@
                           "format": "Microsoft Word Document 97-2003",
                           "puid": "fmt/40",
                           "size": 0.083984375,
-                          "bulk_extractor_reports": [
-
-                          ],
+                          "bulk_extractor_reports": [],
                           "type": "file",
-                          "tags": [
-
-                          ]
+                          "tags": [],
+                          "group": "Word Processing"
                         }
                       ],
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "directory",
                       "puid": "",
-                      "tags": [
-
-                      ]
+                      "tags": []
                     }
                   ],
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "directory",
                   "puid": "",
-                  "tags": [
-
-                  ]
+                  "tags": []
                 }
               ],
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "directory",
               "puid": "",
-              "tags": [
-
-              ]
+              "tags": []
             },
             {
               "id": "c818f091-9f65-42ae-8f2f-a4bce9176e30",
@@ -11157,13 +8835,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0224609375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "ac9340b2-5629-4ede-bb63-d1953698b69d",
@@ -11171,13 +8846,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0322265625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "3b21f7ce-b61f-4176-a167-4d312b9fb11d",
@@ -11185,13 +8857,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.04052734375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "c3b8e1ec-356c-4293-8a79-1db21ab873a5",
@@ -11199,13 +8868,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.138671875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "b1a8db6d-317c-48fa-8a81-b1313a152a14",
@@ -11213,13 +8879,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.03125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "23e802c7-6947-4948-819d-ebc9949f5144",
@@ -11227,13 +8890,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0302734375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "b710bc07-b896-483a-988c-3b8d8d85b6cb",
@@ -11241,13 +8901,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.01953125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "2c594d09-a5eb-472d-8f1b-4640a9caf65c",
@@ -11255,13 +8912,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02001953125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "11d34b64-c213-4659-b9ad-a812934cdded",
@@ -11269,13 +8923,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0283203125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "89ac8941-59d9-4f17-a70a-fba0da15f899",
@@ -11283,13 +8934,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.04541015625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "c7a48ba8-8949-4962-8e99-734598e472a7",
@@ -11297,13 +8945,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.63134765625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "b708aaac-165d-4d4b-b88c-db6116405fbe",
@@ -11311,13 +8956,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0869140625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "c721512e-b340-40bf-9ce1-b30479d97d0a",
@@ -11325,13 +8967,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02734375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "c9039a57-22ec-4716-a4ac-998dcd687d64",
@@ -11339,13 +8978,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.03076171875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "e041382f-1c40-4477-b684-226feb410590",
@@ -11353,13 +8989,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02978515625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "6be703aa-c193-4ea6-8241-de7c781c8515",
@@ -11367,13 +9000,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.021484375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "b1774bcd-71c0-4740-8668-270f39a15e55",
@@ -11381,13 +9011,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.03125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "4735b376-694c-4067-8cf7-196b69e5a110",
@@ -11395,13 +9022,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02587890625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "3db2e66a-fb8d-420b-88b2-6d5dee296395",
@@ -11409,13 +9033,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.0302734375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "5b59f123-da48-4e42-b946-6643c85b1fa8",
@@ -11423,13 +9044,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02099609375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "c46e1af0-b258-4c90-a6cd-cc33ab74120e",
@@ -11437,13 +9055,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02978515625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "f6ce22bb-0afc-4df0-a729-e9920abf0469",
@@ -11451,13 +9066,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.650390625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "a586640f-b47a-494e-a3e0-c2fa29de4a01",
@@ -11465,13 +9077,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02001953125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "f4b770d6-6c4e-49eb-b358-554e4c3f53e4",
@@ -11479,13 +9088,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0224609375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "37b6a833-efea-4f00-a350-709ae580560e",
@@ -11493,13 +9099,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.08203125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "02f4fafa-60b8-421e-b288-7d16abe9691a",
@@ -11507,13 +9110,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0244140625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "fc445b29-e398-477b-8515-9cf1f15282a5",
@@ -11521,13 +9121,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.05224609375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "db2bf5d2-8c91-484c-9b6c-f97e0b56beda",
@@ -11535,13 +9132,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0322265625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "206a7f82-0590-44ae-add7-4c449c02553f",
@@ -11549,23 +9143,16 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02197265625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     }
                   ],
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "directory",
                   "puid": "",
-                  "tags": [
-
-                  ]
+                  "tags": []
                 },
                 {
                   "id": "fa51a383-0e0a-4824-83a7-b71ffa2601c8",
@@ -11589,13 +9176,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.033203125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "bfb771b8-e7d7-47eb-bd89-2f1079f2e9a7",
@@ -11603,13 +9187,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0322265625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "17497749-0ccc-4dcb-a2cd-410857c055b1",
@@ -11617,13 +9198,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02490234375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "ab81254b-45f0-4de2-8118-d30e670693b1",
@@ -11631,13 +9209,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02392578125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "3625e2d2-0e27-4ffe-9d51-db07bfdcc259",
@@ -11645,13 +9220,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02783203125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "3d7a9ea6-c626-49f8-a169-e42dae990d5b",
@@ -11659,13 +9231,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02783203125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "886d1d5b-f228-4566-be95-398dc1b83fd4",
@@ -11673,13 +9242,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0234375,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "467f9b0f-12db-461d-8bb4-894c6cd55fc6",
@@ -11687,13 +9253,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.0205078125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "db9b741d-d7ae-49ef-b3da-21d59a50fb8f",
@@ -11701,13 +9264,10 @@
                       "format": "Hypertext Markup Language 4.0",
                       "puid": "fmt/99",
                       "size": 0.04069709777832031,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Text (Markup)"
                     },
                     {
                       "id": "cd19f388-0a33-4f9c-806c-600afaea09cf",
@@ -11715,13 +9275,10 @@
                       "format": "Hypertext Markup Language 4.0",
                       "puid": "fmt/99",
                       "size": 0.017065048217773438,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Text (Markup)"
                     },
                     {
                       "id": "3937a42f-2f40-46c2-87b0-9adc62e8e27f",
@@ -11729,13 +9286,10 @@
                       "format": "Acrobat PDF 1.6",
                       "puid": "fmt/20",
                       "size": 0.15174293518066406,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Portable Document Format"
                     },
                     {
                       "id": "9bcd1dcd-d451-4ee8-9ba1-de29c17372be",
@@ -11743,13 +9297,10 @@
                       "format": "Acrobat PDF 1.6",
                       "puid": "fmt/20",
                       "size": 0.6819515228271484,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Portable Document Format"
                     },
                     {
                       "id": "528a7571-86dd-4a81-b03a-16aed00bf89f",
@@ -11757,13 +9308,10 @@
                       "format": "Excel 97 Workbook",
                       "puid": "fmt/61",
                       "size": 0.02197265625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Spreadsheet"
                     },
                     {
                       "id": "16312664-8946-4e0d-94cc-2f04b4a4cdf2",
@@ -11771,13 +9319,10 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.0283203125,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     },
                     {
                       "id": "b6cfe345-fae1-4676-a1b2-1668267634ed",
@@ -11785,13 +9330,10 @@
                       "format": "Acrobat PDF 1.6",
                       "puid": "fmt/20",
                       "size": 0.07654857635498047,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Portable Document Format"
                     },
                     {
                       "id": "9cdb5bb9-a3be-4d35-9274-72ac1e003d8e",
@@ -11799,13 +9341,10 @@
                       "format": "Hypertext Markup Language 4.0",
                       "puid": "fmt/99",
                       "size": 0.019969940185546875,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Text (Markup)"
                     },
                     {
                       "id": "5115ebdd-50a4-4d2f-ada8-9eea06d4da40",
@@ -11813,33 +9352,22 @@
                       "format": "Microsoft Word Document 97-2003",
                       "puid": "fmt/40",
                       "size": 0.02587890625,
-                      "bulk_extractor_reports": [
-
-                      ],
+                      "bulk_extractor_reports": [],
                       "type": "file",
-                      "tags": [
-
-                      ]
+                      "tags": [],
+                      "group": "Word Processing"
                     }
                   ],
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "directory",
                   "puid": "",
-                  "tags": [
-
-                  ]
+                  "tags": []
                 }
               ],
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "directory",
               "puid": "",
-              "tags": [
-
-              ]
+              "tags": []
             },
             {
               "id": "7138fb42-8465-4864-a349-a142678fe739",
@@ -11859,13 +9387,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.02734375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "81d38289-5dd7-4b30-b317-0f140a10e347",
@@ -11873,13 +9398,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.0283203125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "251d1018-4e3f-4a76-ba8e-469040ec2fee",
@@ -11887,13 +9409,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.04052734375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "0be77823-4276-41b3-9032-c58747c848b2",
@@ -11901,13 +9420,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.017578125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "c86c9da9-c96a-4667-86fb-4ed7d1e459f5",
@@ -11915,13 +9431,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.0263671875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "984b03ba-4b49-4788-9c0d-3e947e1a706e",
@@ -11929,13 +9442,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.02392578125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "a14c9037-48e4-42f7-b8cc-b982c95cdbe9",
@@ -11943,13 +9453,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.02978515625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "7a146662-32e0-4f47-99ab-db45a52ad41f",
@@ -11957,13 +9464,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.0361328125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "9a055d83-0d18-4f4b-9dfb-b4c30d58bba7",
@@ -11971,13 +9475,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.04248046875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "34cb6798-9e1c-48b9-a9fa-44804c7ac05b",
@@ -11985,13 +9486,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.03076171875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "e566a1a5-f8a7-4c46-9769-026e391c56fb",
@@ -11999,13 +9497,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.02587890625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "1358e5f6-312e-4875-a5bb-9cc4cfb6a430",
@@ -12013,13 +9508,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.0302734375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "934cf71f-b74f-417c-bbf1-b6d835589e81",
@@ -12027,13 +9519,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.0302734375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "02a9a091-a16b-4f12-9168-72a4fc4063d9",
@@ -12041,13 +9530,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.03466796875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "9511cd47-3de6-4bca-92b3-291648597f3e",
@@ -12055,13 +9541,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.02734375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "2a59646a-510f-43d8-9cbb-3811dbc07028",
@@ -12069,13 +9552,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.04541015625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "4077f08e-7759-4dc4-99e7-129981e1eb88",
@@ -12083,13 +9563,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.033203125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "cf0826bb-02db-4bd7-958f-12bbe7acd143",
@@ -12097,13 +9574,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.0302734375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "98d8a818-04eb-4ea4-a596-8cf0a37f3483",
@@ -12111,13 +9585,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.0390625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "6fe69727-81b6-45c0-aa23-47c6f8e7e8d8",
@@ -12125,13 +9596,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.03759765625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "bb42cba2-a016-463d-8165-72162a856f36",
@@ -12139,13 +9607,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.02294921875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "0bc1d393-32ab-49fc-86e8-13379eabcc9a",
@@ -12153,13 +9618,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.0361328125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "9a3d1321-3a5e-41b2-8b92-90bf28a64a9f",
@@ -12167,13 +9629,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.03173828125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "c691969e-4aab-4b95-b7b8-ce0b0df934c5",
@@ -12181,13 +9640,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.0361328125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "03ee42c2-a9b8-4f71-b44d-ee769ad3091c",
@@ -12195,13 +9651,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.02294921875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "728b9ec5-8313-42e0-9c76-c80433b5bad2",
@@ -12209,13 +9662,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.064453125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "8e70c704-ab40-40e9-9995-6c9ba478315d",
@@ -12223,13 +9673,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.037109375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "f76295ff-f2fd-49b4-8fc0-06e5b41a0e21",
@@ -12237,13 +9684,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.1318359375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "e6c8545b-093e-44eb-8ade-4cc79ee3df98",
@@ -12251,13 +9695,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.02880859375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "a998a205-34e8-4848-945d-837c8803b543",
@@ -12265,13 +9706,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.044921875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "670c716b-f6ca-47cd-9590-e4f17e355158",
@@ -12279,13 +9717,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.03662109375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "a8499275-22bc-418a-9021-7e29d52e85e2",
@@ -12293,13 +9728,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.03173828125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "40769334-200a-45ac-b226-d063f17931f1",
@@ -12307,13 +9739,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.0595703125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "c4d8ed8f-2bf1-4b05-a82c-f4f57d725f8e",
@@ -12321,13 +9750,10 @@
                   "format": "Excel 97 Workbook",
                   "puid": "fmt/61",
                   "size": 0.01806640625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Spreadsheet"
                 },
                 {
                   "id": "8ead7e2e-ba40-4aba-9781-0e984e2037de",
@@ -12335,13 +9761,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.0322265625,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "879328d6-ec06-4447-b3c4-611204ec71e6",
@@ -12349,13 +9772,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.03076171875,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "c3f1f342-873b-46d2-ba35-b207249a0ec2",
@@ -12363,13 +9783,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.02880859375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "7b511d12-7889-4294-b3e5-c84d5f340156",
@@ -12377,13 +9794,10 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.02734375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 },
                 {
                   "id": "09a81af7-804c-4008-9e73-8040ebe5cd58",
@@ -12391,43 +9805,28 @@
                   "format": "Microsoft Word Document 97-2003",
                   "puid": "fmt/40",
                   "size": 0.068359375,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Word Processing"
                 }
               ],
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "directory",
               "puid": "",
-              "tags": [
-
-              ]
+              "tags": []
             }
           ],
-          "bulk_extractor_reports": [
-
-          ],
+          "bulk_extractor_reports": [],
           "type": "directory",
           "puid": "",
-          "tags": [
-
-          ]
+          "tags": []
         }
       ],
-      "bulk_extractor_reports": [
-
-      ],
+      "bulk_extractor_reports": [],
       "type": "transfer",
       "puid": "",
-      "tags": [
-
-      ]
+      "tags": []
     },
     {
       "id": "49a16b4d-beb1-4bbf-ada0-e362d4f32651",
@@ -12486,13 +9885,10 @@
               "puid": "fmt/412",
               "extension": ".docx",
               "size": 0.010906219482421875,
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "file",
-              "tags": [
-
-              ]
+              "tags": [],
+              "group": "Word Processing"
             },
             {
               "id": "c93564d6-306c-400f-9bfe-73508ef1addf",
@@ -12506,9 +9902,8 @@
                 "pii"
               ],
               "type": "file",
-              "tags": [
-
-              ]
+              "tags": [],
+              "group": "Presentation"
             },
             {
               "id": "7fc27b8f-fd4e-4220-bd6d-9db98fb14c9d",
@@ -12516,13 +9911,10 @@
               "format": "Acrobat PDF 1.5",
               "puid": "fmt/19",
               "size": 0.037242889404296875,
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "file",
-              "tags": [
-
-              ]
+              "tags": [],
+              "group": "Portable Document Format"
             },
             {
               "id": "8ca89491-5b9a-45e0-8202-3e1a1357eab4",
@@ -12531,39 +9923,28 @@
               "puid": "x-fmt/18",
               "extension": ".csv",
               "size": 0.0016050338745117188,
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "file",
-              "tags": [
-
-              ]
+              "tags": [],
+              "group": "Text (Plain)"
             },
             {
               "id": "d2523802-203b-43e5-b5a9-c719985f726b",
               "title": "Employee Database.accdb",
               "size": 0.37109375,
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "file",
               "puid": "",
-              "tags": [
-
-              ]
+              "tags": []
             },
             {
               "id": "2927af84-d519-41f6-8bda-5c1caec67d0c",
               "title": "Employee Database.mdb",
               "size": 0.21875,
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "file",
               "puid": "",
-              "tags": [
-
-              ]
+              "tags": []
             },
             {
               "id": "e198fa44-5958-4039-9273-7239e5c7e571",
@@ -12571,13 +9952,10 @@
               "format": "Excel 97 Workbook",
               "puid": "fmt/61",
               "size": 0.01953125,
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "file",
-              "tags": [
-
-              ]
+              "tags": [],
+              "group": "Spreadsheet"
             },
             {
               "id": "7fce5968-013c-46f5-9e9b-3774b2aa5cb0",
@@ -12590,9 +9968,8 @@
                 "pii"
               ],
               "type": "file",
-              "tags": [
-
-              ]
+              "tags": [],
+              "group": "Portable Document Format"
             },
             {
               "id": "a7bf717f-c0bd-4161-9a02-a7cb1674c634",
@@ -12605,9 +9982,8 @@
                 "ccn"
               ],
               "type": "file",
-              "tags": [
-
-              ]
+              "tags": [],
+              "group": "Portable Document Format"
             },
             {
               "id": "875d8e59-2ff3-4e9e-a4dd-90edd4152305",
@@ -12615,13 +9991,10 @@
               "format": "Microsoft Word Document 97-2003",
               "puid": "fmt/40",
               "size": 0.02978515625,
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "file",
-              "tags": [
-
-              ]
+              "tags": [],
+              "group": "Word Processing"
             },
             {
               "id": "c233ba1e-014b-4d74-958a-fb05dabc7932",
@@ -12630,13 +10003,10 @@
               "puid": "fmt/214",
               "extension": ".xlsx",
               "size": 0.011753082275390625,
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "file",
-              "tags": [
-
-              ]
+              "tags": [],
+              "group": "Spreadsheet"
             },
             {
               "id": "8f5abbd7-046f-40bd-bae6-6646463c2a41",
@@ -12651,9 +10021,8 @@
                 "ccn"
               ],
               "type": "file",
-              "tags": [
-
-              ]
+              "tags": [],
+              "group": "Package"
             },
             {
               "id": "61f32c21-46b8-442f-9d55-e1828ea788b5",
@@ -12661,13 +10030,10 @@
               "format": "Powerpoint 97-2002",
               "puid": "fmt/126",
               "size": 0.1494140625,
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "file",
-              "tags": [
-
-              ]
+              "tags": [],
+              "group": "Presentation"
             },
             {
               "id": "d12aaf8b-1265-47a4-97c3-64ab03fb2c20",
@@ -12686,23 +10052,16 @@
                   "puid": "x-fmt/111",
                   "extension": ".txt",
                   "size": 0.05178642272949219,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Text (Plain)"
                 }
               ],
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "directory",
               "puid": "",
-              "tags": [
-
-              ]
+              "tags": []
             },
             {
               "id": "a2f5cfb5-87eb-47be-9c97-5ae5837f5410",
@@ -12721,13 +10080,10 @@
                   "puid": "x-fmt/111",
                   "extension": ".txt",
                   "size": 0.00034046173095703125,
-                  "bulk_extractor_reports": [
-
-                  ],
+                  "bulk_extractor_reports": [],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Text (Plain)"
                 },
                 {
                   "id": "97331076-6932-4e19-ad9a-7c31115493e8",
@@ -12741,19 +10097,14 @@
                     "ccn"
                   ],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Text (Plain)"
                 }
               ],
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "directory",
               "puid": "",
-              "tags": [
-
-              ]
+              "tags": []
             },
             {
               "id": "184f3861-fd90-4fdb-96da-6d595da56cd7",
@@ -12778,39 +10129,26 @@
                     "ccn"
                   ],
                   "type": "file",
-                  "tags": [
-
-                  ]
+                  "tags": [],
+                  "group": "Text (Plain)"
                 }
               ],
-              "bulk_extractor_reports": [
-
-              ],
+              "bulk_extractor_reports": [],
               "type": "directory",
               "puid": "",
-              "tags": [
-
-              ]
+              "tags": []
             }
           ],
-          "bulk_extractor_reports": [
-
-          ],
+          "bulk_extractor_reports": [],
           "type": "directory",
           "puid": "",
-          "tags": [
-
-          ]
+          "tags": []
         }
       ],
-      "bulk_extractor_reports": [
-
-      ],
+      "bulk_extractor_reports": [],
       "type": "transfer",
       "puid": "",
-      "tags": [
-
-      ]
+      "tags": []
     }
   ]
 }

--- a/app/index.html
+++ b/app/index.html
@@ -153,6 +153,8 @@
       </div>
       <div class='panel-body' ng-controller="FileListController as vm">
         <div ng-if="vm.file_list.files.length > 0">
+          <p><b><ng-pluralize count="vm.file_list.files.length" when="{'1': '1 object', 'other': '{} objects'}"></ng-pluralize></b> in list, <ng-pluralize count="vm.selected.length" when="{'1': '1 object', 'other': '{} objects'}"></ng-pluralize> selected</p>
+
           <fieldset>
             <label for='start-date-facet'>Date range start</label>
             <input type="text"

--- a/app/report/format.html
+++ b/app/report/format.html
@@ -8,9 +8,9 @@
     <th><a ng-click="set_sort_property('size', 'format_sort_property', 'format_reverse')">Size</a></th>
   </tr>
   <tr ng-repeat="record in records.selected | facet | format_data | orderBy: format_sort_fn : format_reverse">
-    <td><a ng-click="set_file_list(record)">{{ record.format }}</a></td>
+    <td><a ng-click="set_file_list(record.format, 'format')">{{ record.format }}</a></td>
     <td><a target="_blank" href="http://apps.nationalarchives.gov.uk/pronom/{{ record.data.puid }}">{{ record.data.puid }}</a> <i ng-if='record.data.puid' class='fa fa-external-link'></i></td>
-    <td>{{ record.data.group }}</td>
+    <td><a ng-click="set_file_list(record.data.group, 'group')">{{ record.data.group }}</a></td>
     <td><ng-pluralize count="record.data.count" when="{'1': '1 object', 'other': '{} objects'}"></ng-pluralize></td>
     <td>{{ record.data.size | number }} MB</td>
   </tr>

--- a/app/report/report.controller.js
+++ b/app/report/report.controller.js
@@ -35,12 +35,11 @@
     $scope.tag_sort_fn = function(args) {
       var tag = args[0], count = args[1];
       return $scope.tag_sort_property === 'tag' ? tag : count;
-    }
+    };
 
-    $scope.set_file_list = function(record) {
-      var type = record.format;
+    $scope.set_file_list = function(type, attr) {
       FileList.files = SelectedFiles.selected.filter(function(file) {
-        return file.format == type;
+        return file[attr] === type;
       });
     };
 

--- a/test/unit/aggregationFiltersSpec.js
+++ b/test/unit/aggregationFiltersSpec.js
@@ -10,6 +10,7 @@ describe('AggregationFilters', function() {
     'id': '054a0f2c-79bb-4051-b82b-4b0f14564811',
     'title': 'lion.svg',
     'format': 'Scalable Vector Graphics 1.0',
+    'group': 'Image (Vector)',
     'type': 'file',
     'puid': 'fmt/91',
     'size': 5,
@@ -19,6 +20,7 @@ describe('AggregationFilters', function() {
     'id': '7f70d25c-be05-4950-a384-dac159926960',
     'title': 'rose_quartz.svg',
     'format': 'Scalable Vector Graphics 1.0',
+    'group': 'Image (Vector)',
     'type': 'file',
     'puid': 'fmt/91',
     'size': 2,
@@ -29,6 +31,7 @@ describe('AggregationFilters', function() {
     'id': '4e941898-3914-4add-b1f6-476580862069',
     'title': 'pearl.png',
     'format': 'PNG 1.0',
+    'group': 'Image (Raster)',
     'type': 'file',
     'puid': 'fmt/11',
     'size': 13,
@@ -39,6 +42,7 @@ describe('AggregationFilters', function() {
     'id': 'dc08bcee-c4b9-490e-a98e-a884c4a9973c',
     'title': 'pptC1.tmp',
     'format': 'Generic AIFF',
+    'group': 'Audio',
     'extension': '.aif',
     'size': 34,
     'bulk_extractor_reports': [],
@@ -50,6 +54,7 @@ describe('AggregationFilters', function() {
     'id': 'b2a14653-5fd8-458c-b4ae-ccaab4b46b0c',
     'title': 'lapis_lazuli.tiff',
     'format': 'TIFF for Image Technology (TIFF/IT)',
+    'group': 'Image (Raster)',
     'type': 'file',
     'puid': 'fmt/153',
     'size': 89,
@@ -72,35 +77,6 @@ describe('AggregationFilters', function() {
       tag_count = $injector.get('$filter')('tag_count');
     });
   });
-  beforeEach(angular.mock.inject(function(_$httpBackend_, Transfer) {
-    _$httpBackend_.when('GET', '/transfers.json').respond({
-      'formats': [
-        {
-          'title': 'Scalable Vector Graphics 1.0',
-          'group': 'Image (Vector)',
-          'puid': 'fmt/91',
-        },
-        {
-          'title': 'PNG 1.0',
-          'group': 'Image (Raster)',
-          'puid': 'fmt/11',
-        },
-        {
-          'title': 'TIFF for Image Technology (TIFF/IT)',
-          'group': 'Image (Raster)',
-          'puid': 'fmt/153',
-        },
-        {
-          'title': 'Generic AIFF',
-          'group': 'Audio',
-          'puid': '',
-        },
-      ],
-      'transfers': transfers,
-    });
-    Transfer.resolve();
-    _$httpBackend_.flush();
-  }));
 
   it('should aggregate data about multiple files with the same format', function() {
     var aggregate_data = format_data(fmt_91_records);


### PR DESCRIPTION
Add format group to file info in transfers.json (script also condensed empty lists to one line), use that info to send files to file list.  Also display count of files (& selected files) in file list.
