### PR TITLE
Replace bower with webpack

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,0 @@
-{
-  "directory": "app/bower_components"
-}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "parser": "babel-eslint",
   "rules": {
     "array-bracket-spacing": [1, "never"],
     "brace-style": [2, "1tbs"],
@@ -27,7 +28,7 @@
     "space-after-keywords": 2,
     "space-before-blocks": 1,
     "space-before-function-paren": [1, "never"],
-    "strict": [2, "global"]
+    "strict": [0]
   },
   "env": {
     "browser": true,

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 logs/*
 !.gitkeep
 node_modules/
-bower_components/
 tmp
 .DS_Store
 .idea

--- a/app/alert/alert.controller.js
+++ b/app/alert/alert.controller.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import angular from 'angular';
+
 (function() {
   angular.module('alertController', ['alertService']).
 

--- a/app/analysis/analysis.controller.js
+++ b/app/analysis/analysis.controller.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import angular from 'angular';
+
 (function() {
   angular.module('analysisController', ['route-segment']).
 

--- a/app/app.js
+++ b/app/app.js
@@ -13,7 +13,7 @@ import './vendor/angular-tree-control/css/tree-control-attribute.css';
 
 // third-party modules
 import angular from 'angular';
-import 'angular-charts';
+import './vendor/angular-charts/angular-charts.js';
 import 'angular-route';
 import 'angular-route-segment';
 import './vendor/angular-tree-control/angular-tree-control.js';

--- a/app/app.js
+++ b/app/app.js
@@ -1,7 +1,68 @@
 'use strict';
 
+// styles
+import './app.css';
+import './css/directory-picker.css';
+import './css/file-explorer.css';
+import './css/search.css';
+import './css/style.css';
+import 'bootstrap/dist/css/bootstrap.css';
+import 'font-awesome/css/font-awesome.min.css';
+import './vendor/angular-tree-control/css/tree-control.css';
+import './vendor/angular-tree-control/css/tree-control-attribute.css';
+
+// third-party modules
+import angular from 'angular';
+import 'angular-charts';
+import 'angular-route';
+import 'angular-route-segment';
+import './vendor/angular-tree-control/angular-tree-control.js';
+import 'd3';
+import 'jquery';
+import 'jquery-ui';
+import 'restangular';
+
+// controllers
+import './alert/alert.controller.js';
+import './analysis/analysis.controller.js';
+import './archivesspace/archivesspace.controller.js';
+import './arrangement/arrangement.controller.js';
+import './examine_contents/examine_contents.controller.js';
+import './facet_selector/facet_selector.controller.js';
+import './file_list/file_list.controller.js';
+import './preview/preview.controller.js';
+import './report/report.controller.js';
+import './search/search.controller.js';
+import './tree/tree.controller.js';
+import './visualizations/visualizations.controller.js';
+
+// directives
+import './checklist/checklist.directive.js';
+import './tree/tree.directive.js';
+import './ui/ui.directive.js';
+
+// filters
+import './filters/aggregation.filter.js';
+import './filters/facet.filter.js';
+
+// services
+import './services/alert.service.js';
+import './services/archivesspace.service.js';
+import './services/facet.service.js';
+import './services/file.service.js';
+import './services/file_list.service.js';
+import './services/selected.service.js';
+import './services/sip_arrange.service.js';
+import './services/tag.service.js';
+import './services/transfer.service.js';
+
+// misc
+import './components/version/interpolate-filter.js';
+import './components/version/version-directive.js';
+import './components/version/version.js';
+
 // Declare app level module which depends on views, and components
-angular.module('appraisalTab', [
+module.exports = angular.module('appraisalTab', [
   'ngRoute',
   'route-segment',
   'view-segment',

--- a/app/app.js
+++ b/app/app.js
@@ -45,6 +45,20 @@ import './ui/ui.directive.js';
 import './filters/aggregation.filter.js';
 import './filters/facet.filter.js';
 
+// partials
+import 'ng-cache!./analysis/analysis.html';
+import 'ng-cache!./archivesspace/digital_object_form.html';
+import 'ng-cache!./archivesspace/form.html';
+import 'ng-cache!./examine_contents/file_info.html';
+import 'ng-cache!./preview/preview.html';
+import 'ng-cache!./report/format.html';
+import 'ng-cache!./report/tags.html';
+import 'ng-cache!./ui/minimize-bar.html';
+import 'ng-cache!./ui/minimize-panel.html';
+import 'ng-cache!./visualizations/formats_by_files.html';
+import 'ng-cache!./visualizations/formats_by_size.html';
+import 'ng-cache!./visualizations/visualizations.html';
+
 // services
 import './services/alert.service.js';
 import './services/archivesspace.service.js';

--- a/app/archivesspace/archivesspace.controller.js
+++ b/app/archivesspace/archivesspace.controller.js
@@ -1,5 +1,9 @@
 'use strict';
 
+import angular from 'angular';
+import _ from 'lodash';
+import '../vendor/angular-ui-bootstrap/ui-bootstrap-custom-tpls-0.14.3.min.js';
+
 (function() {
   angular.module('archivesSpaceController', ['alertService', 'sipArrangeService', 'transferService', 'ui.bootstrap']).
 

--- a/app/arrangement/arrangement.controller.js
+++ b/app/arrangement/arrangement.controller.js
@@ -1,5 +1,8 @@
 'use strict';
 
+import angular from 'angular';
+import _ from 'lodash';
+
 (function() {
   angular.module('arrangementController', ['sipArrangeService']).
 

--- a/app/checklist/checklist.directive.js
+++ b/app/checklist/checklist.directive.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import angular from 'angular';
+
 (function() {
   angular.module('checklistDirective', []).
 

--- a/app/css/directory-picker.css
+++ b/app/css/directory-picker.css
@@ -5,22 +5,6 @@
   box-sizing: border-box;
 }
 
-.backbone-file-explorer-busy {
-  background-image: url('../images/ajax-loader.gif');
-}
-
-.backbone-file-explorer-directory {
-  background-image: url('../images/filefolder.png');
-}
-
-.backbone-file-explorer-directory_open {
-  background-image: url('../images/filefolderopen.png');
-}
-
-.backbone-file-explorer-busy {
-  background-image: url('../images/ajax-loader.gif');
-}
-
 .backbone-file-explorer-idle {
   background-image: none;
 }

--- a/app/css/file-explorer.css
+++ b/app/css/file-explorer.css
@@ -4,13 +4,6 @@
   background-position: right top;
 }
 
-.backbone-file-explorer-busy {
-  background-color: '#eee';
-  opacity: .5;
-  background-image: url('../img/ajax-loader.gif');
-  background-position: 99% 50%;
-}
-
 .backbone-file-explorer-idle {
   background-color: 'white';
   opacity: 1;
@@ -32,16 +25,6 @@
 
 .backbone-file-explorer-entry-highlighted {
   background-color: #ffcc00;
-}
-
-.backbone-file-explorer-directory {
-  background-image: url('../img/folder.png');
-  background-repeat: no-repeat;
-  background-position: 3px 50%;
-}
-
-.backbone-file-explorer-directory_open {
-  background-image: url('../img/folderopen.png');
 }
 
 .backbone-file-explorer-directory_icon_button {

--- a/app/examine_contents/examine_contents.controller.js
+++ b/app/examine_contents/examine_contents.controller.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import angular from 'angular';
+
 (function() {
   angular.module('examineContentsController', []).
 

--- a/app/facet_selector/facet_selector.controller.js
+++ b/app/facet_selector/facet_selector.controller.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import angular from 'angular';
+
 (function() {
   angular.module('facetController', ['tagService']).
 

--- a/app/file_list/file_list.controller.js
+++ b/app/file_list/file_list.controller.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import angular from 'angular';
+
 (function() {
   angular.module('fileListController', ['fileListService']).
 

--- a/app/filters/aggregation.filter.js
+++ b/app/filters/aggregation.filter.js
@@ -1,5 +1,8 @@
 'use strict';
 
+import angular from 'angular';
+import _ from 'lodash';
+
 (function() {
   // The default hash function may confuse two arrays of objects
   // of the same length as the same set of records.

--- a/app/filters/facet.filter.js
+++ b/app/filters/facet.filter.js
@@ -1,5 +1,8 @@
 'use strict';
 
+import angular from 'angular';
+import _ from 'lodash';
+
 (function() {
   angular.module('facetFilter', []).
 

--- a/app/index.html
+++ b/app/index.html
@@ -9,15 +9,6 @@
   <title>Appraisal tab</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.css">
-  <link rel="stylesheet" href="bower_components/fontawesome/css/font-awesome.min.css">
-  <link rel="stylesheet" href="vendor/angular-tree-control/css/tree-control.css">
-  <link rel="stylesheet" href="vendor/angular-tree-control/css/tree-control-attribute.css">
-  <link rel="stylesheet" href="css/directory-picker.css">
-  <link rel="stylesheet" href="css/file-explorer.css">
-  <link rel="stylesheet" href="css/search.css">
-  <link rel="stylesheet" href="css/style.css">
-  <link rel="stylesheet" href="app.css">
 </head>
 <body>
   <!--[if lt IE 7]>
@@ -357,7 +348,6 @@
   </ui-minimize-panel>
   </ui-minimize-bar>
 
-  <script src="bower_components/lodash/dist/lodash.min.js"></script>
   <script src="/media/vendor/backbone.js"></script>
   <script src="/media/js/advanced-search-query-creator.js"></script>
   <script src="/media/js/ingest/backlog.js"></script>
@@ -365,16 +355,6 @@
   <!-- In production use:
   <script src="//ajax.googleapis.com/ajax/libs/angularjs/x.x.x/angular.min.js"></script>
   -->
-  <script src="bower_components/angular/angular.js"></script>
-  <script src="bower_components/angular-route/angular-route.js"></script>
-  <script src="bower_components/angular-route-segment/build/angular-route-segment.js"></script>
-  <script src="bower_components/d3/d3.js"></script>
-  <script src="bower_components/jquery/dist/jquery.min.js"></script>
-  <script src="bower_components/jqueryui/jquery-ui.min.js"></script>
-  <script src="bower_components/restangular/dist/restangular.min.js"></script>
-  <script src="bower_components/angular-charts/dist/angular-charts.min.js"></script>
-  <script src="vendor/angular-tree-control/angular-tree-control.js"></script>
-  <script src="vendor/angular-ui-bootstrap/ui-bootstrap-custom-tpls-0.14.3.min.js"></script>
   <script src="app.js"></script>
   <script src="ui/ui.directive.js"></script>
   <script src="checklist/checklist.directive.js"></script>

--- a/app/index.html
+++ b/app/index.html
@@ -355,35 +355,6 @@
   <!-- In production use:
   <script src="//ajax.googleapis.com/ajax/libs/angularjs/x.x.x/angular.min.js"></script>
   -->
-  <script src="app.js"></script>
-  <script src="ui/ui.directive.js"></script>
-  <script src="checklist/checklist.directive.js"></script>
-  <script src="tree/tree.directive.js"></script>
-  <script src="services/alert.service.js"></script>
-  <script src="services/archivesspace.service.js"></script>
-  <script src="services/facet.service.js"></script>
-  <script src="services/file.service.js"></script>
-  <script src="services/file_list.service.js"></script>
-  <script src="services/selected.service.js"></script>
-  <script src="services/sip_arrange.service.js"></script>
-  <script src="services/tag.service.js"></script>
-  <script src="services/transfer.service.js"></script>
-  <script src="filters/aggregation.filter.js"></script>
-  <script src="filters/facet.filter.js"></script>
-  <script src="alert/alert.controller.js"></script>
-  <script src="archivesspace/archivesspace.controller.js"></script>
-  <script src="analysis/analysis.controller.js"></script>
-  <script src="arrangement/arrangement.controller.js"></script>
-  <script src="examine_contents/examine_contents.controller.js"></script>
-  <script src="facet_selector/facet_selector.controller.js"></script>
-  <script src="file_list/file_list.controller.js"></script>
-  <script src="preview/preview.controller.js"></script>
-  <script src="search/search.controller.js"></script>
-  <script src="tree/tree.controller.js"></script>
-  <script src="report/report.controller.js"></script>
-  <script src="visualizations/visualizations.controller.js"></script>
-  <script src="components/version/version.js"></script>
-  <script src="components/version/version-directive.js"></script>
-  <script src="components/version/interpolate-filter.js"></script>
+  <script src="appraisal_tab.js"></script>
 </body>
 </html>

--- a/app/preview/preview.controller.js
+++ b/app/preview/preview.controller.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import angular from 'angular';
+
 (function() {
   angular.module('previewController', ['route-segment', 'fileListService']).
 

--- a/app/report/report.controller.js
+++ b/app/report/report.controller.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import angular from 'angular';
+
 (function() {
   angular.module('reportController', ['selectedFilesService']).
 

--- a/app/services/alert.service.js
+++ b/app/services/alert.service.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import angular from 'angular';
+
 (function() {
   angular.module('alertService', []).
 

--- a/app/services/archivesspace.service.js
+++ b/app/services/archivesspace.service.js
@@ -1,5 +1,10 @@
 'use strict';
 
+import angular from 'angular';
+import $ from 'jquery';
+import _ from 'lodash';
+import 'restangular';
+
 (function() {
   angular.module('archivesSpaceService', ['restangular']).
 

--- a/app/services/facet.service.js
+++ b/app/services/facet.service.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import angular from 'angular';
+
 (function() {
   angular.module('facetService', []).
 

--- a/app/services/file.service.js
+++ b/app/services/file.service.js
@@ -1,5 +1,8 @@
 'use strict';
 
+import angular from 'angular';
+import 'restangular';
+
 (function() {
   angular.module('fileService', ['restangular']).
 

--- a/app/services/file_list.service.js
+++ b/app/services/file_list.service.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import angular from 'angular';
+
 (function() {
   angular.module('fileListService', []).
 

--- a/app/services/selected.service.js
+++ b/app/services/selected.service.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import angular from 'angular';
+
 (function() {
   angular.module('selectedFilesService', []).
 

--- a/app/services/sip_arrange.service.js
+++ b/app/services/sip_arrange.service.js
@@ -1,5 +1,10 @@
 'use strict';
 
+import angular from 'angular';
+import $ from 'jquery';
+import _ from 'lodash';
+import 'restangular';
+
 (function() {
   angular.module('sipArrangeService', ['restangular']).
 

--- a/app/services/tag.service.js
+++ b/app/services/tag.service.js
@@ -1,5 +1,8 @@
 'use strict';
 
+import angular from 'angular';
+import 'restangular';
+
 (function() {
   angular.module('tagService', ['restangular']).
 

--- a/app/services/transfer.service.js
+++ b/app/services/transfer.service.js
@@ -1,5 +1,10 @@
 'use strict';
 
+import angular from 'angular';
+import '../services/alert.service';
+import '../services/facet.service';
+import '../services/tag.service';
+
 (function() {
   angular.module('transferService', ['alertService', 'facetService', 'tagService']).
 

--- a/app/tree/tree.controller.js
+++ b/app/tree/tree.controller.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import angular from 'angular';
+
 (function() {
   var treeController = angular.module('treeController', []).
 

--- a/app/tree/tree.directive.js
+++ b/app/tree/tree.directive.js
@@ -1,5 +1,8 @@
 'use strict';
 
+import angular from 'angular';
+import $ from 'jquery';
+
 (function() {
   angular.module('treeDirectives', []).
 

--- a/app/ui/ui.directive.js
+++ b/app/ui/ui.directive.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import angular from 'angular';
+
 (function() {
   angular.module('uiDirectives', []).
 

--- a/app/vendor/angular-charts/angular-charts.js
+++ b/app/vendor/angular-charts/angular-charts.js
@@ -1,0 +1,938 @@
+/**
+ * Main module
+ */
+angular.module('angularCharts', ['angularChartsTemplates']);
+/**
+ * Main directive handling drawing of all charts
+ */
+angular.module('angularCharts').directive('acChart', [
+  '$templateCache',
+  '$compile',
+  '$rootElement',
+  '$window',
+  '$timeout',
+  '$sce',
+  function ($templateCache, $compile, $rootElement, $window, $timeout, $sce) {
+    var defaultColors = [
+        'rgb(255,153,0)',
+        'rgb(220,57,18)',
+        'rgb(70,132,238)',
+        'rgb(73,66,204)',
+        'rgb(0,128,0)',
+        'rgb(0, 169, 221)',
+        'steelBlue',
+        'rgb(0, 169, 221)',
+        'rgb(50, 205, 252)',
+        'rgb(70,132,238)',
+        'rgb(0, 169, 221)',
+        'rgb(5, 150, 194)',
+        'rgb(50, 183, 224)',
+        'steelBlue',
+        'rgb(2, 185, 241)',
+        'rgb(0, 169, 221)',
+        'steelBlue',
+        'rgb(0, 169, 221)',
+        'rgb(50, 205, 252)',
+        'rgb(70,132,238)',
+        'rgb(0, 169, 221)',
+        'rgb(5, 150, 194)',
+        'rgb(50, 183, 224)',
+        'steelBlue',
+        'rgb(2, 185, 241)'
+      ];
+    /**
+   * Utility function to call when we run out of colors!
+   * @return {String} Hexadecimal color
+   */
+    function getRandomColor() {
+      var r = (Math.round(Math.random() * 127) + 127).toString(16);
+      var g = (Math.round(Math.random() * 127) + 127).toString(16);
+      var b = (Math.round(Math.random() * 127) + 127).toString(16);
+      return '#' + r + g + b;
+    }
+    /**
+   * Utility function that gets the child that matches the classname
+   * because Angular.element.children() doesn't take selectors
+   * it's still better than a whole jQuery implementation
+   * @param  {Array}  childrens       An array of childrens - element.children() or element.find('div')
+   * @param  {String} className       Class name
+   * @return {Angular.element|null}    The founded child or null
+   */
+    function getChildrenByClassname(childrens, className) {
+      var child = null;
+      for (var i in childrens) {
+        if (angular.isElement(childrens[i])) {
+          child = angular.element(childrens[i]);
+          if (child.hasClass(className))
+            return child;
+        }
+      }
+      return child;
+    }
+    /**
+   * Main link function
+   * @param  {[type]} scope   [description]
+   * @param  {[type]} element [description]
+   * @param  {[type]} attrs   [description]
+   * @return {[type]}         [description]
+   */
+    function link(scope, element, attrs) {
+      var config = {
+          title: '',
+          tooltips: true,
+          labels: false,
+          mouseover: function () {
+          },
+          mouseout: function () {
+          },
+          click: function () {
+          },
+          legend: {
+            display: true,
+            position: 'left',
+            htmlEnabled: false
+          },
+          colors: defaultColors,
+          innerRadius: 0,
+          lineLegend: 'lineEnd',
+          lineCurveType: 'cardinal',
+          isAnimate: true,
+          yAxisTickFormat: 's',
+          waitForHeightAndWidth: false
+        };
+      prepareConfig();
+      var totalWidth = element[0].clientWidth;
+      var totalHeight = element[0].clientHeight;
+      validateHeightAndWidth();
+      var data, series, points, height, width, chartContainer, legendContainer, chartType;
+      /**
+     * All the magic happens here
+     * handles extracting chart type
+     * getting data
+     * validating data
+     * drawing the chart
+     * @return {[type]} [description]
+     */
+      function init() {
+        if (!validateHeightAndWidth()) {
+          return;
+        }
+        prepareData();
+        setHeightWidth();
+        setContainers();
+        var chartFunc = getChartFunction(chartType);
+        chartFunc();
+        drawLegend();
+      }
+      /**
+     * Checks that the height and width are valid.
+     * It throws an exception unless the config key waitForHeightAndWidth is set to true
+     */
+      function validateHeightAndWidth() {
+        if (totalHeight && totalWidth) {
+          return true;
+        }
+        if (config.waitForHeightAndWidth) {
+          return false;
+        }
+        throw new Error('Please set height and width for the chart element');
+      }
+      /**
+     * Sets height and width of chart area based on legend
+     * used for setting radius, bar width of chart
+     */
+      function setHeightWidth() {
+        if (!config.legend.display) {
+          height = totalHeight;
+          width = totalWidth;
+          return;
+        }
+        switch (config.legend.position) {
+        case 'top':
+        case 'bottom':
+          height = totalHeight * 0.75;
+          width = totalWidth;
+          break;
+        case 'left':
+        case 'right':
+          height = totalHeight;
+          width = totalWidth * 0.75;
+          break;
+        }
+      }
+      /**
+     * Creates appropriate DOM structure for legend + chart
+     */
+      function setContainers() {
+        var container = $templateCache.get('angularChartsTemplate_' + config.legend.position);
+        element.html(container);
+        //http://stackoverflow.com/a/17883151
+        $compile(element.contents())(scope);
+        //getting children divs
+        var childrens = element.find('div');
+        chartContainer = getChildrenByClassname(childrens, 'ac-chart');
+        legendContainer = getChildrenByClassname(childrens, 'ac-legend');
+        height -= getChildrenByClassname(childrens, 'ac-title')[0].clientHeight;
+      }
+      /**
+     * Merges the give configuration with the default configuration
+     */
+      function prepareConfig() {
+        if (scope.acConfig) {
+          angular.extend(config, scope.acConfig);
+        }
+      }
+      /**
+     * Parses data from attributes
+     * @return {[type]} [description]
+     */
+      function prepareData() {
+        data = scope.acData;
+        chartType = scope.acChart;
+        series = data ? data.series || [] : [];
+        points = data ? data.data || [] : [];
+      }
+      /**
+     * Returns appropriate chart function to call
+     * @param  {[type]} type [description]
+     * @return {[type]}      [description]
+     */
+      function getChartFunction(type) {
+        var charts = {
+            'pie': pieChart,
+            'bar': barChart,
+            'line': lineChart,
+            'area': areaChart,
+            'point': pointChart
+          };
+        return charts[type];
+      }
+      /**
+     * Filters down the x axis labels if a limit is specified
+     */
+      function filterXAxis(xAxis, x) {
+        var allTicks = x.domain();
+        if (config.xAxisMaxTicks && allTicks.length > config.xAxisMaxTicks) {
+          var mod = Math.ceil(allTicks.length / config.xAxisMaxTicks);
+          xAxis.tickValues(allTicks.filter(function (e, i) {
+            return i % mod === 0;
+          }));
+        }
+      }
+      /**
+     * Draws a bar chart, grouped with negative value handling
+     * @return {[type]} [description]
+     */
+      function barChart() {
+        /**
+       * Setup date attributes
+       * @type {Object}
+       */
+        var margin = {
+            top: 0,
+            right: 20,
+            bottom: 30,
+            left: 40
+          };
+        width -= margin.left + margin.right;
+        height -= margin.top + margin.bottom;
+        var x = d3.scale.ordinal().rangeRoundBands([
+            0,
+            width
+          ], 0.1);
+        var y = d3.scale.linear().range([
+            height,
+            10
+          ]);
+        var x0 = d3.scale.ordinal().rangeRoundBands([
+            0,
+            width
+          ], 0.1);
+        var yData = [0];
+        points.forEach(function (d) {
+          d.nicedata = d.y.map(function (e, i) {
+            yData.push(e);
+            return {
+              x: d.x,
+              y: e,
+              s: i,
+              tooltip: angular.isArray(d.tooltip) ? d.tooltip[i] : d.tooltip
+            };
+          });
+        });
+        var yMaxPoints = d3.max(points.map(function (d) {
+            return d.y.length;
+          }));
+        scope.yMaxData = yMaxPoints;
+        x.domain(points.map(function (d) {
+          return d.x;
+        }));
+        var padding = d3.max(yData) * 0.2;
+        y.domain([
+          d3.min(yData),
+          d3.max(yData) + padding
+        ]);
+        x0.domain(d3.range(yMaxPoints)).rangeRoundBands([
+          0,
+          x.rangeBand()
+        ]);
+        /**
+       * Create scales using d3
+       * @type {[type]}
+       */
+        var xAxis = d3.svg.axis().scale(x).orient('bottom');
+        filterXAxis(xAxis, x);
+        var yAxis = d3.svg.axis().scale(y).orient('left').ticks(10).tickFormat(d3.format(config.yAxisTickFormat));
+        /**
+       * Start drawing the chart!
+       * @type {[type]}
+       */
+        var svg = d3.select(chartContainer[0]).append('svg').attr('width', width + margin.left + margin.right).attr('height', height + margin.top + margin.bottom).append('g').attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+        svg.append('g').attr('class', 'x axis').attr('transform', 'translate(0,' + height + ')').call(xAxis);
+        svg.append('g').attr('class', 'y axis').call(yAxis);
+        /**
+       * Add bars
+       * @type {[type]}
+       */
+        var barGroups = svg.selectAll('.state').data(points).enter().append('g').attr('class', 'g').attr('transform', function (d) {
+            return 'translate(' + x(d.x) + ',0)';
+          });
+        var bars = barGroups.selectAll('rect').data(function (d) {
+            return d.nicedata;
+          }).enter().append('rect');
+        bars.attr('width', x0.rangeBand());
+        bars.attr('x', function (d, i) {
+          return x0(i);
+        }).attr('y', height).style('fill', function (d) {
+          return getColor(d.s);
+        }).attr('height', 0).transition().ease('cubic-in-out').duration(config.isAnimate ? 1000 : 0).attr('y', function (d) {
+          return y(Math.max(0, d.y));
+        }).attr('height', function (d) {
+          return Math.abs(y(d.y) - y(0));
+        });
+        /**
+       * Add events for tooltip
+       * @param  {[type]} d [description]
+       * @return {[type]}   [description]
+       */
+        bars.on('mouseover', function (d) {
+          makeToolTip({
+            index: d.x,
+            value: d.tooltip ? d.tooltip : d.y,
+            series: series[d.s]
+          }, d3.event);
+          config.mouseover(d, d3.event);
+          scope.$apply();
+        }).on('mouseleave', function (d) {
+          removeToolTip();
+          config.mouseout(d, d3.event);
+          scope.$apply();
+        }).on('mousemove', function (d) {
+          updateToolTip(d, d3.event);
+        }).on('click', function (d) {
+          config.click.call(d, d3.event);
+          scope.$apply();
+        });
+        /**
+       * Create labels
+       */
+        if (config.labels) {
+          barGroups.selectAll('not-a-class').data(function (d) {
+            return d.nicedata;
+          }).enter().append('text').attr('x', function (d, i) {
+            return x0(i);
+          }).attr('y', function (d) {
+            return height - Math.abs(y(d.y) - y(0));
+          }).text(function (d) {
+            return d.y;
+          });
+        }
+        /**
+       * Draw one zero line in case negative values exist
+       */
+        svg.append('line').attr('x1', width).attr('y1', y(0)).attr('y2', y(0)).style('stroke', 'silver');
+      }
+      /**
+     * Draws a line chart
+     * @return {[type]} [description]
+     */
+      function lineChart() {
+        var margin = {
+            top: 0,
+            right: 40,
+            bottom: 20,
+            left: 40
+          };
+        width -= margin.left + margin.right;
+        height -= margin.top + margin.bottom;
+        var x = d3.scale.ordinal().domain(points.map(function (d) {
+            return d.x;
+          })).rangeRoundBands([
+            0,
+            width
+          ]);
+        var y = d3.scale.linear().range([
+            height,
+            10
+          ]);
+        var xAxis = d3.svg.axis().scale(x).orient('bottom');
+        filterXAxis(xAxis, x);
+        var yAxis = d3.svg.axis().scale(y).orient('left').ticks(5).tickFormat(d3.format(config.yAxisTickFormat));
+        var line = d3.svg.line().interpolate(config.lineCurveType).x(function (d) {
+            return getX(d.x);
+          }).y(function (d) {
+            return y(d.y);
+          });
+        var yData = [0];
+        var linedata = [];
+        points.forEach(function (d) {
+          d.y.map(function (e) {
+            yData.push(e);
+          });
+        });
+        var yMaxPoints = d3.max(points.map(function (d) {
+            return d.y.length;
+          }));
+        scope.yMaxData = yMaxPoints;
+        series.slice(0, yMaxPoints).forEach(function (value, index) {
+          var d = {};
+          d.series = value;
+          d.values = points.map(function (point) {
+            return point.y.map(function (e) {
+              return {
+                x: point.x,
+                y: e,
+                tooltip: point.tooltip
+              };
+            })[index] || {
+              x: points[index].x,
+              y: 0
+            };
+          });
+          linedata.push(d);
+        });
+        var svg = d3.select(chartContainer[0]).append('svg').attr('width', width + margin.left + margin.right).attr('height', height + margin.top + margin.bottom).append('g').attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+        var padding = d3.max(yData) * 0.2;
+        y.domain([
+          d3.min(yData),
+          d3.max(yData) + padding
+        ]);
+        svg.append('g').attr('class', 'x axis').attr('transform', 'translate(0,' + height + ')').call(xAxis);
+        svg.append('g').attr('class', 'y axis').call(yAxis);
+        var point = svg.selectAll('.points').data(linedata).enter().append('g');
+        var path = point.attr('points', 'points').append('path').attr('class', 'ac-line').style('stroke', function (d, i) {
+            return getColor(i);
+          }).attr('d', function (d) {
+            return line(d.values);
+          }).attr('stroke-width', '2').attr('fill', 'none');
+        /** Animation function
+       * [last description]
+       * @type {[type]}
+       */
+        if (linedata.length > 0) {
+          var last = linedata[linedata.length - 1].values;
+          if (last.length > 0) {
+            var totalLength = path.node().getTotalLength() + getX(last[last.length - 1].x);
+            path.attr('stroke-dasharray', totalLength + ' ' + totalLength).attr('stroke-dashoffset', totalLength).transition().duration(config.isAnimate ? 1500 : 0).ease('linear').attr('stroke-dashoffset', 0).attr('d', function (d) {
+              return line(d.values);
+            });
+          }
+        }
+        /**
+       * Add points
+       * @param  {[type]} value [description]
+       * @param  {[type]} key   [description]
+       * @return {[type]}       [description]
+       */
+        angular.forEach(linedata, function (value, key) {
+          var points = svg.selectAll('.circle').data(value.values).enter();
+          points.append('circle').attr('cx', function (d) {
+            return getX(d.x);
+          }).attr('cy', function (d) {
+            return y(d.y);
+          }).attr('r', 3).style('fill', getColor(linedata.indexOf(value))).style('stroke', getColor(linedata.indexOf(value))).on('mouseover', function (series) {
+            return function (d) {
+              makeToolTip({
+                index: d.x,
+                value: d.tooltip ? d.tooltip : d.y,
+                series: series
+              }, d3.event);
+              config.mouseover(d, d3.event);
+              scope.$apply();
+            };
+          }(value.series)).on('mouseleave', function (d) {
+            removeToolTip();
+            config.mouseout(d, d3.event);
+            scope.$apply();
+          }).on('mousemove', function (d) {
+            updateToolTip(d3.event);
+          }).on('click', function (d) {
+            config.click(d, d3.event);
+            scope.$apply();
+          });
+          if (config.labels) {
+            points.append('text').attr('x', function (d) {
+              return getX(d.x);
+            }).attr('y', function (d) {
+              return y(d.y);
+            }).text(function (d) {
+              return d.y;
+            });
+          }
+        });
+        /**
+       * Labels at the end of line
+       */
+        if (config.lineLegend === 'lineEnd') {
+          point.append('text').datum(function (d) {
+            return {
+              name: d.series,
+              value: d.values[d.values.length - 1]
+            };
+          }).attr('transform', function (d) {
+            return 'translate(' + getX(d.value.x) + ',' + y(d.value.y) + ')';
+          }).attr('x', 3).text(function (d) {
+            return d.name;
+          });
+        }
+        /**
+       * Returns x point of line point
+       * @param  {[type]} d [description]
+       * @return {[type]}   [description]
+       */
+        function getX(d) {
+          return Math.round(x(d)) + x.rangeBand() / 2;
+        }
+        return linedata;
+      }
+      /**
+     * Creates a nice area chart
+     * @return {[type]} [description]
+     */
+      function areaChart() {
+        var margin = {
+            top: 0,
+            right: 40,
+            bottom: 20,
+            left: 40
+          };
+        width -= margin.left + margin.right;
+        height -= margin.top + margin.bottom;
+        var x = d3.scale.ordinal().domain(points.map(function (d) {
+            return d.x;
+          })).rangePoints([
+            0,
+            width
+          ]);
+        var y = d3.scale.linear().range([
+            height,
+            10
+          ]);
+        var xAxis = d3.svg.axis().scale(x).orient('bottom');
+        filterXAxis(xAxis, x);
+        var yAxis = d3.svg.axis().scale(y).orient('left').ticks(5).tickFormat(d3.format(config.yAxisTickFormat));
+        d3.svg.line().interpolate(config.lineCurveType).x(function (d) {
+          return getX(d.x);
+        }).y(function (d) {
+          return y(d.y);
+        });
+        var yData = [0];
+        var linedata = [];
+        points.forEach(function (d) {
+          d.y.map(function (e) {
+            yData.push(e);
+          });
+        });
+        var yMaxPoints = d3.max(points.map(function (d) {
+            return d.y.length;
+          }));
+        /**
+       * Important to set for legend
+       * @type {[type]}
+       */
+        scope.yMaxData = yMaxPoints;
+        series.slice(0, yMaxPoints).forEach(function (value, index) {
+          var d = {};
+          d.series = value;
+          d.values = points.map(function (point) {
+            return point.y.map(function (e) {
+              return {
+                x: point.x,
+                y: e
+              };
+            })[index] || {
+              x: points[index].x,
+              y: 0
+            };
+          });
+          linedata.push(d);
+        });
+        var svg = d3.select(chartContainer[0]).append('svg').attr('width', width + margin.left + margin.right).attr('height', height + margin.top + margin.bottom).append('g').attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+        var padding = d3.max(yData) * 0.2;
+        y.domain([
+          d3.min(yData),
+          d3.max(yData) + padding
+        ]);
+        svg.append('g').attr('class', 'x axis').attr('transform', 'translate(0,' + height + ')').call(xAxis);
+        svg.append('g').attr('class', 'y axis').call(yAxis);
+        var point = svg.selectAll('.points').data(linedata).enter().append('g');
+        var area = d3.svg.area().interpolate('basis').x(function (d) {
+            return getX(d.x);
+          }).y0(function () {
+            return y(0);
+          }).y1(function (d) {
+            return y(0 + d.y);
+          });
+        point.append('path').attr('class', 'area').attr('d', function (d) {
+          return area(d.values);
+        }).style('fill', function (d, i) {
+          return getColor(i);
+        }).style('opacity', '0.7');
+        function getX(d) {
+          return Math.round(x(d)) + x.rangeBand() / 2;
+        }
+      }
+      /**
+     * Draws a beautiful pie chart
+     * @return {[type]} [description]
+     */
+      function pieChart() {
+        var radius = Math.min(width, height) / 2;
+        var svg = d3.select(chartContainer[0]).append('svg').attr('width', width).attr('height', height).append('g').attr('transform', 'translate(' + width / 2 + ',' + height / 2 + ')');
+        var innerRadius = 0;
+        if (config.innerRadius) {
+          var configRadius = config.innerRadius;
+          if (typeof configRadius === 'string' && configRadius.indexOf('%') > 0) {
+            configRadius = radius * (parseFloat(configRadius) * 0.01);
+          } else {
+            configRadius = Number(configRadius);
+          }
+          if (configRadius >= 0) {
+            innerRadius = configRadius;
+          }
+        }
+        scope.yMaxData = points.length;
+        var arc = d3.svg.arc().outerRadius(radius - 10).innerRadius(innerRadius);
+        d3.svg.arc().outerRadius(radius + 5).innerRadius(0);
+        var pie = d3.layout.pie().sort(null).value(function (d) {
+            return d.y[0];
+          });
+        var path = svg.selectAll('.arc').data(pie(points)).enter().append('g');
+        var complete = false;
+        path.append('path').style('fill', function (d, i) {
+          return getColor(i);
+        }).transition().ease('linear').duration(config.isAnimate ? 500 : 0).attrTween('d', tweenPie).attr('class', 'arc').each('end', function () {
+          //avoid firing multiple times
+          if (!complete) {
+            complete = true;
+            //Add listeners when transition is done
+            path.on('mouseover', function (d) {
+              makeToolTip({ value: d.data.tooltip ? d.data.tooltip : d.data.y[0] }, d3.event);
+              d3.select(this).select('path').transition().duration(200).style('stroke', 'white').style('stroke-width', '2px');
+              config.mouseover(d, d3.event);
+              scope.$apply();
+            }).on('mouseleave', function (d) {
+              d3.select(this).select('path').transition().duration(200).style('stroke', '').style('stroke-width', '');
+              removeToolTip();
+              config.mouseout(d, d3.event);
+              scope.$apply();
+            }).on('mousemove', function (d) {
+              updateToolTip(d, d3.event);
+            }).on('click', function (d) {
+              config.click(d, d3.event);
+              scope.$apply();
+            });
+          }
+        });
+        if (!!config.labels) {
+          path.append('text').attr('transform', function (d) {
+            return 'translate(' + arc.centroid(d) + ')';
+          }).attr('dy', '.35em').style('text-anchor', 'middle').text(function (d) {
+            return d.data.y[0];
+          });
+        }
+        function tweenPie(b) {
+          b.innerRadius = 0;
+          var i = d3.interpolate({
+              startAngle: 0,
+              endAngle: 0
+            }, b);
+          return function (t) {
+            return arc(i(t));
+          };
+        }
+      }
+      function pointChart() {
+        var margin = {
+            top: 0,
+            right: 40,
+            bottom: 20,
+            left: 40
+          };
+        width -= margin.left - margin.right;
+        height -= margin.top - margin.bottom;
+        var x = d3.scale.ordinal().domain(points.map(function (d) {
+            return d.x;
+          })).rangeRoundBands([
+            0,
+            width
+          ]);
+        var y = d3.scale.linear().range([
+            height,
+            10
+          ]);
+        var xAxis = d3.svg.axis().scale(x).orient('bottom');
+        filterXAxis(xAxis, x);
+        var yAxis = d3.svg.axis().scale(y).orient('left').ticks(5).tickFormat(d3.format(config.yAxisTickFormat));
+        var yData = [0];
+        var linedata = [];
+        points.forEach(function (d) {
+          d.y.map(function (e, i) {
+            yData.push(e);
+          });
+        });
+        var yMaxPoints = d3.max(points.map(function (d) {
+            return d.y.length;
+          }));
+        scope.yMaxPoints = yMaxPoints;
+        series.slice(0, yMaxPoints).forEach(function (value, index) {
+          var d = {};
+          d.series = value;
+          d.values = points.map(function (point) {
+            return point.y.map(function (e) {
+              return {
+                x: point.x,
+                y: e
+              };
+            })[index] || {
+              x: points[index].x,
+              y: 0
+            };
+          });
+          linedata.push(d);
+        });
+        var svg = d3.select(chartContainer[0]).append('svg').attr('width', width + margin.left + margin.right).attr('height', height + margin.top + margin.bottom).append('g').attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+        var padding = d3.max(yData) * 0.2;
+        y.domain([
+          d3.min(yData),
+          d3.max(yData) + padding
+        ]);
+        svg.append('g').attr('class', 'x axis').attr('transform', 'translate(0,' + height + ')').call(xAxis);
+        svg.append('g').attr('class', 'y axis').call(yAxis);
+        svg.selectAll('.points').data(linedata).enter().append('g');
+        /**
+       * Add points
+       * @param  {[type]} value [description]
+       * @param  {[type]} key   [description]
+       * @return {[type]}       [description]
+       */
+        angular.forEach(linedata, function (value, key) {
+          var points = svg.selectAll('.circle').data(value.values).enter();
+          points.append('circle').attr('cx', function (d) {
+            return getX(d.x);
+          }).attr('cy', function (d) {
+            return y(d.y);
+          }).attr('r', 3).style('fill', getColor(linedata.indexOf(value))).style('stroke', getColor(linedata.indexOf(value))).on('mouseover', function (series) {
+            return function (d) {
+              makeToolTip({
+                index: d.x,
+                value: d.tooltip ? d.tooltip : d.y,
+                series: series
+              }, d3.event);
+              config.mouseover(d, d3.event);
+              scope.$apply();
+            };
+          }(value.series)).on('mouseleave', function (d) {
+            removeToolTip();
+            config.mouseout(d, d3.event);
+            scope.$apply();
+          }).on('mousemove', function (d) {
+            updateToolTip(d3.event);
+          }).on('click', function (d) {
+            config.click(d, d3.event);
+            scope.$apply();
+          });
+          if (config.labels) {
+            points.append('text').attr('x', function (d) {
+              return getX(d.x);
+            }).attr('y', function (d) {
+              return y(d.y);
+            }).text(function (d) {
+              return d.y;
+            });
+          }
+        });
+        /**
+       * Returns x point of line point
+       * @param  {[type]} d [description]
+       * @return {[type]}   [description]
+       */
+        function getX(d) {
+          return Math.round(x(d)) + x.rangeBand() / 2;
+        }
+      }
+      /**
+     * Creates and displays tooltip
+     * @return {[type]} [description]
+     */
+      function makeToolTip(data, event) {
+        if (!config.tooltips) {
+          return;
+        }
+        if (typeof config.tooltips === 'function') {
+          data = config.tooltips(data);
+        } else {
+          data = data.value;
+        }
+        var el = angular.element('<p class="ac-tooltip"></p>').html(data).css({
+            left: event.pageX + 20 + 'px',
+            top: event.pageY - 30 + 'px'
+          });
+        angular.element(document.querySelector('.ac-tooltip')).remove();
+        angular.element(document.body).append(el);
+        scope.$tooltip = el;
+      }
+      /**
+     * Clears the tooltip from body
+     * @return {[type]} [description]
+     */
+      function removeToolTip() {
+        if (scope.$tooltip) {
+          scope.$tooltip.remove();
+        }
+      }
+      function updateToolTip(d, event) {
+        if (scope.$tooltip) {
+          scope.$tooltip.css({
+            left: event.pageX + 20 + 'px',
+            top: event.pageY - 30 + 'px'
+          });
+        }
+      }
+      /**
+     * Adds data to legend
+     * @return {[type]} [description]
+     */
+      function drawLegend() {
+        scope.legends = [];
+        if (chartType === 'pie') {
+          angular.forEach(points, function (value, key) {
+            scope.legends.push({
+              color: config.colors[key],
+              title: getBindableTextForLegend(value.x)
+            });
+          });
+        }
+        if (chartType === 'bar' || chartType === 'area' || chartType === 'point' || chartType === 'line' && config.lineLegend === 'traditional') {
+          angular.forEach(series, function (value, key) {
+            scope.legends.push({
+              color: config.colors[key],
+              title: getBindableTextForLegend(value)
+            });
+          });
+        }
+      }
+      var HTML_ENTITY_MAP = {
+          '&': '&amp;',
+          '<': '&lt;',
+          '>': '&gt;',
+          '"': '&quot;',
+          '\'': '&#39;',
+          '/': '&#x2F;'
+        };
+      function escapeHtml(string) {
+        return String(string).replace(/[&<>"'\/]/g, function (char) {
+          return HTML_ENTITY_MAP[char];
+        });
+      }
+      function getBindableTextForLegend(text) {
+        return $sce.trustAsHtml(config.legend.htmlEnabled ? text : escapeHtml(text));
+      }
+      /**
+     * Checks if index is available in color
+     * else returns a random color
+     * @param  {[type]} i [description]
+     * @return {[type]}   [description]
+     */
+      function getColor(i) {
+        if (i < config.colors.length) {
+          return config.colors[i];
+        } else {
+          var color = getRandomColor();
+          config.colors.push(color);
+          return color;
+        }
+      }
+      var w = angular.element($window);
+      var resizePromise = null;
+      w.bind('resize', function (ev) {
+        resizePromise && $timeout.cancel(resizePromise);
+        resizePromise = $timeout(function () {
+          totalWidth = element[0].clientWidth;
+          totalHeight = element[0].clientHeight;
+          init();
+        }, 100);
+      });
+      scope.getWindowDimensions = function () {
+        return {
+          'h': w[0].clientHeight,
+          'w': w[0].clientWidth
+        };
+      };
+      // Watch for any of the config changing.
+      scope.$watch('[acChart, acData, acConfig]', init, true);
+      scope.$watch(function () {
+        return {
+          w: element[0].clientWidth,
+          h: element[0].clientHeight
+        };
+      }, function (newvalue) {
+        totalWidth = newvalue.w;
+        totalHeight = newvalue.h;
+        init();
+      }, true);
+    }
+    return {
+      restrict: 'EA',
+      link: link,
+      transclude: 'true',
+      scope: {
+        acChart: '=',
+        acData: '=',
+        acConfig: '='
+      }
+    };
+  }
+]);
+(function () {
+    // styles.min.css
+    var cssText = "" +
+".angular-charts-template .axis path,.angular-charts-template .axis line{fill:none;stroke:#333}.angular-charts-template .ac-title{font-weight:700;font-size:1.2em}.angular-charts-template .ac-chart{float:left;width:75%}.angular-charts-template .ac-line{fill:none;stroke-width:2px}.angular-charts-template table{float:left;max-width:25%;list-style:none;margin:0;padding:0}.angular-charts-template td[ng-bind]{display:inline-block}.angular-charts-template .ac-legend-box{border-radius:5px;height:15px;width:15px}.ac-tooltip{display:block;position:absolute;border:2px solid rgba(51,51,51,.9);background-color:rgba(22,22,22,.7);border-radius:5px;padding:5px;color:#fff}";
+    // cssText end
+
+    var styleEl = document.createElement("style");
+    document.getElementsByTagName("head")[0].appendChild(styleEl);
+    if (styleEl.styleSheet) {
+        if (!styleEl.styleSheet.disabled) {
+            styleEl.styleSheet.cssText = cssText;
+        }
+    } else {
+        try {
+            styleEl.innerHTML = cssText
+        } catch(e) {
+            styleEl.innerText = cssText;
+        }
+    }
+}());
+
+angular.module('angularChartsTemplates', ['angularChartsTemplate_left', 'angularChartsTemplate_right']);
+
+angular.module("angularChartsTemplate_left", []).run(["$templateCache", function($templateCache) {
+  $templateCache.put("angularChartsTemplate_left",
+    "<div class=\"angular-charts-template\"><div class=\"ac-title\" ng-if=\"acConfig.title !== false\">{{acConfig.title}}</div><div class=\"ac-legend\" ng-show=\"{{acConfig.legend.display}}\"><table><tr ng-repeat=\"l in legends\"><td><div class=\"ac-legend-box\" ng-attr-style=\"background:{{l.color}};\"></div></td><td ng-bind-html=\"l.title\"></td></tr></table></div><div class=\"ac-chart\"></div></div>");
+}]);
+
+angular.module("angularChartsTemplate_right", []).run(["$templateCache", function($templateCache) {
+  $templateCache.put("angularChartsTemplate_right",
+    "<div class=\"angular-charts-template\"><div class=\"ac-title\" ng-if=\"acConfig.title !== false\">{{acConfig.title}}</div><div class=\"ac-chart\"></div><div class=\"ac-legend\" ng-show=\"{{acConfig.legend.display}}\"><table><tr ng-repeat=\"l in legends | limitTo:yMaxData\"><td><div class=\"ac-legend-box\" ng-attr-style=\"background:{{l.color}};\"></div></td><td ng-bind-html=\"l.title\"></td></tr></table></div></div>");
+}]);

--- a/app/visualizations/visualizations.controller.js
+++ b/app/visualizations/visualizations.controller.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import angular from 'angular';
+
 (function() {
   angular.module('visualizationsController', [
     'angularCharts',

--- a/package.json
+++ b/package.json
@@ -6,17 +6,23 @@
   "repository": "https://github.com/artefactual-labs/appraisal-tab",
   "license": "AGPL3",
   "devDependencies": {
-    "bower": "^1.3.1",
+    "babel-core": "^6.3.26",
+    "babel-loader": "^6.2.0",
+    "babel-preset-es2015": "^6.3.13",
+    "css-loader": "^0.23.1",
+    "file-loader": "^0.8.5",
     "http-server": "^0.6.1",
     "karma": "~0.13",
     "karma-chrome-launcher": "^0.2.1",
     "karma-jasmine": "^0.3.6",
     "karma-junit-reporter": "^0.2.2",
     "protractor": "^1.1.1",
-    "shelljs": "^0.2.6"
+    "shelljs": "^0.2.6",
+    "style-loader": "^0.13.0",
+    "url-loader": "^0.5.7",
+    "webpack": "^1.12.9"
   },
   "scripts": {
-    "postinstall": "bower install",
     "prestart": "npm install",
     "start": "http-server -a localhost -p 8000 -c-1",
     "pretest": "npm install",
@@ -25,7 +31,21 @@
     "preupdate-webdriver": "npm install",
     "update-webdriver": "webdriver-manager update",
     "preprotractor": "npm run update-webdriver",
-    "protractor": "protractor e2e-tests/protractor.conf.js",
-    "update-index-async": "node -e \"require('shelljs/global'); sed('-i', /\\/\\/@@NG_LOADER_START@@[\\s\\S]*\\/\\/@@NG_LOADER_END@@/, '//@@NG_LOADER_START@@\\n' + sed(/sourceMappingURL=angular-loader.min.js.map/,'sourceMappingURL=bower_components/angular-loader/angular-loader.min.js.map','app/bower_components/angular-loader/angular-loader.min.js') + '\\n//@@NG_LOADER_END@@', 'app/index-async.html');\""
+    "protractor": "protractor e2e-tests/protractor.conf.js"
+  },
+  "dependencies": {
+    "angular": "^1.3.20",
+    "angular-charts": "git+https://github.com/chinmaymk/angular-charts.git#1ef68b8ec94768dbc4b317b7563b029182a1fa6d",
+    "angular-loader": "^1.3.20",
+    "angular-mocks": "^1.3.20",
+    "angular-route": "^1.3.20",
+    "angular-route-segment": "^1.5.0",
+    "bootstrap": "^3.3.6",
+    "d3": "^3.5.12",
+    "font-awesome": "^4.3.0",
+    "jquery": "^1.11.3",
+    "jquery-ui": "^1.10.5",
+    "lodash": "^1.3.1",
+    "restangular": "^1.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "webpack": "^1.12.9"
   },
   "scripts": {
+    "prepublish": "webpack --progress --colors",
     "prestart": "npm install",
     "start": "http-server -a localhost -p 8000 -c-1",
     "pretest": "npm install",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   },
   "dependencies": {
     "angular": "^1.3.20",
-    "angular-charts": "git+https://github.com/chinmaymk/angular-charts.git#1ef68b8ec94768dbc4b317b7563b029182a1fa6d",
     "angular-loader": "^1.3.20",
     "angular-mocks": "^1.3.20",
     "angular-route": "^1.3.20",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "karma-chrome-launcher": "^0.2.1",
     "karma-jasmine": "^0.3.6",
     "karma-junit-reporter": "^0.2.2",
+    "ng-cache-loader": "0.0.15",
     "protractor": "^1.1.1",
     "shelljs": "^0.2.6",
     "style-loader": "^0.13.0",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -4,18 +4,8 @@ module.exports = function(config){
     basePath : '../',
 
     files : [
-      'app/bower_components/angular/angular.js',
-      'app/bower_components/angular-route/angular-route.js',
-      'app/bower_components/angular-mocks/angular-mocks.js',
-      'app/bower_components/lodash/dist/lodash.min.js',
-      'app/bower_components/restangular/src/restangular.js',
-      'app/bower_components/jquery/dist/jquery.min.js',
-      'app/app.js',
-      'app/filters/*.js',
-      'app/services/*.js',
-      'app/components/**/*.js',
+      'test/tests.webpack.js',
       'app/vendor/base64.js',
-      'test/unit/**/*.js'
     ],
 
     autoWatch : true,
@@ -26,13 +16,27 @@ module.exports = function(config){
 
     plugins : [
             'karma-chrome-launcher',
-            'karma-jasmine'
+            'karma-jasmine',
+            'karma-webpack',
             ],
 
     junitReporter : {
       outputFile: 'test_out/unit.xml',
-      suite: 'unit'
-    }
+      suite: 'unit',
+    },
+
+    preprocessors: {
+      'test/tests.webpack.js': ['webpack'],
+    },
+
+    webpack: {
+      devtool: 'inline-source-map',
+      module: {
+        loaders: [
+          { test: /\.js$/, loader: 'babel?presets[]=es2015' },
+        ],
+      },
+    },
 
   });
 };

--- a/test/tests.webpack.js
+++ b/test/tests.webpack.js
@@ -1,0 +1,7 @@
+'use strict';
+
+import 'angular';
+import 'angular-mocks/angular-mocks';
+
+var context = require.context('./unit', true, /Spec\.js$/); //make sure you have your directory and regex test set correctly!
+context.keys().forEach(context);

--- a/test/unit/aggregationFiltersSpec.js
+++ b/test/unit/aggregationFiltersSpec.js
@@ -1,5 +1,8 @@
 'use strict';
 
+import '../../app/filters/aggregation.filter.js';
+import '../../app/services/transfer.service.js';
+
 describe('AggregationFilters', function() {
   var format_data;
   var find_files;
@@ -67,8 +70,8 @@ describe('AggregationFilters', function() {
   }];
 
   beforeEach(function() {
-    module('aggregationFilters');
-    module('transferService');
+    angular.mock.module('aggregationFilters');
+    angular.mock.module('transferService');
 
     inject(function($injector) {
       format_data = $injector.get('$filter')('format_data');

--- a/test/unit/archivesspaceSpec.js
+++ b/test/unit/archivesspaceSpec.js
@@ -1,7 +1,9 @@
 'use strict';
 
+import '../../app/services/archivesspace.service.js';
+
 describe('ArchivesSpace', function() {
-  beforeEach(module('archivesSpaceService'));
+  beforeEach(angular.mock.module('archivesSpaceService'));
   beforeEach(angular.mock.inject(function(_$httpBackend_) {
     _$httpBackend_.when('GET', '/access/archivesspace').respond([
       {

--- a/test/unit/facetSpec.js
+++ b/test/unit/facetSpec.js
@@ -1,7 +1,9 @@
 'use strict';
 
+import '../../app/services/facet.service.js';
+
 describe('Facet', function() {
-  beforeEach(module('facetService'));
+  beforeEach(angular.mock.module('facetService'));
 
   it('should allow new facets to be defined by name', inject(function(Facet) {
     expect(Facet.get('foo')).toBe(undefined);

--- a/test/unit/fileListSpec.js
+++ b/test/unit/fileListSpec.js
@@ -1,7 +1,9 @@
 'use strict';
 
+import '../../app/services/file_list.service.js';
+
 describe('FileList', function() {
-  beforeEach(module('fileListService'));
+  beforeEach(angular.mock.module('fileListService'));
   beforeEach(inject(function(FileList) {
     FileList.files = [];
   }));

--- a/test/unit/fileSpec.js
+++ b/test/unit/fileSpec.js
@@ -1,7 +1,9 @@
 'use strict';
 
+import '../../app/services/file.service.js';
+
 describe('File', function() {
-  beforeEach(module('fileService'));
+  beforeEach(angular.mock.module('fileService'));
   beforeEach(angular.mock.inject(function(_$httpBackend_) {
     _$httpBackend_.when('GET', '/file/054a0f2c-79bb-4051-b82b-4b0f14564811').respond({'id': '054a0f2c-79bb-4051-b82b-4b0f14564811', 'parent': '0e3bd878-069d-49e2-b270-46b0b40cba5b', 'text': 'lion.svg', 'icon': 'file', 'puid': 'fmt/91', 'size': '5'});
     _$httpBackend_.when('GET', '/file/cf02698a-3185-45b6-bdaa-af484d5ede5b/bulk_extractor?reports=').respond({

--- a/test/unit/selectedFilesSpec.js
+++ b/test/unit/selectedFilesSpec.js
@@ -1,7 +1,9 @@
 'use strict';
 
+import '../../app/services/selected.service.js';
+
 describe('SelectedFiles', function() {
-  beforeEach(module('selectedFilesService'));
+  beforeEach(angular.mock.module('selectedFilesService'));
 
   var test_item_1 = {
     'id': '054a0f2c-79bb-4051-b82b-4b0f14564811',

--- a/test/unit/sip_arrangeSpec.js
+++ b/test/unit/sip_arrangeSpec.js
@@ -1,7 +1,9 @@
 'use strict';
 
+import '../../app/services/sip_arrange.service.js';
+
 describe('SipArrange', function() {
-  beforeEach(module('sipArrangeService'));
+  beforeEach(angular.mock.module('sipArrangeService'));
   beforeEach(angular.mock.inject(function(_$httpBackend_) {
     _$httpBackend_.when('POST', '/filesystem/create_directory_within_arrange', 'path=L2FycmFuZ2UvYS9mdWxsL25ld19wYXRo').respond({'success': true});
     _$httpBackend_.when('GET', '/filesystem/contents/arrange?path=').respond({

--- a/test/unit/tagSpec.js
+++ b/test/unit/tagSpec.js
@@ -1,7 +1,9 @@
 'use strict';
 
+import '../../app/services/tag.service.js';
+
 describe('Tag', function() {
-  beforeEach(module('tagService'));
+  beforeEach(angular.mock.module('tagService'));
   beforeEach(angular.mock.inject(function(_$httpBackend_) {
     _$httpBackend_.when('GET', '/file/e9010578-e065-4fa1-91c8-a105665037d6/tags').respond([
       'fetched_tag_1', 'fetched_tag_2',

--- a/test/unit/transferSpec.js
+++ b/test/unit/transferSpec.js
@@ -1,7 +1,9 @@
 'use strict';
 
+import '../../app/services/transfer.service.js';
+
 describe('Transfer', function() {
-  beforeEach(module('transferService'));
+  beforeEach(angular.mock.module('transferService'));
   beforeEach(angular.mock.inject(function(Transfer) {
     Transfer.resolve({
       'formats': [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var webpack = require('webpack');
+var APP = __dirname + '/app';
+
+module.exports = {
+  context: APP,
+  entry: './app.js',
+  output: {
+    path: APP,
+    filename: 'appraisal_tab.js',
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        loader: 'babel?presets[]=es2015',
+        exclude: /node_modules/,
+      },
+      {
+        test: /\.css/,
+        loader: 'style!css',
+      },
+      {
+          test: /\.png$/,
+          loader: 'url-loader',
+          query: {
+            mimetype: 'image/png',
+          },
+      },
+      {
+          test: /\.(eot|woff|woff2|ttf|svg)(\?v=\d\.\d\.\d)?$/,
+          loader: 'url-loader',
+      },
+    ],
+  },
+};


### PR DESCRIPTION
This replaces bower with webpack, in order to produce a single bundled .js file which contains the entire appraisal tab and all of its dependencies. This greatly simplifies including the appraisal tab in other HTML pages, e.g. to help us integrate it with Django more easily.

This makes a few major changes:
- All dependencies are now installed using npm instead of bower.
- [Babel](http://babeljs.io) has been introduced to the build phase, allowing ES6 features to be used in the appraisal tab; modules are transpiled to browser-compatible JS during the pack phase. Currently, only ES6 `import` statements are used, but in the future other features could be used too.
- External, non-Archivematica dependencies now no longer use global names and instead depend on explicit `import` statements within each file. Since Angular has its own module system, there hasn't been much change to how the appraisal tab itself works, and I haven't begun converting any code from other parts of Archivematica to use modules.
- Non-JavaScript resources (CSS, images, webfonts, Angular partials) are also bundled into the same file; it's not necessary for the appraisal tab to fetch any of those separately. The bundling of Angular partials also means that Django routing doesn't break the appraisal tab.
