### PR TITLE
ArchivesSpace: enable dragging within arrange

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -263,8 +263,17 @@
                selected-node="selected"
                on-node-toggle="on_toggle(node, expanded)"
                expanded-nodes="expanded_nodes">
-          <span tree-droppable on-drop="drop">
+          <!-- ArchivesSpace record -->
+          <span ng-if="node.type !== 'arrange_entry'" tree-droppable on-drop="drop" file-type="record">
             {{ node.title }} <div ng-if="node.identifier">({{ node.identifier }})</div>
+          </span>
+          <!-- SIP arrange directory -->
+          <span ng-if="(node.type === 'arrange_entry') &amp;&amp; node.directory" tree-droppable tree-draggable on-drop="drop" file-type="arrange" file-path="{{ node.path }}">
+            {{ node.title }}
+          </span>
+          <!-- SIP arrange file -->
+          <span ng-if="(node.type === 'arrange_entry') &amp;&amp; !node.directory" tree-draggable file-type="arrange" file-path="{{ node.path }}">
+            {{ node.title }}
           </span>
         </treecontrol>
       </div>

--- a/app/services/archivesspace.service.js
+++ b/app/services/archivesspace.service.js
@@ -48,6 +48,15 @@
             {'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'}
           );
         },
+        move: function(filepath, id) {
+          var url_fragment = id_to_urlsafe(id);
+          return ArchivesSpace.one(url_fragment).customPOST(
+            $.param({filepath: Base64.encode(filepath)}),
+            'move_within_arrange',
+            {},
+            {'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'}
+          );
+        },
         list_arrange_contents: function(id, parent) {
           // TODO don't clone these from SIPArrange
           var decode_entry_response = function(response) {
@@ -72,6 +81,7 @@
                 parent: parent,
                 display: true,
                 properties: data.properties[element],
+                type: 'arrange_entry',
               };
 
               if (data.directories.indexOf(element) > -1) {

--- a/app/services/sip_arrange.service.js
+++ b/app/services/sip_arrange.service.js
@@ -19,6 +19,8 @@
           parent: parent,
           display: true,
           children_fetched: false,
+          type: 'arrange_entry',
+          directory: true,
         };
       };
 
@@ -48,6 +50,8 @@
             display: true,
             properties: data.properties[directory],
             children_fetched: false,
+            type: 'arrange_entry',
+            directory: true,
           };
         });
       };
@@ -60,6 +64,7 @@
             parent: parent,
             display: true,
             properties: data.properties[element],
+            type: 'arrange_entry',
           };
 
           if (data.directories.indexOf(element) > -1) {
@@ -67,9 +72,11 @@
             child.has_children = true;
             child.children = [];
             child.children_fetched = false;
+            child.directory = true;
           } else {
             // file
             child.has_children = false;
+            child.directory = false;
           }
 
           return child;


### PR DESCRIPTION
~~This is about 90% complete.~~

~~Currently, dragging items into ArchivesSpace arrange directories fails; the generated call to /access/:id/move_within_arrange is failing with the following message: `"arrange/undefined/G31DS.TIF and /arrange/-repositories-2-resources-1fe5f6f28-5cc8-47ba-8910-8cfb3c8dccea/ must be inside /arrange/"`~~

~~There appears to be two problems:~~
- ~~The part of the ArchivesSpace service which assigns the `path` attribute to the child is failing to actually assign the correct full path, due to the absence of a `path` attribute in the parent: https://github.com/artefactual-labs/appraisal-tab/blob/master/app/services/archivesspace.service.js#L71~~
- ~~There is potentially a missing leading slash on the `filepath` attribute~~

Beyond this, everything else works, though this needs a version of the `loading` parameter used in the arrangement tab to prevent conflicting calls while things are still pending.
