### PR TITLE
ArchivesSpace: add digital object support

### DIFF
--- a/app/archivesspace/digital_object_form.html
+++ b/app/archivesspace/digital_object_form.html
@@ -1,0 +1,14 @@
+<form class="digital-object-component-form" name="digital_object_component_form">
+  <div class="row">
+    <div class="col-md-6">
+      <label>Title:</label> <input type="text" ng-model="form.title" required>
+    </div>
+    <div class="col-md-6">
+      <label>Label:</label> <input type="text" ng-model="form.label">
+    </div>
+  </div>
+  <div class="btn-group" role="group">
+    <button type="submit" class="btn btn-success" ng-click="form.ok()" ng-disabled="digital_object_component_form.$invalid">Save</button>
+    <button type="submit" class="btn btn-danger" ng-click="form.cancel()">Cancel</button>
+  </div>
+</form>

--- a/app/index.html
+++ b/app/index.html
@@ -254,7 +254,7 @@
         <input type='button'
                class='btn btn-primary'
                id='finalize_arrange'
-               ng-disabled="selected.type !== 'digital_object'"
+               ng-disabled="selected.type !== 'resource' &amp;&amp; selected.type !== 'resource_component'"
                ng-click="finalize_arrangement(selected)"
                value='Finalize Arrangement'>
         <input type='button'
@@ -270,12 +270,12 @@
                on-node-toggle="on_toggle(node, expanded)"
                expanded-nodes="expanded_nodes">
           <!-- ArchivesSpace record -->
-          <span ng-if="node.type === 'resource'" tree-droppable on-drop="drop" file-type="record">
+          <span ng-if="node.type === 'resource'" file-type="record">
             <i ng-if="node.has_children" class="fa fa-folder-o"></i>
             <i ng-if="!node.has_children" class="fa fa-file-o"></i>
             {{ node.title }} <div ng-if="node.identifier">({{ node.identifier }})</div>
           </span>
-          <span ng-if="node.type === 'resource_component'" tree-droppable on-drop="drop" file-type="record">
+          <span ng-if="node.type === 'resource_component'" file-type="record">
             <i ng-if="node.has_children" class="fa fa-folder-o"></i>
             <i ng-if="!node.has_children" class="fa fa-file-o"></i>
             <div ng-if="node.display_title">{{ node.display_title }}</div>
@@ -293,7 +293,7 @@
             {{ node.title }}
           </span>
           <!-- Digital object -->
-          <span ng-if="node.type === 'digital_object'">
+          <span ng-if="node.type === 'digital_object'" tree-droppable on-drop="drop" file-type="digital_object">
             <i class="fa fa-barcode"></i>
             {{ node.title }}
           </span>

--- a/app/index.html
+++ b/app/index.html
@@ -234,6 +234,12 @@
                value='Add New Child Record'>
         <input type='button'
                class='btn btn-primary'
+               id='add_child_record'
+               ng-disabled="selected.type !== 'resource' &amp;&amp; selected.type !== 'resource_component'"
+               ng-click="add_digital_object(selected)"
+               value='Add New Digital Object Component'>
+        <input type='button'
+               class='btn btn-primary'
                id='edit_record'
                ng-disabled="!selected || selected.request_pending"
                ng-click="edit(selected)"
@@ -248,7 +254,7 @@
         <input type='button'
                class='btn btn-primary'
                id='finalize_arrange'
-               ng-disabled="!selected"
+               ng-disabled="selected.type !== 'digital_object'"
                ng-click="finalize_arrangement(selected)"
                value='Finalize Arrangement'>
         <input type='button'
@@ -284,6 +290,11 @@
           <!-- SIP arrange file -->
           <span ng-if="(node.type === 'arrange_entry') &amp;&amp; !node.directory" tree-draggable file-type="arrange" file-path="{{ node.path }}">
             <i class="fa fa-file-code-o"></i>
+            {{ node.title }}
+          </span>
+          <!-- Digital object -->
+          <span ng-if="node.type === 'digital_object'">
+            <i class="fa fa-barcode"></i>
             {{ node.title }}
           </span>
         </treecontrol>

--- a/app/index.html
+++ b/app/index.html
@@ -257,7 +257,7 @@
                ng-click="refresh(selected)"
                value='Reload'>
         <treecontrol id="archivesspace-tree"
-               class="tree-classic"
+               class="tree-light"
                tree-model="data"
                options="options"
                selected-node="selected"
@@ -265,19 +265,25 @@
                expanded-nodes="expanded_nodes">
           <!-- ArchivesSpace record -->
           <span ng-if="node.type === 'resource'" tree-droppable on-drop="drop" file-type="record">
+            <i ng-if="node.has_children" class="fa fa-folder-o"></i>
+            <i ng-if="!node.has_children" class="fa fa-file-o"></i>
             {{ node.title }} <div ng-if="node.identifier">({{ node.identifier }})</div>
           </span>
           <span ng-if="node.type === 'resource_component'" tree-droppable on-drop="drop" file-type="record">
