### PR TITLE
package.json: update deps to work with npm 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,29 +6,26 @@
   "repository": "https://github.com/artefactual-labs/appraisal-tab",
   "license": "AGPL3",
   "devDependencies": {
-    "karma": "~0.13",
-    "protractor": "^1.1.1",
-    "http-server": "^0.6.1",
     "bower": "^1.3.1",
-    "shelljs": "^0.2.6",
-    "karma-junit-reporter": "^0.2.2"
+    "http-server": "^0.6.1",
+    "karma": "~0.13",
+    "karma-chrome-launcher": "^0.2.1",
+    "karma-jasmine": "^0.3.6",
+    "karma-junit-reporter": "^0.2.2",
+    "protractor": "^1.1.1",
+    "shelljs": "^0.2.6"
   },
   "scripts": {
     "postinstall": "bower install",
-
     "prestart": "npm install",
     "start": "http-server -a localhost -p 8000 -c-1",
-
     "pretest": "npm install",
     "test": "karma start test/karma.conf.js",
     "test-single-run": "karma start test/karma.conf.js  --single-run",
-
     "preupdate-webdriver": "npm install",
     "update-webdriver": "webdriver-manager update",
-
     "preprotractor": "npm run update-webdriver",
     "protractor": "protractor e2e-tests/protractor.conf.js",
-
     "update-index-async": "node -e \"require('shelljs/global'); sed('-i', /\\/\\/@@NG_LOADER_START@@[\\s\\S]*\\/\\/@@NG_LOADER_END@@/, '//@@NG_LOADER_START@@\\n' + sed(/sourceMappingURL=angular-loader.min.js.map/,'sourceMappingURL=bower_components/angular-loader/angular-loader.min.js.map','app/bower_components/angular-loader/angular-loader.min.js') + '\\n//@@NG_LOADER_END@@', 'app/index-async.html');\""
   }
 }

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -26,7 +26,6 @@ module.exports = function(config){
 
     plugins : [
             'karma-chrome-launcher',
-            'karma-firefox-launcher',
             'karma-jasmine'
             ],
 


### PR DESCRIPTION
This adjusts the dependencies to work with npm 3.

Npm 3 removed support for [peer dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/), which were used by the dependency tree expressed in our package.json to install several of karma's plugins (karma-jasmine, karma-chrome-launcher, and karma-firefox-launcher). I've added them as direct dependencies in our package.json, which fixes the issue.

I removed the Firefox launcher from karma's configuration file because neither @Hwesta and I use it, IFAICT. We both run the unit tests in Chrome.
