### PR TITLE
Integrate SIP arrange into ArchivesSpace

### DIFF
--- a/app/archivesspace/archivesspace.controller.js
+++ b/app/archivesspace/archivesspace.controller.js
@@ -117,11 +117,14 @@
       // Loads the children of the specified element,
       // along with arranged SIP contents that might exist
       var load_element_children = function(node) {
+        $scope.loading = true;
+
         var on_failure = function(error) {
           Alert.alerts.push({
             type: 'danger',
             message: 'Unable to fetch record ' + node.id + ' from ArchivesSpace!',
           });
+          $scope.loading = false;
         };
 
         node.children = [];
@@ -129,6 +132,7 @@
         ArchivesSpace.get_children(node.id).then(function(children) {
           node.children = node.children.concat(children);
           node.children_fetched = true;
+          $scope.loading = false;
         }, on_failure);
 
         // Also call into SIP arrange to see if there are any contents at this
@@ -190,6 +194,10 @@
       };
 
       $scope.drop = function(unused, ui) {
+        if ($scope.loading) {
+          return;
+        }
+
         var file_uuid = ui.draggable.attr('uuid');
         var file = Transfer.id_map[file_uuid];
         if (dragged_ids.indexOf(file_uuid) !== -1) {
@@ -231,6 +239,8 @@
         }
 
         $scope.$apply(function() {
+          $scope.loading = true;
+
           ArchivesSpace.create_directory(self.id).then(on_directory_creation);
 
           if ($scope.expanded_nodes.indexOf(self) === -1) {

--- a/app/index.html
+++ b/app/index.html
@@ -221,11 +221,11 @@
   </ui-minimize-panel>
 
   <ui-minimize-panel title='ArchivesSpace'>
-    <div class='panel panel-default'>
+    <div class='panel panel-default' ng-controller="ArchivesSpaceController">
       <div class='panel-heading'>
-        ArchivesSpace
+        ArchivesSpace <span ng-if="loading"><i class="fa fa-spinner fa-spin"></i></span>
       </div>
-      <div class="transfer-tree panel-body" ng-controller="ArchivesSpaceController">
+      <div class="transfer-tree panel-body">
         <input type='button'
                class='btn btn-primary'
                id='edit_record'

--- a/app/index.html
+++ b/app/index.html
@@ -242,6 +242,7 @@
                class='btn btn-primary'
                id='finalize_arrange'
                ng-disabled="!selected"
+               ng-click="finalize_arrangement(selected)"
                value='Finalize Arrangement'>
         <treecontrol id="archivesspace-tree"
                class="tree-classic"

--- a/app/services/archivesspace.service.js
+++ b/app/services/archivesspace.service.js
@@ -4,32 +4,96 @@
   angular.module('archivesSpaceService', ['restangular']).
 
   factory('ArchivesSpace', ['Restangular', function(Restangular) {
+      var id_to_urlsafe = function(id) {
+        return id.replace(/\//g, '-');
+      };
+
       var ArchivesSpace = Restangular.all('access').all('archivesspace');
       return {
         all: function() {
           return ArchivesSpace.getList();
         },
         get: function(id) {
-          var url_fragment = id.replace(/\//g, '-');
+          var url_fragment = id_to_urlsafe(id);
           return ArchivesSpace.one(url_fragment).get();
         },
         get_by_accession: function(accession) {
           return ArchivesSpace.one('accession').one(accession).getList();
         },
         get_children: function(id) {
-          var url_fragment = id.replace(/\//g, '-');
+          var url_fragment = id_to_urlsafe(id);
           return ArchivesSpace.one(url_fragment).one('children').getList();
         },
         get_levels_of_description: function() {
           return ArchivesSpace.one('levels').getList();
         },
         edit: function(id, record) {
-          var url_fragment = id.replace(/\//g, '-');
+          var url_fragment = id_to_urlsafe(id);
           return ArchivesSpace.one(url_fragment).customPUT(record);
         },
         add_child: function(id, record) {
-          var url_fragment = id.replace(/\//g, '-');
+          var url_fragment = id_to_urlsafe(id);
           return ArchivesSpace.one(url_fragment).one('children').customPOST(record);
+        },
+        create_directory: function(id) {
+          var url_fragment = id_to_urlsafe(id);
+          return ArchivesSpace.one(url_fragment).one('create_directory_within_arrange').customPOST();
+        },
+        copy_to_arrange: function(id, filepath) {
+          var url_fragment = id_to_urlsafe(id);
+          return ArchivesSpace.one(url_fragment).customPOST(
+            $.param({filepath: Base64.encode(filepath)}),
+            'copy_to_arrange',
+            {},
+            {'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'}
+          );
+        },
+        list_arrange_contents: function(id) {
+          // TODO don't clone these from SIPArrange
+          var decode_entry_response = function(response) {
+            var new_response = _.extend({}, response);
+
+            angular.forEach(['entries', 'directories'], function(key) {
+              new_response[key] = response[key].map(Base64.decode);
+            });
+            angular.forEach(response.properties, function(value, key) {
+              new_response.properties[Base64.decode(key)] = value;
+            });
+
+            return new_response;
+          };
+
+          // TODO don't dupe this from SipArrange
+          var format_results = function(data) {
+            return data.entries.map(function(element) {
+              var child = {
+                title: element,
+                path: parent ? parent.title + '/' + element : element,
+                parent: parent,
+                display: true,
+                properties: data.properties[element],
+              };
+
+              if (data.directories.indexOf(element) > -1) {
+                // directory
+                child.directory = true;
+                child.children = [];
+                child.children_fetched = false;
+              } else {
+                // file
+                child.directory = false;
+              }
+
+              return child;
+            });
+          };
+
+          var url_fragment = id_to_urlsafe(id);
+          return ArchivesSpace.one(url_fragment).one('contents').one('arrange').get(url_fragment).then(decode_entry_response).then(format_results);
+        },
+        start_sip: function(id) {
+          var url_fragment = id_to_urlsafe(id);
+          return ArchivesSpace.one(url_fragment).one('copy_from_arrange').post();
         },
       };
   }]);

--- a/test/unit/archivesspaceSpec.js
+++ b/test/unit/archivesspaceSpec.js
@@ -65,6 +65,25 @@ describe('ArchivesSpace', function() {
       'success': true,
       'message': 'Record successfully edited',
     });
+    _$httpBackend_.when('POST', '/access/archivesspace/-repositories-2-archival_objects-6/create_directory_within_arrange').respond({
+      'success': true,
+      'message': 'Creation successful.',
+    });
+    _$httpBackend_.when('POST', '/access/archivesspace/-repositories-2-archival_objects-6/copy_to_arrange').respond({
+      'message': 'Files added to the SIP.',
+    });
+    _$httpBackend_.when('GET', '/access/archivesspace/-repositories-2-archival_objects-6/contents/arrange').respond({
+      'entries': [
+        'VGVzdA==',
+      ],
+      'directories': [
+        'VGVzdA==',
+      ],
+      'properties': [],
+    });
+    _$httpBackend_.when('POST', '/access/archivesspace/-repositories-2-archival_objects-6/copy_from_arrange').respond({
+      'message': 'SIP created.',
+    });
   }));
 
   it('should be able to return a list of all ArchivesSpace records', inject(function(_$httpBackend_, ArchivesSpace) {
@@ -116,6 +135,36 @@ describe('ArchivesSpace', function() {
       'level': 'subsubseries',
     }).then(function(response) {
       expect(response.success).toBe(true);
+    });
+    _$httpBackend_.flush();
+  }));
+
+  it('should be able to create a new SIP arrange directory to back a record', inject(function(_$httpBackend_, ArchivesSpace) {
+    ArchivesSpace.create_directory('/repositories/2/archival_objects/6').then(function(result) {
+      expect(result.success).toBe(true);
+    });
+    _$httpBackend_.flush();
+  }));
+
+  it('should be able to add files to a record', inject(function(_$httpBackend_, ArchivesSpace) {
+    ArchivesSpace.copy_to_arrange('/repositories/2/archival_objects/6').then(function(result) {
+      expect(result.message).toEqual('Files added to the SIP.');
+    });
+    _$httpBackend_.flush();
+  }));
+
+  it('should be able to list arrange files within a record', inject(function(_$httpBackend_, ArchivesSpace) {
+    ArchivesSpace.list_arrange_contents('/repositories/2/archival_objects/6').then(function(records) {
+      expect(records.length).toEqual(1);
+      expect(records[0].title).toEqual('Test');
+      expect(records[0].directory).toBe(true);
+    });
+    _$httpBackend_.flush();
+  }));
+
+  it('should be able to start a SIP given a record ID', inject(function(_$httpBackend_, ArchivesSpace) {
+    ArchivesSpace.start_sip('/repositories/2/archival_objects/6').then(function(response) {
+      expect(response.message).toEqual('SIP created.');
     });
     _$httpBackend_.flush();
   }));


### PR DESCRIPTION
Requires #80 and artefactual/archivematica#293.

This has a few remaining bugs:
- [x] After files are dragged into a descriptive record, that record's descriptive record children are displayed twice.
- [ ] Records cannot be dragged within arrange. (This is also true in #80.)
- [ ] Should possibly prevent attempting to finalize an unarranged descriptive record. (Currently will let you hit the button, but warn you that it won't create a SIP. Maybe that's okay?)
- [x] Clean up commit history.
