### PR TITLE
ArchivesSpace: submit record changes to AS

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -229,7 +229,7 @@
         <input type='button'
                class='btn btn-primary'
                id='edit_record'
-               ng-disabled="!selected"
+               ng-disabled="!selected || selected.request_pending"
                ng-click="edit(selected)"
                value='Edit Metadata'>
         <input type='button'


### PR DESCRIPTION
This alters the edit workflow to PUT the records to the dashboard to submit the changes to AS. Update the record in the UI right away, so there's no lag, but back it out if the response returns back with a non-successful response. Also adds an alert if the edit is unsuccessful.

This adds a "request_pending" property to a node whose edit hasn't yet been resolved; this will prevent any future edits to the same record until the request resolves, to avoid edit conflicts.

The PUT uses the API defined in artefactual/archivematica#281.
