### PR TITLE
transferSpec: fix tests

### DIFF
--- a/test/unit/transferSpec.js
+++ b/test/unit/transferSpec.js
@@ -2,8 +2,8 @@
 
 describe('Transfer', function() {
   beforeEach(module('transferService'));
-  beforeEach(angular.mock.inject(function(_$httpBackend_) {
-    _$httpBackend_.when('GET', '/ingest/appraisal_list?field=&query=&type=term').respond({
+  beforeEach(angular.mock.inject(function(Transfer) {
+    Transfer.resolve({
       'formats': [
         {
           'label': 'Powerpoint 97-2002',
@@ -34,46 +34,28 @@ describe('Transfer', function() {
     });
   }));
 
-  it('should return a JSON array of objects when fetching transfer backlog records', inject(function(_$httpBackend_, Transfer) {
-    Transfer.all().then(function(objects) {
-        expect(objects.transfers.length).toEqual(1);
-        expect(objects.transfers[0].id).toEqual('d5700e44-68f1-4eec-a7e4-c5a5c7da2373');
-    });
-    _$httpBackend_.flush();
-  }));
-
-  it('should be able to track a copy of fetched transfers on itself', inject(function(_$httpBackend_, Transfer) {
-    Transfer.resolve();
-    _$httpBackend_.flush();
+  it('should be able to track a copy of fetched transfers on itself', inject(function(Transfer) {
     expect(Transfer.data.length).toEqual(1);
     expect(Transfer.data[0].id).toEqual('d5700e44-68f1-4eec-a7e4-c5a5c7da2373');
   }));
 
-  it('should provide a flat map of all stored transfers using IDs as keys', inject(function(_$httpBackend_, Transfer) {
-    Transfer.resolve();
-    _$httpBackend_.flush();
+  it('should provide a flat map of all stored transfers using IDs as keys', inject(function(Transfer) {
     expect(Transfer.id_map['d5700e44-68f1-4eec-a7e4-c5a5c7da2373'].title).toEqual('Images-49c47319-1387-48c4-aab7-381923f07f7c');
   }));
 
-  it('should be able to track a copy of the fetched transfers\' formats on itself', inject(function(_$httpBackend_, Transfer) {
-    Transfer.resolve();
-    _$httpBackend_.flush();
+  it('should be able to track a copy of the fetched transfers\' formats on itself', inject(function(Transfer) {
     expect(Transfer.formats.length).toEqual(1);
     expect(Transfer.formats[0].puid).toEqual('fmt/126');
   }));
 
-  it('should be able to add tags to files', inject(function(_$httpBackend_, Transfer) {
-    Transfer.resolve();
-    _$httpBackend_.flush();
+  it('should be able to add tags to files', inject(function(Transfer) {
     var ruby = Transfer.id_map['042340ba-e682-4454-aa26-a9230de79c5f'];
     expect(ruby.tags.length).toEqual(0);
     Transfer.add_tag('042340ba-e682-4454-aa26-a9230de79c5f', 'test', true);
     expect(ruby.tags.length).toEqual(1);
   }));
 
-  it('should be able to remove tags for a given file', inject(function(_$httpBackend_, Transfer) {
-    Transfer.resolve();
-    _$httpBackend_.flush();
+  it('should be able to remove tags for a given file', inject(function(Transfer) {
     var ruby = Transfer.id_map['042340ba-e682-4454-aa26-a9230de79c5f'];
     Transfer.add_tag('042340ba-e682-4454-aa26-a9230de79c5f', 'test', true);
     expect(ruby.tags.length).toEqual(1);
@@ -81,9 +63,7 @@ describe('Transfer', function() {
     expect(ruby.tags.length).toEqual(0);
   }));
 
-  it('should be able to remove all tags for a given file if no tag is specified', inject(function(_$httpBackend_, Transfer) {
-    Transfer.resolve();
-    _$httpBackend_.flush();
+  it('should be able to remove all tags for a given file if no tag is specified', inject(function(Transfer) {
     var ruby = Transfer.id_map['042340ba-e682-4454-aa26-a9230de79c5f'];
     Transfer.add_tag('042340ba-e682-4454-aa26-a9230de79c5f', 'test1', true);
     Transfer.add_tag('042340ba-e682-4454-aa26-a9230de79c5f', 'test2', true);
@@ -92,12 +72,10 @@ describe('Transfer', function() {
     expect(ruby.tags.length).toEqual(0);
   }));
 
-  it('should track a flat list of all applied tags', inject(function(_$httpBackend_, Transfer) {
-    Transfer.resolve();
-    _$httpBackend_.flush();
+  it('should track a flat list of all applied tags', inject(function(Transfer) {
     expect(Transfer.tags).toEqual([]);
     Transfer.add_tag('042340ba-e682-4454-aa26-a9230de79c5f', 'test1');
     Transfer.add_tag('c3908e0d-3ac7-4603-8d0b-9b26a0df9c64', 'test2');
     expect(Transfer.tags).toEqual(['test1', 'test2']);
-  }))
+  }));
 });


### PR DESCRIPTION
These were broken by the change made in 031ea3c9a5357cd5294d083ec6ae00a960d5d446.
