### PR TITLE
ArchivesSpace: components can have no title if they have dates

### DIFF
--- a/app/archivesspace/archivesspace.controller.js
+++ b/app/archivesspace/archivesspace.controller.js
@@ -48,7 +48,7 @@
               return false;
             },
             date_expression: function() {
-              return false;
+              return node.date_expression;
             },
             note: function() {
               if (node.notes && node.notes[0]) {

--- a/app/archivesspace/form.html
+++ b/app/archivesspace/form.html
@@ -1,7 +1,7 @@
 <form class="resource-form" name="resource_form">
   <div class="row">
     <div class="col-md-6">
-      <label>Title:</label> <input type="text" ng-model="form.title" required>
+      <label>Title:</label> <input type="text" ng-model="form.title" ng-required="!form.date_expression">
     </div>
     <div class="col-md-6">
       <label>Level of description:</label> <select ng-model="form.level"
@@ -26,7 +26,7 @@
     <label>Dates:</label>
     <input type="text" class="form-control" uib-datepicker-popup ng-model="form.end_date" is-open="form.status.end_date_opened" ng-required="false" close-text="Close"/>
     <button type="button" class="btn btn-default" ng-click="form.open_datepicker('end', $event)"><i class="fa fa-calendar"></i></button>
-    <label>Expression:</label> <input type="text" ng-model="form.date_expression">
+    <label>Expression:</label> <input type="text" ng-model="form.date_expression" ng-required="!form.title">
   </div>
   </div>
   <div class="btn-group" role="group">


### PR DESCRIPTION
ArchivesSpace allows resource components to be created with no title on the condition that a date expression is present. Since we're now displaying these records using the `display_string` value, which incorporates the date as a portion of the title, this shouldn't cause problems for us.
