### PR TITLE
SipArrange: reformat entries in the service

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -26,6 +26,7 @@ angular.module('appraisalTab', [
   'analysisController',
   'alertController',
   'archivesSpaceController',
+  'arrangementController',
   'examineContentsController',
   'facetController',
   'fileListController',

--- a/app/arrangement/arrangement.controller.js
+++ b/app/arrangement/arrangement.controller.js
@@ -1,0 +1,198 @@
+'use strict';
+
+(function() {
+  angular.module('arrangementController', ['sipArrangeService']).
+
+  controller('ArrangementController', ['$scope', 'Alert', 'Transfer', 'SipArrange', function($scope, Alert, Transfer, SipArrange) {
+    var vm = this;
+
+    var load_data = function() {
+      SipArrange.list_contents().then(function(data) {
+        vm.data = data.directories.map(function(directory) {
+          return {
+            title: directory,
+            directory: true,
+            children: [],
+            // "path" tracks the full path to the directory, including
+            // all of its parents.
+            // Since these are top-level directories, their paths are the
+            // same as their names.
+            path: directory,
+            display: true,
+            properties: data.properties[directory],
+            children_fetched: false,
+          };
+        });
+      });
+    };
+
+    vm.options = {
+      dirSelectable: true,
+      isLeaf: function(node) {
+        return !node.directory;
+      },
+    };
+    vm.filter_expression = {display: true};
+    vm.filter_comparator = true;
+
+    vm.on_toggle = function(node, expanded) {
+      if (!expanded || node.children_fetched) {
+        return;
+      }
+
+      var path = '/arrange/' + node.path;
+      SipArrange.list_contents(path).then(function(data) {
+        node.children = data.entries.map(function(element) {
+          var child = {
+            title: element,
+            path: node.title + '/' + element,
+            parent: node,
+            display: true,
+            properties: data.properties[element],
+          }
+
+          if (data.directories.indexOf(element) > -1) {
+            // directory
+            child.directory = true;
+            child.children = [];
+            child.children_fetched = false;
+          } else {
+            // file
+            child.directory = false;
+          }
+
+          return child;
+        });
+
+        node.children_fetched = true;
+      });
+    };
+
+    vm.create_directory = function(parent) {
+      var path = prompt('Name of new directory?');
+      if (!path) {
+        return;
+      }
+
+      if (parent === undefined) {
+        var target = vm.data;
+        var full_path = path;
+      } else {
+        var target = parent.children;
+        var full_path = parent.path + '/' + path;
+      }
+
+      SipArrange.create_directory('/arrange/' + full_path).then(function(success) {
+        target.push({
+          title: path,
+          directory: true,
+          children: [],
+          path: full_path,
+          parent: parent,
+          display: true,
+          children_fetched: false,
+        });
+      });
+    };
+
+    vm.delete_directory = function(element) {
+      SipArrange.remove('/arrange/' + element.path).then(function(success) {
+        // `element.parent` is undefined if this is a root-level directory
+        var parent = element.parent ? element.parent.children : vm.data;
+
+        var idx = parent.indexOf(element);
+        parent.splice(idx, 1);
+      });
+    };
+
+    var hide_elements = function(node) {
+      node.display = false;
+      if (node.children) {
+        for (var i = 0; i < node.children.length; i++) {
+          hide_elements(node.children[i]);
+        }
+      }
+    };
+
+    vm.start_sip = function(directory) {
+      var on_success = function(success) {
+        // Hide elements from the UI so user doesn't try to start it again
+        hide_elements(directory);
+
+        Alert.alerts.push({
+          'type': 'success',
+          'message': 'SIP successfully started!',
+        });
+      };
+
+      var on_failure = function(error) {
+        Alert.alerts.push({
+          'type': 'danger',
+          'message': 'SIP could not be started! Check dashboard logs.',
+        });
+      };
+
+      SipArrange.start_sip('/arrange/' + directory.path + '/').then(on_success, on_failure);
+    };
+
+    // Filter the list of dragged files to contain only files with the "display"
+    // parameter, so that only visibly selected files are dragged over
+    var filter_files = function(file) {
+      if (!file.display) {
+        return {};
+      }
+
+      // Filter children recursively
+      if (file.children) {
+        var children = file.children;
+        file.children = [];
+        angular.forEach(children, function(child) {
+          child = filter_files(child);
+          // Omit empty objects, or directories whose children have all been filtered out
+          if (child.id && child.type === 'file' || (child.children && child.children.length > 0)) {
+            file.children.push(child);
+          }
+        });
+      }
+
+      return file;
+    };
+
+    vm.drop = function(unused, ui) {
+      var self = this;
+
+      var file_uuid = ui.draggable.attr('uuid');
+      var file = Transfer.id_map[file_uuid];
+      // create a deep copy of the file and its children so we don't mutate
+      // the copies used in the backlog
+      file = filter_files(_.extend({}, file));
+
+      var on_failure = function(error) {
+        Alert.alerts.push({
+          'type': 'danger',
+          'message': 'Failed to copy files to SIP arrange; check Dashboard logs.',
+        });
+      };
+      var on_success = function(success) {
+        // Reload the tree, rather than recreating the structure locally,
+        // since it's possible the structure of the dragged files
+        // may differ from the structure of what actually entered arrange.
+        // TODO: when bugs about dragging contents into the wrong directory are
+        //       resolved, maybe want to reload only the directory into which
+        //       contents were dragged and not the entire tree.
+        load_data();
+      };
+
+      var source_path;
+      if (file.type === 'file') {
+        source_path = file.relative_path;
+      } else {
+        source_path = file.relative_path + '/';
+      }
+
+      SipArrange.copy_to_arrange('/originals/' + source_path, '/arrange/' + self.path + '/').then(on_success, on_failure);
+    };
+
+    load_data();
+  }]);
+})();

--- a/app/arrangement/arrangement.controller.js
+++ b/app/arrangement/arrangement.controller.js
@@ -7,22 +7,8 @@
     var vm = this;
 
     var load_data = function() {
-      SipArrange.list_contents().then(function(data) {
-        vm.data = data.directories.map(function(directory) {
-          return {
-            title: directory,
-            directory: true,
-            children: [],
-            // "path" tracks the full path to the directory, including
-            // all of its parents.
-            // Since these are top-level directories, their paths are the
-            // same as their names.
-            path: directory,
-            display: true,
-            properties: data.properties[directory],
-            children_fetched: false,
-          };
-        });
+      SipArrange.list_contents().then(function(directories) {
+        vm.data = directories;
       });
     };
 
@@ -41,29 +27,8 @@
       }
 
       var path = '/arrange/' + node.path;
-      SipArrange.list_contents(path).then(function(data) {
-        node.children = data.entries.map(function(element) {
-          var child = {
-            title: element,
-            path: node.title + '/' + element,
-            parent: node,
-            display: true,
-            properties: data.properties[element],
-          }
-
-          if (data.directories.indexOf(element) > -1) {
-            // directory
-            child.directory = true;
-            child.children = [];
-            child.children_fetched = false;
-          } else {
-            // file
-            child.directory = false;
-          }
-
-          return child;
-        });
-
+      SipArrange.list_contents(path).then(function(entries) {
+        node.children = entries;
         node.children_fetched = true;
       });
     };
@@ -82,16 +47,8 @@
         var full_path = parent.path + '/' + path;
       }
 
-      SipArrange.create_directory('/arrange/' + full_path).then(function(success) {
-        target.push({
-          title: path,
-          directory: true,
-          children: [],
-          path: full_path,
-          parent: parent,
-          display: true,
-          children_fetched: false,
-        });
+      SipArrange.create_directory('/arrange/' + full_path, path, parent).then(function(result) {
+        target.push(result);
       });
     };
 

--- a/app/index.html
+++ b/app/index.html
@@ -257,6 +257,55 @@
       </div>
     </div>
   </ui-minimize-panel>
+
+  <ui-minimize-panel title='Arrangement'>
+  <div class='panel panel-default'>
+    <div class='panel-heading'>
+      Arrangement
+    </div>
+    <div class="transfer-tree panel-body" ng-controller="ArrangementController as vm">
+      <input type="button"
+             class="btn btn-primary"
+             id="delete_directory"
+             ng-disabled="!vm.selected"
+             ng-click="vm.delete_directory(vm.selected)"
+             value="Delete">
+      <input type="button"
+             class="btn btn-primary"
+             id="start_sip_arrangemnt"
+             ng-disabled="!vm.selected"
+             ng-click="vm.start_sip(vm.selected)"
+             value="Create SIP">
+      <input type="button"
+             class="btn btn-primary"
+             id="edit_metadata_arrangement"
+             ng-disabled="true"
+             value="Edit Metadata">
+      <input type="button"
+             class="btn btn-primary"
+             id="add_directory"
+             ng-disabled="!vm.data"
+             ng-click="vm.create_directory(vm.selected)"
+             value="Add Directory">
+      <treecontrol id="arrangement-tree"
+            class="tree-classic"
+            tree-model="vm.data"
+            options="vm.options"
+            selected-node="vm.selected"
+            on-node-toggle="vm.on_toggle(node, expanded)"
+            filter-expression="vm.filter_expression"
+            filter-comparator="vm.filter_comparator">
+        <!-- New files can only be dragged into directories, not other files -->
+        <span tree-droppable on-drop="vm.drop" ng-if="node.directory">
+          {{ node.title }} <span ng-if="node.properties">({{ node.properties.display_string }})</span>
+        </span>
+        <span ng-if="!node.directory">
+          {{ node.title }}
+        </span>
+      </treecontrol>
+    </div>
+  </div>
+  </ui-minimize-panel>
   </ui-minimize-bar>
 
   <script src="bower_components/lodash/dist/lodash.min.js"></script>
@@ -295,6 +344,7 @@
   <script src="alert/alert.controller.js"></script>
   <script src="archivesspace/archivesspace.controller.js"></script>
   <script src="analysis/analysis.controller.js"></script>
+  <script src="arrangement/arrangement.controller.js"></script>
   <script src="examine_contents/examine_contents.controller.js"></script>
   <script src="facet_selector/facet_selector.controller.js"></script>
   <script src="file_list/file_list.controller.js"></script>

--- a/test/unit/sip_arrangeSpec.js
+++ b/test/unit/sip_arrangeSpec.js
@@ -3,7 +3,7 @@
 describe('SipArrange', function() {
   beforeEach(module('sipArrangeService'));
   beforeEach(angular.mock.inject(function(_$httpBackend_) {
-    _$httpBackend_.when('POST', '/filesystem/create_directory_within_arrange', 'path=bmV3X3BhdGg%3D').respond({'success': true});
+    _$httpBackend_.when('POST', '/filesystem/create_directory_within_arrange', 'path=L2FycmFuZ2UvYS9mdWxsL25ld19wYXRo').respond({'success': true});
     _$httpBackend_.when('GET', '/filesystem/contents/arrange?path=').respond({
       'entries': [
         'VGVzdA==',
@@ -14,8 +14,8 @@ describe('SipArrange', function() {
       'properties': [],
     });
     _$httpBackend_.when('GET', '/filesystem/contents/arrange?path=L2FycmFuZ2UvY2hpbGQv').respond({
-      'entries': [],
-      'directories': [],
+      'entries': ['ZmlsZQ==', 'ZGlyZWN0b3J5'],
+      'directories': ['ZGlyZWN0b3J5'],
       'properties': [],
     });
     _$httpBackend_.when('POST', '/filesystem/move_within_arrange', 'filepath=c291cmNl&destination=ZGVzdGluYXRpb24%3D').respond({
@@ -33,26 +33,31 @@ describe('SipArrange', function() {
   }));
 
   it('should be able to create SIP arrange directories', inject(function(_$httpBackend_, SipArrange) {
-    SipArrange.create_directory('new_path').then(function(response) {
-      expect(response.success).toBe(true);
+    var parent = {title: 'parent'};
+    SipArrange.create_directory('/arrange/a/full/new_path', 'new_path', parent).then(function(directory) {
+      expect(directory.title).toEqual('new_path');
+      expect(directory.path).toEqual('a/full/new_path');
+      expect(directory.parent).toBe(parent);
     });
     _$httpBackend_.flush();
   }));
 
   it('should be able to list arrange contents', inject(function(_$httpBackend_, SipArrange) {
-    SipArrange.list_contents().then(function(response) {
-      expect(response.entries).toEqual(['Test']);
-      expect(response.directories).toEqual(['Test']);
-      expect(response.properties).toEqual([]);
+    SipArrange.list_contents().then(function(directories) {
+      expect(directories.length).toEqual(1);
+      expect(directories[0].title).toEqual('Test');
+      expect(directories[0].directory).toBe(true);
     });
     _$httpBackend_.flush();
   }));
 
   it('should be able to list arrange contents within a given directory', inject(function(_$httpBackend_, SipArrange) {
-    SipArrange.list_contents('/arrange/child/').then(function(response) {
-      expect(response.entries).toEqual([]);
-      expect(response.directories).toEqual([]);
-      expect(response.properties).toEqual([]);
+    var parent = {title: '/a/parent/node'};
+    SipArrange.list_contents('/arrange/child/', parent).then(function(entries) {
+      expect(entries.length).toEqual(2);
+      expect(entries[0].directory).toBe(false);
+      expect(entries[0].title).toEqual('file');
+      expect(entries[1].directory).toBe(true);
     });
     _$httpBackend_.flush();
   }));


### PR DESCRIPTION
Instead of leaving reformatting these into objects within the controller, define a common data format and reformat these in the service by chaining promises.

This will make it easier to share this logic between the arrangement controller and the changes coming to the ArchivesSpace controller.

This requires #80.
