### PR TITLE
Disable cache

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -37,7 +37,6 @@ angular.module('appraisalTab', [
 
 config(['RestangularProvider', function(RestangularProvider) {
   RestangularProvider.setRequestSuffix('/');
-  RestangularProvider.setDefaultHttpFields({cache: true});
 }]).
 
 config(['$routeSegmentProvider', function($routeSegmentProvider) {


### PR DESCRIPTION
Certain parts of the app, like SIP arrange, need to redo requests relatively soon after making changes that would affect the response; this can result in stale data being returned from the cache.