+            <i ng-if="node.has_children" class="fa fa-folder-o"></i>
+            <i ng-if="!node.has_children" class="fa fa-file-o"></i>
             <div ng-if="node.display_title">{{ node.display_title }}</div>
             <div ng-if="!node.display_title">{{ node.title }}</div>
             <div ng-if="node.identifier">({{ node.identifier }})</div>
           </span>
           <!-- SIP arrange directory -->
           <span ng-if="(node.type === 'arrange_entry') &amp;&amp; node.directory" tree-droppable tree-draggable on-drop="drop" file-type="arrange" file-path="{{ node.path }}">
+            <i class="fa fa-folder-o"></i>
             {{ node.title }}
           </span>
           <!-- SIP arrange file -->
           <span ng-if="(node.type === 'arrange_entry') &amp;&amp; !node.directory" tree-draggable file-type="arrange" file-path="{{ node.path }}">
+            <i class="fa fa-file-code-o"></i>
             {{ node.title }}
           </span>
         </treecontrol>

--- a/test/unit/archivesspaceSpec.js
+++ b/test/unit/archivesspaceSpec.js
@@ -72,6 +72,22 @@ describe('ArchivesSpace', function() {
     _$httpBackend_.when('POST', '/access/archivesspace/-repositories-2-archival_objects-6/copy_to_arrange').respond({
       'message': 'Files added to the SIP.',
     });
+    _$httpBackend_.when('GET', '/access/archivesspace/-repositories-2-archival_objects-7/digital_object_components').respond([{
+      'id': 1,
+    }]);
+    _$httpBackend_.when('POST', '/access/archivesspace/-repositories-2-archival_objects-7/digital_object_components').respond({
+      'id': 2,
+    });
+    _$httpBackend_.when('PUT', '/access/archivesspace/-repositories-2-archival_objects-7/digital_object_components').respond('');
+    _$httpBackend_.when('GET', '/access/archivesspace/-repositories-2-archival_objects-7/digital_object_components/2/files').respond({
+      'entries': [
+        'VGVzdA==',
+      ],
+      'directories': [
+        'VGVzdA==',
+      ],
+      'properties': [],
+    });
     _$httpBackend_.when('GET', '/access/archivesspace/-repositories-2-archival_objects-6/contents/arrange').respond({
       'entries': [
         'VGVzdA==',
@@ -146,6 +162,40 @@ describe('ArchivesSpace', function() {
   it('should be able to create a new SIP arrange directory to back a record', inject(function(_$httpBackend_, ArchivesSpace) {
     ArchivesSpace.create_directory('/repositories/2/archival_objects/6').then(function(result) {
       expect(result.success).toBe(true);
+    });
+    _$httpBackend_.flush();
+  }));
+
+  it('should be able to list digital object components for a record', inject(function(_$httpBackend_, ArchivesSpace) {
+    ArchivesSpace.digital_object_components('/repositories/2/archival_objects/7').then(function(result) {
+      expect(result.length).toBe(1);
+      expect(result[0].id).toEqual(1);
+    });
+    _$httpBackend_.flush();
+  }));
+
+  it('should be able to create a new digital object component', inject(function(_$httpBackend_, ArchivesSpace) {
+    ArchivesSpace.create_digital_object_component('/repositories/2/archival_objects/7').then(function(result) {
+      expect(result.id).toEqual(2);
+    });
+    _$httpBackend_.flush();
+  }));
+
+  it('should be able to edit an existing digital object component', inject(function(_$httpBackend_, ArchivesSpace) {
+    var updated_record = {
+      'id': 2,
+      'label': 'Updated label',
+      'title': 'Updated title',
+    };
+    ArchivesSpace.edit_digital_object_component('/repositories/2/archival_objects/7', updated_record);
+    _$httpBackend_.flush();
+  }));
+
+  it('should be able to list files within a digital object component', inject(function(_$httpBackend_, ArchivesSpace) {
+    ArchivesSpace.list_digital_object_component_contents('/repositories/2/archival_objects/7', '2').then(function(records) {
+      expect(records.length).toEqual(1);
+      expect(records[0].title).toEqual('Test');
+      expect(records[0].has_children).toBe(true);
     });
     _$httpBackend_.flush();
   }));


### PR DESCRIPTION
This requires artefactual/archivematica#330. See that issue for a discussion of the workflow.

This adds support for the new ArchivesSpace digital object component workflow in the appraisal tab, and removes support for the old workflow. Major changes:
- Digital object components have been added to the tree (and will be loaded as appropriate).
- A button has been added to add new digital object components to ArchivesSpace records, and the "edit" button can edit their metadata.
- Drag and drop has been removed from ArchivesSpace records and added to digital object records.
