### PR TITLE
ArchivesSpace: use getList, not customGET

### DIFF
--- a/app/services/archivesspace.service.js
+++ b/app/services/archivesspace.service.js
@@ -7,7 +7,7 @@
       var ArchivesSpace = Restangular.all('archivesspace.json');
       return {
         all: function() {
-          return ArchivesSpace.customGET();
+          return ArchivesSpace.getList();
         },
         get: function(id) {
           var url_fragment = id.replace(/\//g, '-');


### PR DESCRIPTION
This ensures that each of the retrieved items will have Restangular methods, allowing them to POST back to the server.

I plan to use this in an Archivematica PR, to add POST as a method on `/access/:system/:id` in order to allow modifying records.
