### PR TITLE
SIP arrange fixes

### DIFF
--- a/app/arrangement/arrangement.controller.js
+++ b/app/arrangement/arrangement.controller.js
@@ -27,7 +27,7 @@
       }
 
       var path = '/arrange/' + node.path;
-      SipArrange.list_contents(path).then(function(entries) {
+      SipArrange.list_contents(path, node).then(function(entries) {
         node.children = entries;
         node.children_fetched = true;
       });

--- a/app/services/sip_arrange.service.js
+++ b/app/services/sip_arrange.service.js
@@ -56,7 +56,7 @@
         return data.entries.map(function(element) {
           var child = {
             title: element,
-            path: parent ? parent.title + '/' + element : element,
+            path: parent ? parent.path + '/' + element : element,
             parent: parent,
             display: true,
             properties: data.properties[element],


### PR DESCRIPTION
- Specify parent when calling `SIPArrange.list_contents` on a subdirectory
- Fix constructing path for nested children
