### PR TITLE
ES6 cleanups

### DIFF
--- a/app/alert/alert.controller.js
+++ b/app/alert/alert.controller.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import angular from 'angular';
 
 (function() {

--- a/app/alert/alert.controller.js
+++ b/app/alert/alert.controller.js
@@ -6,7 +6,7 @@ controller('AlertDisplayController', ['Alert', function(Alert) {
   var vm = this;
 
   vm.alert = Alert;
-  vm.remove = function(index) {
+  vm.remove = index => {
     Alert.alerts.splice(index, 1);
   };
 }]);

--- a/app/alert/alert.controller.js
+++ b/app/alert/alert.controller.js
@@ -1,14 +1,12 @@
 import angular from 'angular';
 
-(function() {
-  angular.module('alertController', ['alertService']).
+angular.module('alertController', ['alertService']).
 
-  controller('AlertDisplayController', ['Alert', function(Alert) {
-    var vm = this;
+controller('AlertDisplayController', ['Alert', function(Alert) {
+  var vm = this;
 
-    vm.alert = Alert;
-    vm.remove = function(index) {
-      Alert.alerts.splice(index, 1);
-    };
-  }]);
-})();
+  vm.alert = Alert;
+  vm.remove = function(index) {
+    Alert.alerts.splice(index, 1);
+  };
+}]);

--- a/app/analysis/analysis.controller.js
+++ b/app/analysis/analysis.controller.js
@@ -1,9 +1,7 @@
 import angular from 'angular';
 
-(function() {
-  angular.module('analysisController', ['route-segment']).
+angular.module('analysisController', ['route-segment']).
 
-  controller('AnalysisController', ['$scope', '$routeSegment', function($scope, $routeSegment) {
-    $scope.$routeSegment = $routeSegment;
-  }]);
-})();
+controller('AnalysisController', ['$scope', '$routeSegment', function($scope, $routeSegment) {
+  $scope.$routeSegment = $routeSegment;
+}]);

--- a/app/analysis/analysis.controller.js
+++ b/app/analysis/analysis.controller.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import angular from 'angular';
 
 (function() {

--- a/app/app.js
+++ b/app/app.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // styles
 import './app.css';
 import './css/directory-picker.css';

--- a/app/archivesspace/archivesspace.controller.js
+++ b/app/archivesspace/archivesspace.controller.js
@@ -2,564 +2,562 @@ import angular from 'angular';
 import _ from 'lodash';
 import '../vendor/angular-ui-bootstrap/ui-bootstrap-custom-tpls-0.14.3.min.js';
 
-(function() {
-  angular.module('archivesSpaceController', ['alertService', 'sipArrangeService', 'transferService', 'ui.bootstrap']).
+angular.module('archivesSpaceController', ['alertService', 'sipArrangeService', 'transferService', 'ui.bootstrap']).
 
-  controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'ArchivesSpace', 'SipArrange', 'Transfer', function($scope, $uibModal, Alert, ArchivesSpace, SipArrange, Transfer) {
-    // Reformats several properties on the form object, returning them in
-    // a format suitable for use with the ArchivesSpace service's `edit`
-    // and `add_child` functions.
-    // Returns a modified copy of the passed-in object.
-    var reformat_form_results = function(form) {
-      var copy = _.extend({}, form);
+controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'ArchivesSpace', 'SipArrange', 'Transfer', function($scope, $uibModal, Alert, ArchivesSpace, SipArrange, Transfer) {
+  // Reformats several properties on the form object, returning them in
+  // a format suitable for use with the ArchivesSpace service's `edit`
+  // and `add_child` functions.
+  // Returns a modified copy of the passed-in object.
+  var reformat_form_results = function(form) {
+    var copy = _.extend({}, form);
 
-      copy.levelOfDescription = form.level;
-      copy.notes = [{
-        type: 'odd',
-        content: form.note,
-      }];
-      delete copy.note;
+    copy.levelOfDescription = form.level;
+    copy.notes = [{
+      type: 'odd',
+      content: form.note,
+    }];
+    delete copy.note;
 
-      if (form.start_date) {
-        copy.dates = form.start_date.toISOString().slice(0, 10) + '-' + form.end_date.toISOString().slice(0, 10);
-      }
+    if (form.start_date) {
+      copy.dates = form.start_date.toISOString().slice(0, 10) + '-' + form.end_date.toISOString().slice(0, 10);
+    }
 
-      return copy;
+    return copy;
+  };
+
+  var append_child = function(node, child) {
+    if (!node.has_children) {
+      node.has_children = true;
+      node.children = [];
+      node.children_fetched = false;
+    }
+    node.children.push(child);
+  };
+
+  var levels_of_description = ArchivesSpace.get_levels_of_description().$object;
+  $scope.edit = function(node) {
+    if (node.type === 'digital_object') {
+      return edit_component(node);
+    } else if (node.type === 'resource' || node.type === 'resource_component') {
+      return edit_record(node);
+    }
+  };
+
+  var edit_component = function(node) {
+    var form = $uibModal.open({
+      templateUrl: 'archivesspace/digital_object_form.html',
+      controller: 'DigitalObjectEditController',
+      controllerAs: 'form',
+      resolve: {
+        title: function() {
+          return node.title;
+        },
+        label: function() {
+          return node.label;
+        },
+      },
+    });
+    form.result.then(function(result) {
+      var original_title = node.title;
+      var original_label = node.label;
+
+      var on_success = function(result) {
+        node.request_pending = false;
+      };
+
+      var on_failure = function(result) {
+        node.request_pending = false;
+        node.title = original_title;
+        node.label = original_label;
+
+        Alert.alerts.push({
+          type: 'danger',
+          message: 'Unable to submit edits to record "' + node.title + '"; check dashboard logs.',
+        });
+      };
+
+      node.request_pending = true;
+      node.title = result.title;
+      node.label = result.label;
+      result.component_id = node.id;
+      ArchivesSpace.edit_digital_object_component(node.resourceid, result).then(on_success, on_failure);
+    });
+  };
+
+    var edit_record = function(node) {
+      var form = $uibModal.open({
+        templateUrl: 'archivesspace/form.html',
+        controller: 'ArchivesSpaceEditController',
+        controllerAs: 'form',
+        resolve: {
+          levels: function() {
+            return levels_of_description;
+          },
+          title: function() {
+            return node.title;
+          },
+          level: function() {
+            return node.levelOfDescription;
+          },
+          start_date: function() {
+            return false;
+          },
+          end_date: function() {
+            return false;
+          },
+          date_expression: function() {
+            return node.date_expression;
+          },
+          note: function() {
+            if (node.notes && node.notes[0]) {
+              return node.notes[0].content;
+            }
+          },
+        },
+      });
+      form.result.then(function(result) {
+        // Assign these to variables so we can restore them if the PUT fails
+        var original_title = node.title;
+        var original_level = node.levelOfDescription;
+        var original_note = node.notes;
+
+        node.title = result.title;
+        var formatted = reformat_form_results(result);
+        node.levelOfDescription = formatted.levelOfDescription;
+        node.notes = formatted.notes;
+        node.dates = formatted.dates;
+        // Any node with pending requests will be marked as non-editable
+        node.request_pending = true;
+
+        var on_success = function(response) {
+          node.request_pending = false;
+        };
+
+        var on_failure = function(error) {
+          // Restore the original title/level since the request failed
+          node.title = original_title;
+          node.levelOfDescription = original_level;
+          node.notes = original_note;
+          node.request_pending = false;
+
+          var title = node.title;
+          if (node.identifier) {
+            title = title + ' (' + node.identifier + ')';
+          }
+
+          Alert.alerts.push({
+            type: 'danger',
+            message: 'Unable to submit edits to record "' + title + '"; check dashboard logs.',
+          });
+        };
+
+        ArchivesSpace.edit(node.id, node).then(on_success, on_failure);
+      });
     };
 
-    var append_child = function(node, child) {
-      if (!node.has_children) {
-        node.has_children = true;
-        node.children = [];
-        node.children_fetched = false;
-      }
-      node.children.push(child);
+    $scope.add_child = function(node) {
+      var form = $uibModal.open({
+        templateUrl: 'archivesspace/form.html',
+        controller: 'ArchivesSpaceEditController',
+        controllerAs: 'form',
+        resolve: {
+          levels: function() {
+            return ArchivesSpace.get_levels_of_description().$object;
+          },
+          title: function() {
+            return '';
+          },
+          level: function() {
+            return '';
+          },
+          start_date: function() {
+            return new Date();
+          },
+          end_date: function() {
+            return new Date();
+          },
+          date_expression: function() {
+            return '';
+          },
+          note: function() {
+            return '';
+          },
+        },
+      });
+      form.result.then(function(result) {
+        var result = reformat_form_results(result);
+
+        var on_success = function(response) {
+          result.id = response.id;
+          result.parent = node;
+          append_child(node, result);
+        };
+
+        var on_failure = function(error) {
+          Alert.alerts.push({
+            type: 'danger',
+            message: 'Unable to add new child record to record ' + node.id,
+          });
+        };
+
+        ArchivesSpace.add_child(node.id, result).then(on_success, on_failure);
+      });
     };
 
-    var levels_of_description = ArchivesSpace.get_levels_of_description().$object;
-    $scope.edit = function(node) {
-      if (node.type === 'digital_object') {
-        return edit_component(node);
-      } else if (node.type === 'resource' || node.type === 'resource_component') {
-        return edit_record(node);
-      }
-    };
-
-    var edit_component = function(node) {
+    // Add a "digital object" object, to which files can be dragged in order
+    // to produce digital object components
+    $scope.add_digital_object = function(node) {
       var form = $uibModal.open({
         templateUrl: 'archivesspace/digital_object_form.html',
         controller: 'DigitalObjectEditController',
         controllerAs: 'form',
         resolve: {
           title: function() {
-            return node.title;
+            return '';
           },
           label: function() {
-            return node.label;
+            return '';
           },
         },
       });
-      form.result.then(function(result) {
-        var original_title = node.title;
-        var original_label = node.label;
 
-        var on_success = function(result) {
-          node.request_pending = false;
+      form.result.then(function(result) {
+        var on_success = function(response) {
+          result.id = response.component_id;
+          result.type = 'digital_object';
+          append_child(node, result);
         };
 
         var on_failure = function(result) {
-          node.request_pending = false;
-          node.title = original_title;
-          node.label = original_label;
-
           Alert.alerts.push({
             type: 'danger',
-            message: 'Unable to submit edits to record "' + node.title + '"; check dashboard logs.',
+            message: 'Unable to add new digital object component to record ' + node.id,
           });
         };
 
-        node.request_pending = true;
-        node.title = result.title;
-        node.label = result.label;
-        result.component_id = node.id;
-        ArchivesSpace.edit_digital_object_component(node.resourceid, result).then(on_success, on_failure);
+        ArchivesSpace.create_digital_object_component(node.id, result).then(on_success, on_failure);
       });
     };
 
-      var edit_record = function(node) {
-        var form = $uibModal.open({
-          templateUrl: 'archivesspace/form.html',
-          controller: 'ArchivesSpaceEditController',
-          controllerAs: 'form',
-          resolve: {
-            levels: function() {
-              return levels_of_description;
-            },
-            title: function() {
-              return node.title;
-            },
-            level: function() {
-              return node.levelOfDescription;
-            },
-            start_date: function() {
-              return false;
-            },
-            end_date: function() {
-              return false;
-            },
-            date_expression: function() {
-              return node.date_expression;
-            },
-            note: function() {
-              if (node.notes && node.notes[0]) {
-                return node.notes[0].content;
-              }
-            },
-          },
-        });
-        form.result.then(function(result) {
-          // Assign these to variables so we can restore them if the PUT fails
-          var original_title = node.title;
-          var original_level = node.levelOfDescription;
-          var original_note = node.notes;
-
-          node.title = result.title;
-          var formatted = reformat_form_results(result);
-          node.levelOfDescription = formatted.levelOfDescription;
-          node.notes = formatted.notes;
-          node.dates = formatted.dates;
-          // Any node with pending requests will be marked as non-editable
-          node.request_pending = true;
-
-          var on_success = function(response) {
-            node.request_pending = false;
-          };
-
-          var on_failure = function(error) {
-            // Restore the original title/level since the request failed
-            node.title = original_title;
-            node.levelOfDescription = original_level;
-            node.notes = original_note;
-            node.request_pending = false;
-
-            var title = node.title;
-            if (node.identifier) {
-              title = title + ' (' + node.identifier + ')';
-            }
-
-            Alert.alerts.push({
-              type: 'danger',
-              message: 'Unable to submit edits to record "' + title + '"; check dashboard logs.',
-            });
-          };
-
-          ArchivesSpace.edit(node.id, node).then(on_success, on_failure);
-        });
-      };
-
-      $scope.add_child = function(node) {
-        var form = $uibModal.open({
-          templateUrl: 'archivesspace/form.html',
-          controller: 'ArchivesSpaceEditController',
-          controllerAs: 'form',
-          resolve: {
-            levels: function() {
-              return ArchivesSpace.get_levels_of_description().$object;
-            },
-            title: function() {
-              return '';
-            },
-            level: function() {
-              return '';
-            },
-            start_date: function() {
-              return new Date();
-            },
-            end_date: function() {
-              return new Date();
-            },
-            date_expression: function() {
-              return '';
-            },
-            note: function() {
-              return '';
-            },
-          },
-        });
-        form.result.then(function(result) {
-          var result = reformat_form_results(result);
-
-          var on_success = function(response) {
-            result.id = response.id;
-            result.parent = node;
-            append_child(node, result);
-          };
-
-          var on_failure = function(error) {
-            Alert.alerts.push({
-              type: 'danger',
-              message: 'Unable to add new child record to record ' + node.id,
-            });
-          };
-
-          ArchivesSpace.add_child(node.id, result).then(on_success, on_failure);
-        });
-      };
-
-      // Add a "digital object" object, to which files can be dragged in order
-      // to produce digital object components
-      $scope.add_digital_object = function(node) {
-        var form = $uibModal.open({
-          templateUrl: 'archivesspace/digital_object_form.html',
-          controller: 'DigitalObjectEditController',
-          controllerAs: 'form',
-          resolve: {
-            title: function() {
-              return '';
-            },
-            label: function() {
-              return '';
-            },
-          },
-        });
-
-        form.result.then(function(result) {
-          var on_success = function(response) {
-            result.id = response.component_id;
-            result.type = 'digital_object';
-            append_child(node, result);
-          };
-
-          var on_failure = function(result) {
-            Alert.alerts.push({
-              type: 'danger',
-              message: 'Unable to add new digital object component to record ' + node.id,
-            });
-          };
-
-          ArchivesSpace.create_digital_object_component(node.id, result).then(on_success, on_failure);
-        });
-      };
-
-      $scope.options = {
-        dirSelectable: true,
-        equality: function(a, b) {
-          if (a === undefined || b === undefined) {
-            return false;
-          } else if (a.id && b.id) {
-            return a.id === b.id;
-          } else {
-            return a.path === b.path;
-          }
-        },
-        isLeaf: function(node) {
-          return !node.has_children && node.type !== 'digital_object';
-        },
-      };
-
-      // Loads the children of the specified element,
-      // along with arranged SIP contents that might exist
-      var load_element_children = function(node) {
-        $scope.loading = true;
-
-        var on_failure_aspace = function(error) {
-          Alert.alerts.push({
-            type: 'danger',
-            message: 'Unable to fetch record ' + node.id + ' from ArchivesSpace!',
-          });
-          $scope.loading = false;
-        };
-
-        var on_failure_arrange = function(error) {
-          Alert.alerts.push({
-            type: 'danger',
-            message: 'Unable to fetch record ' + node.path + ' from Arrangement!',
-          });
-          $scope.loading = false;
-        };
-
-        node.children = [];
-
-        if (node.id && node.type !== 'digital_object') {  // ArchivesSpace node
-          ArchivesSpace.get_children(node.id).then(function(children) {
-            children.map(function(element) { element.parent = node; });
-            node.children = node.children.concat(children);
-            node.children_fetched = true;
-            $scope.loading = false;
-          }, on_failure_aspace);
-
-          // Also check to see if there are any digital object components;
-          // if so, render them like any other ASpace objects
-          ArchivesSpace.digital_object_components(node.id).then(function(components) {
-            node.children = node.children.concat(components);
-          });
-        } else {  // SipArrange node
-          SipArrange.list_contents(node.path, node).then(function(entries) {
-            node.children = entries;
-            node.children_fetched = true;
-            $scope.loading = false;
-          }, on_failure_arrange);
-        }
-      };
-
-      $scope.refresh = function(node) {
-        if (node) {
-          load_element_children(node);
+    $scope.options = {
+      dirSelectable: true,
+      equality: function(a, b) {
+        if (a === undefined || b === undefined) {
+          return false;
+        } else if (a.id && b.id) {
+          return a.id === b.id;
         } else {
-          load_data();
+          return a.path === b.path;
         }
-      };
+      },
+      isLeaf: function(node) {
+        return !node.has_children && node.type !== 'digital_object';
+      },
+    };
 
-      $scope.on_toggle = function(node, expanded) {
-        if ((!expanded || !node.has_children || node.children_fetched) && node.type !== 'digital_object') {
-          return;
-        }
+    // Loads the children of the specified element,
+    // along with arranged SIP contents that might exist
+    var load_element_children = function(node) {
+      $scope.loading = true;
 
-        load_element_children(node);
-      };
-
-      var load_data = function() {
-        // TODO: handle failure to contact ArchivesSpace here;
-        //       probably want to scope this to only happen if ASpace pane is opened.
-        //       (The controller is always instantiated before the pane opens,
-        //       so adding an alert here would always render even if ArchivesSpace
-        //       wasn't clicked.)
-        $scope.loading = true;
-        ArchivesSpace.all().then(function(data) {
-          $scope.data = data;
-          $scope.loading = false;
+      var on_failure_aspace = function(error) {
+        Alert.alerts.push({
+          type: 'danger',
+          message: 'Unable to fetch record ' + node.id + ' from ArchivesSpace!',
         });
+        $scope.loading = false;
       };
-      load_data();
 
-      // Prevent a given file or its descendants from being dragged more than once
-      var dragged_ids = [];
-      var log_ids = function(file) {
-        dragged_ids.push(file.id);
-        if (file.children) {
-          for (var i = 0; i < file.children.length; i++) {
-            log_ids(file.children[i]);
-          }
-        }
+      var on_failure_arrange = function(error) {
+        Alert.alerts.push({
+          type: 'danger',
+          message: 'Unable to fetch record ' + node.path + ' from Arrangement!',
+        });
+        $scope.loading = false;
+      };
+
+      node.children = [];
+
+      if (node.id && node.type !== 'digital_object') {  // ArchivesSpace node
+        ArchivesSpace.get_children(node.id).then(function(children) {
+          children.map(function(element) { element.parent = node; });
+          node.children = node.children.concat(children);
+          node.children_fetched = true;
+          $scope.loading = false;
+        }, on_failure_aspace);
+
+        // Also check to see if there are any digital object components;
+        // if so, render them like any other ASpace objects
+        ArchivesSpace.digital_object_components(node.id).then(function(components) {
+          node.children = node.children.concat(components);
+        });
+      } else {  // SipArrange node
+        SipArrange.list_contents(node.path, node).then(function(entries) {
+          node.children = entries;
+          node.children_fetched = true;
+          $scope.loading = false;
+        }, on_failure_arrange);
+      }
+    };
+
+    $scope.refresh = function(node) {
+      if (node) {
+        load_element_children(node);
+      } else {
+        load_data();
+      }
+    };
+
+    $scope.on_toggle = function(node, expanded) {
+      if ((!expanded || !node.has_children || node.children_fetched) && node.type !== 'digital_object') {
+        return;
       }
 
-      // Filter the list of dragged files to contain only files with the "display"
-      // parameter, so that only visibly selected files are dragged over
-      var filter_files = function(file) {
-        if (!file.display) {
-          return {};
+      load_element_children(node);
+    };
+
+    var load_data = function() {
+      // TODO: handle failure to contact ArchivesSpace here;
+      //       probably want to scope this to only happen if ASpace pane is opened.
+      //       (The controller is always instantiated before the pane opens,
+      //       so adding an alert here would always render even if ArchivesSpace
+      //       wasn't clicked.)
+      $scope.loading = true;
+      ArchivesSpace.all().then(function(data) {
+        $scope.data = data;
+        $scope.loading = false;
+      });
+    };
+    load_data();
+
+    // Prevent a given file or its descendants from being dragged more than once
+    var dragged_ids = [];
+    var log_ids = function(file) {
+      dragged_ids.push(file.id);
+      if (file.children) {
+        for (var i = 0; i < file.children.length; i++) {
+          log_ids(file.children[i]);
         }
+      }
+    }
 
-        // Filter children recursively
-        if (file.children) {
-          var children = file.children;
-          file.children = [];
-          angular.forEach(children, function(child) {
-            child = filter_files(child);
-            // Omit empty objects, or directories whose children have all been filtered out
-            if (child.id && child.type === 'file' || (child.children && child.children.length > 0)) {
-              file.children.push(child);
-            }
-          });
-        }
+    // Filter the list of dragged files to contain only files with the "display"
+    // parameter, so that only visibly selected files are dragged over
+    var filter_files = function(file) {
+      if (!file.display) {
+        return {};
+      }
 
-        return file;
-      };
-
-      $scope.drop = function(unused, ui) {
-        if ($scope.loading) {
-          return;
-        }
-
-        var type = ui.draggable.attr('file-type');
-        var is_arrange_file = this.type !== 'digital_object';
-        if (type === 'arrange') {
-          var path = ui.draggable.attr('file-path');
-          if (is_arrange_file) {
-            return copy_arrange_to_arrange.apply(this, [path]);
-          } else {
-            return copy_arrange_to_aspace.apply(this, [path]);
+      // Filter children recursively
+      if (file.children) {
+        var children = file.children;
+        file.children = [];
+        angular.forEach(children, function(child) {
+          child = filter_files(child);
+          // Omit empty objects, or directories whose children have all been filtered out
+          if (child.id && child.type === 'file' || (child.children && child.children.length > 0)) {
+            file.children.push(child);
           }
+        });
+      }
+
+      return file;
+    };
+
+    $scope.drop = function(unused, ui) {
+      if ($scope.loading) {
+        return;
+      }
+
+      var type = ui.draggable.attr('file-type');
+      var is_arrange_file = this.type !== 'digital_object';
+      if (type === 'arrange') {
+        var path = ui.draggable.attr('file-path');
+        if (is_arrange_file) {
+          return copy_arrange_to_arrange.apply(this, [path]);
         } else {
-          var file = Transfer.id_map[ui.draggable.attr('uuid')];
-          if (is_arrange_file) {
-            return copy_backlog_to_arrange.apply(this, [file]);
-          } else {
-            return copy_backlog_to_aspace.apply(this, [file]);
-          }
+          return copy_arrange_to_aspace.apply(this, [path]);
         }
-      };
-
-      var copy_arrange_to_arrange = function(path) {
-        var self = this;
-
-        var on_move = function() {
-          load_element_children(self);
-        };
-
-        SipArrange.copy_to_arrange(path, '/arrange/' + this.path).then(on_move);
-      };
-
-      var copy_arrange_to_aspace = function(path) {
-        var self = this;
-
-        var on_move = function() {
-          load_element_children(self);
-        };
-
-        SipArrange.copy_to_arrange(path, this.path).then(on_move);
-      };
-
-      var copy_backlog_to_aspace = function(file) {
-        var self = this;
-
-        // create a deep copy of the file and its children so we don't mutate
-        // the copies used in the backlog
-        file = filter_files(_.extend({}, file));
-        if (!file.id) {
-          return;
-        }
-
-        var on_copy = function() {
-          if ($scope.expanded_nodes.indexOf(self) === -1) {
-            $scope.expanded_nodes.push(self);
-            // expanded event will not fire if the node was programmatically expanded - this loads children
-            $scope.on_toggle(self, true);
-          } else {
-            // Reload the directory to reflect new contents
-            load_element_children(self);
-          }
-        };
-
-        var source_path;
-        if (file.type === 'file') {
-          source_path = file.relative_path;
+      } else {
+        var file = Transfer.id_map[ui.draggable.attr('uuid')];
+        if (is_arrange_file) {
+          return copy_backlog_to_arrange.apply(this, [file]);
         } else {
-          source_path = file.relative_path + '/';
+          return copy_backlog_to_aspace.apply(this, [file]);
         }
+      }
+    };
 
-        // TODO make sure `path` property is correctly specified
-        $scope.$apply(function() {
-          $scope.loading = true;
+    var copy_arrange_to_arrange = function(path) {
+      var self = this;
 
-          self.has_children = true;
-          self.children = [];
-          self.children_fetched = false;
-          SipArrange.copy_to_arrange('/originals/' + source_path, self.path).then(on_copy);
+      var on_move = function() {
+        load_element_children(self);
+      };
+
+      SipArrange.copy_to_arrange(path, '/arrange/' + this.path).then(on_move);
+    };
+
+    var copy_arrange_to_aspace = function(path) {
+      var self = this;
+
+      var on_move = function() {
+        load_element_children(self);
+      };
+
+      SipArrange.copy_to_arrange(path, this.path).then(on_move);
+    };
+
+    var copy_backlog_to_aspace = function(file) {
+      var self = this;
+
+      // create a deep copy of the file and its children so we don't mutate
+      // the copies used in the backlog
+      file = filter_files(_.extend({}, file));
+      if (!file.id) {
+        return;
+      }
+
+      var on_copy = function() {
+        if ($scope.expanded_nodes.indexOf(self) === -1) {
+          $scope.expanded_nodes.push(self);
+          // expanded event will not fire if the node was programmatically expanded - this loads children
+          $scope.on_toggle(self, true);
+        } else {
+          // Reload the directory to reflect new contents
+          load_element_children(self);
+        }
+      };
+
+      var source_path;
+      if (file.type === 'file') {
+        source_path = file.relative_path;
+      } else {
+        source_path = file.relative_path + '/';
+      }
+
+      // TODO make sure `path` property is correctly specified
+      $scope.$apply(function() {
+        $scope.loading = true;
+
+        self.has_children = true;
+        self.children = [];
+        self.children_fetched = false;
+        SipArrange.copy_to_arrange('/originals/' + source_path, self.path).then(on_copy);
+      });
+    };
+
+    var copy_backlog_to_arrange = function(file) {
+      var self = this;
+
+      var source_path;
+      if (file.type === 'file') {
+        source_path = file.relative_path;
+      } else {
+        source_path = file.relative_path + '/';
+      }
+
+      // Reload the directory to reflect new contents
+      var on_copy = function() {
+        load_element_children(self);
+      };
+
+      $scope.$apply(function() {
+        SipArrange.copy_to_arrange('/arrange/' + source_path, '/arrange/' + self.path).then(on_copy);
+      });
+    };
+
+    $scope.remove = function(node) {
+      if ($scope.loading) {
+        return;
+      }
+
+      var on_delete = function(element) {
+        // `node.parent` is undefined if this is a root-level directory
+        var siblings = node.parent ? node.parent.children : $scope.data.children;
+        var idx = siblings.indexOf(node);
+        if (idx !== -1){
+          siblings.splice(idx, 1);
+        }
+        $scope.selected = undefined;
+      };
+
+      // TODO is this a reliable way to tell nodes apart?
+      if (node.id) { // ArchivesSpace node
+        ArchivesSpace.remove(node.id).then(on_delete);
+      } else {  // SipArrange node
+        SipArrange.remove(node.path).then(on_delete);
+      }
+    };
+
+    $scope.finalize_arrangement = function(node) {
+      var on_success = function() {
+        Alert.alerts.push({
+          type: 'success',
+          message: 'Successfully started SIP from record "' + node.title + '"',
+        });
+
+        // Remove the digital object components so the user doesn't try to add new items
+        node.children = node.children.filter(function(element) {
+          return element.type !== 'digital_object';
+        });
+      };
+      var on_failure = function(error) {
+        var message;
+        // error.message won't be defined if this returned an HTML 500
+        if (error.message && error.message.startsWith('No SIP Arrange mapping')) {
+          message = 'Unable to start SIP; no files arranged into record "' + node.title + '".';
+        } else {
+          message = 'Unable to start SIP; check dashboard logs.';
+        }
+        Alert.alerts.push({
+          type: 'danger',
+          message: message,
         });
       };
 
-      var copy_backlog_to_arrange = function(file) {
-        var self = this;
-
-        var source_path;
-        if (file.type === 'file') {
-          source_path = file.relative_path;
-        } else {
-          source_path = file.relative_path + '/';
-        }
-
-        // Reload the directory to reflect new contents
-        var on_copy = function() {
-          load_element_children(self);
-        };
-
-        $scope.$apply(function() {
-          SipArrange.copy_to_arrange('/arrange/' + source_path, '/arrange/' + self.path).then(on_copy);
-        });
-      };
-
-      $scope.remove = function(node) {
-        if ($scope.loading) {
-          return;
-        }
-
-        var on_delete = function(element) {
-          // `node.parent` is undefined if this is a root-level directory
-          var siblings = node.parent ? node.parent.children : $scope.data.children;
-          var idx = siblings.indexOf(node);
-          if (idx !== -1){
-            siblings.splice(idx, 1);
-          }
-          $scope.selected = undefined;
-        };
-
-        // TODO is this a reliable way to tell nodes apart?
-        if (node.id) { // ArchivesSpace node
-          ArchivesSpace.remove(node.id).then(on_delete);
-        } else {  // SipArrange node
-          SipArrange.remove(node.path).then(on_delete);
-        }
-      };
-
-      $scope.finalize_arrangement = function(node) {
-        var on_success = function() {
-          Alert.alerts.push({
-            type: 'success',
-            message: 'Successfully started SIP from record "' + node.title + '"',
-          });
-
-          // Remove the digital object components so the user doesn't try to add new items
-          node.children = node.children.filter(function(element) {
-            return element.type !== 'digital_object';
-          });
-        };
-        var on_failure = function(error) {
-          var message;
-          // error.message won't be defined if this returned an HTML 500
-          if (error.message && error.message.startsWith('No SIP Arrange mapping')) {
-            message = 'Unable to start SIP; no files arranged into record "' + node.title + '".';
-          } else {
-            message = 'Unable to start SIP; check dashboard logs.';
-          }
-          Alert.alerts.push({
-            type: 'danger',
-            message: message,
-          });
-        };
-
-        ArchivesSpace.start_sip(node.id).then(on_success, on_failure);
-      };
-    }]).
-
-  controller('ArchivesSpaceEditController', ['$uibModalInstance', 'levels', 'level', 'title', 'start_date', 'end_date', 'date_expression', 'note', function($uibModalInstance, levels, level, title, start_date, end_date, date_expression, note) {
-    var vm = this;
-
-    vm.levels = levels;
-    vm.level = level;
-    vm.title = title;
-    vm.start_date = start_date;
-    vm.end_date = end_date;
-    vm.date_expression = date_expression;
-    vm.note = note;
-
-    vm.ok = function() {
-      $uibModalInstance.close(vm);
-    };
-    vm.cancel = function() {
-      $uibModalInstance.dismiss('cancel');
-    };
-    vm.open_datepicker = function(picker, $event) {
-      var prop = picker + '_date_opened';
-      this.status[prop] = true;
-    };
-    vm.status = {
-      start_date_opened: false,
-      end_date_opened: false,
+      ArchivesSpace.start_sip(node.id).then(on_success, on_failure);
     };
   }]).
 
-  controller('DigitalObjectEditController', ['$uibModalInstance', 'title', 'label', function($uibModalInstance, title, label) {
-    var vm = this;
+controller('ArchivesSpaceEditController', ['$uibModalInstance', 'levels', 'level', 'title', 'start_date', 'end_date', 'date_expression', 'note', function($uibModalInstance, levels, level, title, start_date, end_date, date_expression, note) {
+  var vm = this;
 
-    vm.title = title;
-    vm.label = label;
+  vm.levels = levels;
+  vm.level = level;
+  vm.title = title;
+  vm.start_date = start_date;
+  vm.end_date = end_date;
+  vm.date_expression = date_expression;
+  vm.note = note;
 
-    vm.ok = function() {
-      $uibModalInstance.close(vm);
-    };
-    vm.cancel = function() {
-      $uibModalInstance.dismiss('cancel');
-    };
-  }]);
-})();
+  vm.ok = function() {
+    $uibModalInstance.close(vm);
+  };
+  vm.cancel = function() {
+    $uibModalInstance.dismiss('cancel');
+  };
+  vm.open_datepicker = function(picker, $event) {
+    var prop = picker + '_date_opened';
+    this.status[prop] = true;
+  };
+  vm.status = {
+    start_date_opened: false,
+    end_date_opened: false,
+  };
+}]).
+
+controller('DigitalObjectEditController', ['$uibModalInstance', 'title', 'label', function($uibModalInstance, title, label) {
+  var vm = this;
+
+  vm.title = title;
+  vm.label = label;
+
+  vm.ok = function() {
+    $uibModalInstance.close(vm);
+  };
+  vm.cancel = function() {
+    $uibModalInstance.dismiss('cancel');
+  };
+}]);

--- a/app/archivesspace/archivesspace.controller.js
+++ b/app/archivesspace/archivesspace.controller.js
@@ -1,5 +1,4 @@
 import angular from 'angular';
-import _ from 'lodash';
 import '../vendor/angular-ui-bootstrap/ui-bootstrap-custom-tpls-0.14.3.min.js';
 
 angular.module('archivesSpaceController', ['alertService', 'sipArrangeService', 'transferService', 'ui.bootstrap']).
@@ -10,7 +9,7 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
   // and `add_child` functions.
   // Returns a modified copy of the passed-in object.
   var reformat_form_results = form => {
-    var copy = _.extend({}, form);
+    var copy = Object.assign({}, form);
 
     copy.levelOfDescription = form.level;
     copy.notes = [{
@@ -408,7 +407,7 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
     var copy_backlog_to_aspace = function(file) {
       // create a deep copy of the file and its children so we don't mutate
       // the copies used in the backlog
-      file = filter_files(_.extend({}, file));
+      file = filter_files(Object.assign({}, file));
       if (!file.id) {
         return;
       }

--- a/app/archivesspace/archivesspace.controller.js
+++ b/app/archivesspace/archivesspace.controller.js
@@ -9,7 +9,7 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
   // a format suitable for use with the ArchivesSpace service's `edit`
   // and `add_child` functions.
   // Returns a modified copy of the passed-in object.
-  var reformat_form_results = function(form) {
+  var reformat_form_results = form => {
     var copy = _.extend({}, form);
 
     copy.levelOfDescription = form.level;
@@ -26,7 +26,7 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
     return copy;
   };
 
-  var append_child = function(node, child) {
+  var append_child = (node, child) => {
     if (!node.has_children) {
       node.has_children = true;
       node.children = [];
@@ -44,29 +44,29 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
     }
   };
 
-  var edit_component = function(node) {
+  var edit_component = node => {
     var form = $uibModal.open({
       templateUrl: 'archivesspace/digital_object_form.html',
       controller: 'DigitalObjectEditController',
       controllerAs: 'form',
       resolve: {
-        title: function() {
+        title: () => {
           return node.title;
         },
-        label: function() {
+        label: () => {
           return node.label;
         },
       },
     });
-    form.result.then(function(result) {
+    form.result.then(result => {
       var original_title = node.title;
       var original_label = node.label;
 
-      var on_success = function(result) {
+      var on_success = result => {
         node.request_pending = false;
       };
 
-      var on_failure = function(result) {
+      var on_failure = result => {
         node.request_pending = false;
         node.title = original_title;
         node.label = original_label;
@@ -85,38 +85,38 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
     });
   };
 
-    var edit_record = function(node) {
+    var edit_record = node => {
       var form = $uibModal.open({
         templateUrl: 'archivesspace/form.html',
         controller: 'ArchivesSpaceEditController',
         controllerAs: 'form',
         resolve: {
-          levels: function() {
+          levels: () => {
             return levels_of_description;
           },
-          title: function() {
+          title: () => {
             return node.title;
           },
-          level: function() {
+          level: () => {
             return node.levelOfDescription;
           },
-          start_date: function() {
+          start_date: () => {
             return false;
           },
-          end_date: function() {
+          end_date: () => {
             return false;
           },
-          date_expression: function() {
+          date_expression: () => {
             return node.date_expression;
           },
-          note: function() {
+          note: () => {
             if (node.notes && node.notes[0]) {
               return node.notes[0].content;
             }
           },
         },
       });
-      form.result.then(function(result) {
+      form.result.then(result => {
         // Assign these to variables so we can restore them if the PUT fails
         var original_title = node.title;
         var original_level = node.levelOfDescription;
@@ -130,11 +130,11 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
         // Any node with pending requests will be marked as non-editable
         node.request_pending = true;
 
-        var on_success = function(response) {
+        var on_success = response => {
           node.request_pending = false;
         };
 
-        var on_failure = function(error) {
+        var on_failure = error => {
           // Restore the original title/level since the request failed
           node.title = original_title;
           node.levelOfDescription = original_level;
@@ -162,39 +162,39 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
         controller: 'ArchivesSpaceEditController',
         controllerAs: 'form',
         resolve: {
-          levels: function() {
+          levels: () => {
             return ArchivesSpace.get_levels_of_description().$object;
           },
-          title: function() {
+          title: () => {
             return '';
           },
-          level: function() {
+          level: () => {
             return '';
           },
-          start_date: function() {
+          start_date: () => {
             return new Date();
           },
-          end_date: function() {
+          end_date: () => {
             return new Date();
           },
-          date_expression: function() {
+          date_expression: () => {
             return '';
           },
-          note: function() {
+          note: () => {
             return '';
           },
         },
       });
-      form.result.then(function(result) {
+      form.result.then(result => {
         var result = reformat_form_results(result);
 
-        var on_success = function(response) {
+        var on_success = response => {
           result.id = response.id;
           result.parent = node;
           append_child(node, result);
         };
 
-        var on_failure = function(error) {
+        var on_failure = error => {
           Alert.alerts.push({
             type: 'danger',
             message: 'Unable to add new child record to record ' + node.id,
@@ -213,23 +213,23 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
         controller: 'DigitalObjectEditController',
         controllerAs: 'form',
         resolve: {
-          title: function() {
+          title: () => {
             return '';
           },
-          label: function() {
+          label: () => {
             return '';
           },
         },
       });
 
-      form.result.then(function(result) {
-        var on_success = function(response) {
+      form.result.then(result => {
+        var on_success = response => {
           result.id = response.component_id;
           result.type = 'digital_object';
           append_child(node, result);
         };
 
-        var on_failure = function(result) {
+        var on_failure = result => {
           Alert.alerts.push({
             type: 'danger',
             message: 'Unable to add new digital object component to record ' + node.id,
@@ -242,7 +242,7 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
 
     $scope.options = {
       dirSelectable: true,
-      equality: function(a, b) {
+      equality: (a, b) => {
         if (a === undefined || b === undefined) {
           return false;
         } else if (a.id && b.id) {
@@ -251,17 +251,17 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
           return a.path === b.path;
         }
       },
-      isLeaf: function(node) {
+      isLeaf: node => {
         return !node.has_children && node.type !== 'digital_object';
       },
     };
 
     // Loads the children of the specified element,
     // along with arranged SIP contents that might exist
-    var load_element_children = function(node) {
+    var load_element_children = node => {
       $scope.loading = true;
 
-      var on_failure_aspace = function(error) {
+      var on_failure_aspace = error => {
         Alert.alerts.push({
           type: 'danger',
           message: 'Unable to fetch record ' + node.id + ' from ArchivesSpace!',
@@ -269,7 +269,7 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
         $scope.loading = false;
       };
 
-      var on_failure_arrange = function(error) {
+      var on_failure_arrange = error => {
         Alert.alerts.push({
           type: 'danger',
           message: 'Unable to fetch record ' + node.path + ' from Arrangement!',
@@ -280,8 +280,8 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
       node.children = [];
 
       if (node.id && node.type !== 'digital_object') {  // ArchivesSpace node
-        ArchivesSpace.get_children(node.id).then(function(children) {
-          children.map(function(element) { element.parent = node; });
+        ArchivesSpace.get_children(node.id).then(children => {
+          children.map(element => element.parent = node);
           node.children = node.children.concat(children);
           node.children_fetched = true;
           $scope.loading = false;
@@ -289,11 +289,11 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
 
         // Also check to see if there are any digital object components;
         // if so, render them like any other ASpace objects
-        ArchivesSpace.digital_object_components(node.id).then(function(components) {
+        ArchivesSpace.digital_object_components(node.id).then(components => {
           node.children = node.children.concat(components);
         });
       } else {  // SipArrange node
-        SipArrange.list_contents(node.path, node).then(function(entries) {
+        SipArrange.list_contents(node.path, node).then(entries => {
           node.children = entries;
           node.children_fetched = true;
           $scope.loading = false;
@@ -317,14 +317,14 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
       load_element_children(node);
     };
 
-    var load_data = function() {
+    var load_data = () => {
       // TODO: handle failure to contact ArchivesSpace here;
       //       probably want to scope this to only happen if ASpace pane is opened.
       //       (The controller is always instantiated before the pane opens,
       //       so adding an alert here would always render even if ArchivesSpace
       //       wasn't clicked.)
       $scope.loading = true;
-      ArchivesSpace.all().then(function(data) {
+      ArchivesSpace.all().then(data => {
         $scope.data = data;
         $scope.loading = false;
       });
@@ -333,18 +333,18 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
 
     // Prevent a given file or its descendants from being dragged more than once
     var dragged_ids = [];
-    var log_ids = function(file) {
+    var log_ids = file => {
       dragged_ids.push(file.id);
       if (file.children) {
         for (var i = 0; i < file.children.length; i++) {
           log_ids(file.children[i]);
         }
       }
-    }
+    };
 
     // Filter the list of dragged files to contain only files with the "display"
     // parameter, so that only visibly selected files are dragged over
-    var filter_files = function(file) {
+    var filter_files = file => {
       if (!file.display) {
         return {};
       }
@@ -353,7 +353,7 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
       if (file.children) {
         var children = file.children;
         file.children = [];
-        angular.forEach(children, function(child) {
+        angular.forEach(children, child => {
           child = filter_files(child);
           // Omit empty objects, or directories whose children have all been filtered out
           if (child.id && child.type === 'file' || (child.children && child.children.length > 0)) {
@@ -390,28 +390,22 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
     };
 
     var copy_arrange_to_arrange = function(path) {
-      var self = this;
-
-      var on_move = function() {
-        load_element_children(self);
+      var on_move = () => {
+        load_element_children(this);
       };
 
       SipArrange.copy_to_arrange(path, '/arrange/' + this.path).then(on_move);
     };
 
     var copy_arrange_to_aspace = function(path) {
-      var self = this;
-
-      var on_move = function() {
-        load_element_children(self);
+      var on_move = () => {
+        load_element_children(this);
       };
 
       SipArrange.copy_to_arrange(path, this.path).then(on_move);
     };
 
     var copy_backlog_to_aspace = function(file) {
-      var self = this;
-
       // create a deep copy of the file and its children so we don't mutate
       // the copies used in the backlog
       file = filter_files(_.extend({}, file));
@@ -419,14 +413,14 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
         return;
       }
 
-      var on_copy = function() {
-        if ($scope.expanded_nodes.indexOf(self) === -1) {
-          $scope.expanded_nodes.push(self);
+      var on_copy = () => {
+        if ($scope.expanded_nodes.indexOf(this) === -1) {
+          $scope.expanded_nodes.push(this);
           // expanded event will not fire if the node was programmatically expanded - this loads children
-          $scope.on_toggle(self, true);
+          $scope.on_toggle(this, true);
         } else {
           // Reload the directory to reflect new contents
-          load_element_children(self);
+          load_element_children(this);
         }
       };
 
@@ -438,19 +432,17 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
       }
 
       // TODO make sure `path` property is correctly specified
-      $scope.$apply(function() {
+      $scope.$apply(() => {
         $scope.loading = true;
 
-        self.has_children = true;
-        self.children = [];
-        self.children_fetched = false;
-        SipArrange.copy_to_arrange('/originals/' + source_path, self.path).then(on_copy);
+        this.has_children = true;
+        this.children = [];
+        this.children_fetched = false;
+        SipArrange.copy_to_arrange('/originals/' + source_path, this.path).then(on_copy);
       });
     };
 
     var copy_backlog_to_arrange = function(file) {
-      var self = this;
-
       var source_path;
       if (file.type === 'file') {
         source_path = file.relative_path;
@@ -459,12 +451,12 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
       }
 
       // Reload the directory to reflect new contents
-      var on_copy = function() {
-        load_element_children(self);
+      var on_copy = () => {
+        load_element_children(this);
       };
 
-      $scope.$apply(function() {
-        SipArrange.copy_to_arrange('/arrange/' + source_path, '/arrange/' + self.path).then(on_copy);
+      $scope.$apply(() => {
+        SipArrange.copy_to_arrange('/arrange/' + source_path, '/arrange/' + this.path).then(on_copy);
       });
     };
 
@@ -473,7 +465,7 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
         return;
       }
 
-      var on_delete = function(element) {
+      var on_delete = element => {
         // `node.parent` is undefined if this is a root-level directory
         var siblings = node.parent ? node.parent.children : $scope.data.children;
         var idx = siblings.indexOf(node);
@@ -492,18 +484,16 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
     };
 
     $scope.finalize_arrangement = function(node) {
-      var on_success = function() {
+      var on_success = () => {
         Alert.alerts.push({
           type: 'success',
           message: 'Successfully started SIP from record "' + node.title + '"',
         });
 
         // Remove the digital object components so the user doesn't try to add new items
-        node.children = node.children.filter(function(element) {
-          return element.type !== 'digital_object';
-        });
+        node.children = node.children.filter(element => element.type !== 'digital_object');
       };
-      var on_failure = function(error) {
+      var on_failure = error => {
         var message;
         // error.message won't be defined if this returned an HTML 500
         if (error.message && error.message.startsWith('No SIP Arrange mapping')) {
@@ -538,7 +528,7 @@ controller('ArchivesSpaceEditController', ['$uibModalInstance', 'levels', 'level
   vm.cancel = function() {
     $uibModalInstance.dismiss('cancel');
   };
-  vm.open_datepicker = function(picker, $event) {
+  vm.open_datepicker = (picker, $event) => {
     var prop = picker + '_date_opened';
     this.status[prop] = true;
   };
@@ -554,10 +544,10 @@ controller('DigitalObjectEditController', ['$uibModalInstance', 'title', 'label'
   vm.title = title;
   vm.label = label;
 
-  vm.ok = function() {
+  vm.ok = () => {
     $uibModalInstance.close(vm);
   };
-  vm.cancel = function() {
+  vm.cancel = () => {
     $uibModalInstance.dismiss('cancel');
   };
 }]);

--- a/app/archivesspace/archivesspace.controller.js
+++ b/app/archivesspace/archivesspace.controller.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import angular from 'angular';
 import _ from 'lodash';
 import '../vendor/angular-ui-bootstrap/ui-bootstrap-custom-tpls-0.14.3.min.js';

--- a/app/arrangement/arrangement.controller.js
+++ b/app/arrangement/arrangement.controller.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import angular from 'angular';
 import _ from 'lodash';
 

--- a/app/arrangement/arrangement.controller.js
+++ b/app/arrangement/arrangement.controller.js
@@ -6,22 +6,22 @@ angular.module('arrangementController', ['sipArrangeService']).
 controller('ArrangementController', ['$scope', 'Alert', 'Transfer', 'SipArrange', function($scope, Alert, Transfer, SipArrange) {
   var vm = this;
 
-  var load_data = function() {
-    SipArrange.list_contents().then(function(directories) {
+  var load_data = () => {
+    SipArrange.list_contents().then(directories => {
       vm.data = directories;
     });
   };
 
   vm.options = {
     dirSelectable: true,
-    isLeaf: function(node) {
+    isLeaf: node => {
       return !node.has_children;
     },
   };
   vm.filter_expression = {display: true};
   vm.filter_comparator = true;
 
-  vm.refresh = function(node) {
+  vm.refresh = node => {
     if (node) {
       load_element_children(node);
     } else {
@@ -29,22 +29,22 @@ controller('ArrangementController', ['$scope', 'Alert', 'Transfer', 'SipArrange'
     }
   };
 
-  var load_element_children = function(node) {
+  var load_element_children = node => {
     var path = '/arrange/' + node.path;
-    SipArrange.list_contents(path, node).then(function(entries) {
+    SipArrange.list_contents(path, node).then(entries => {
       node.children = entries;
       node.children_fetched = true;
     });
   };
 
-  vm.on_toggle = function(node, expanded) {
+  vm.on_toggle = (node, expanded) => {
     if (!expanded || node.children_fetched) {
       return;
     }
     load_element_children(node);
   };
 
-  vm.create_directory = function(parent) {
+  vm.create_directory = parent => {
     var path = prompt('Name of new directory?');
     if (!path) {
       return;
@@ -58,13 +58,13 @@ controller('ArrangementController', ['$scope', 'Alert', 'Transfer', 'SipArrange'
       var full_path = parent.path + '/' + path;
     }
 
-    SipArrange.create_directory('/arrange/' + full_path, path, parent).then(function(result) {
+    SipArrange.create_directory('/arrange/' + full_path, path, parent).then(result => {
       target.push(result);
     });
   };
 
-  vm.delete_directory = function(element) {
-    SipArrange.remove('/arrange/' + element.path).then(function(success) {
+  vm.delete_directory = element => {
+    SipArrange.remove('/arrange/' + element.path).then(success => {
       // `element.parent` is undefined if this is a root-level directory
       var parent = element.parent ? element.parent.children : vm.data;
 
@@ -74,7 +74,7 @@ controller('ArrangementController', ['$scope', 'Alert', 'Transfer', 'SipArrange'
     });
   };
 
-  var hide_elements = function(node) {
+  var hide_elements = node => {
     node.display = false;
     if (node.children) {
       for (var i = 0; i < node.children.length; i++) {
@@ -83,8 +83,8 @@ controller('ArrangementController', ['$scope', 'Alert', 'Transfer', 'SipArrange'
     }
   };
 
-  vm.start_sip = function(directory) {
-    var on_success = function(success) {
+  vm.start_sip = directory => {
+    var on_success = success => {
       // Hide elements from the UI so user doesn't try to start it again
       hide_elements(directory);
 
@@ -94,7 +94,7 @@ controller('ArrangementController', ['$scope', 'Alert', 'Transfer', 'SipArrange'
       });
     };
 
-    var on_failure = function(error) {
+    var on_failure = error => {
       Alert.alerts.push({
         'type': 'danger',
         'message': 'SIP could not be started! Check dashboard logs.',
@@ -106,7 +106,7 @@ controller('ArrangementController', ['$scope', 'Alert', 'Transfer', 'SipArrange'
 
   // Filter the list of dragged files to contain only files with the "display"
   // parameter, so that only visibly selected files are dragged over
-  var filter_files = function(file) {
+  var filter_files = file => {
     if (!file.display) {
       return {};
     }
@@ -115,7 +115,7 @@ controller('ArrangementController', ['$scope', 'Alert', 'Transfer', 'SipArrange'
     if (file.children) {
       var children = file.children;
       file.children = [];
-      angular.forEach(children, function(child) {
+      angular.forEach(children, child => {
         child = filter_files(child);
         // Omit empty objects, or directories whose children have all been filtered out
         if (child.id && child.type === 'file' || (child.children && child.children.length > 0)) {
@@ -127,7 +127,7 @@ controller('ArrangementController', ['$scope', 'Alert', 'Transfer', 'SipArrange'
     return file;
   };
 
-  vm.drop = function(unused, ui) {
+  vm.drop = (unused, ui) => {
     if (ui.draggable.attr('file-type') === 'arrange') {
       return drop_from_arrange.apply(this, [unused, ui]);
     } else {
@@ -135,13 +135,13 @@ controller('ArrangementController', ['$scope', 'Alert', 'Transfer', 'SipArrange'
     }
   };
 
-  var on_copy_failure = function(error) {
+  var on_copy_failure = error => {
     Alert.alerts.push({
       'type': 'danger',
       'message': 'Failed to copy files to SIP arrange; check Dashboard logs.',
     });
   };
-  var on_copy_success = function(success) {
+  var on_copy_success = success => {
     // Reload the tree, rather than recreating the structure locally,
     // since it's possible the structure of the dragged files
     // may differ from the structure of what actually entered arrange.

--- a/app/arrangement/arrangement.controller.js
+++ b/app/arrangement/arrangement.controller.js
@@ -1,180 +1,178 @@
 import angular from 'angular';
 import _ from 'lodash';
 
-(function() {
-  angular.module('arrangementController', ['sipArrangeService']).
+angular.module('arrangementController', ['sipArrangeService']).
 
-  controller('ArrangementController', ['$scope', 'Alert', 'Transfer', 'SipArrange', function($scope, Alert, Transfer, SipArrange) {
-    var vm = this;
+controller('ArrangementController', ['$scope', 'Alert', 'Transfer', 'SipArrange', function($scope, Alert, Transfer, SipArrange) {
+  var vm = this;
 
-    var load_data = function() {
-      SipArrange.list_contents().then(function(directories) {
-        vm.data = directories;
-      });
-    };
+  var load_data = function() {
+    SipArrange.list_contents().then(function(directories) {
+      vm.data = directories;
+    });
+  };
 
-    vm.options = {
-      dirSelectable: true,
-      isLeaf: function(node) {
-        return !node.has_children;
-      },
-    };
-    vm.filter_expression = {display: true};
-    vm.filter_comparator = true;
+  vm.options = {
+    dirSelectable: true,
+    isLeaf: function(node) {
+      return !node.has_children;
+    },
+  };
+  vm.filter_expression = {display: true};
+  vm.filter_comparator = true;
 
-    vm.refresh = function(node) {
-      if (node) {
-        load_element_children(node);
-      } else {
-        load_data();
-      }
-    };
-
-    var load_element_children = function(node) {
-      var path = '/arrange/' + node.path;
-      SipArrange.list_contents(path, node).then(function(entries) {
-        node.children = entries;
-        node.children_fetched = true;
-      });
-    };
-
-    vm.on_toggle = function(node, expanded) {
-      if (!expanded || node.children_fetched) {
-        return;
-      }
+  vm.refresh = function(node) {
+    if (node) {
       load_element_children(node);
-    };
+    } else {
+      load_data();
+    }
+  };
 
-    vm.create_directory = function(parent) {
-      var path = prompt('Name of new directory?');
-      if (!path) {
-        return;
+  var load_element_children = function(node) {
+    var path = '/arrange/' + node.path;
+    SipArrange.list_contents(path, node).then(function(entries) {
+      node.children = entries;
+      node.children_fetched = true;
+    });
+  };
+
+  vm.on_toggle = function(node, expanded) {
+    if (!expanded || node.children_fetched) {
+      return;
+    }
+    load_element_children(node);
+  };
+
+  vm.create_directory = function(parent) {
+    var path = prompt('Name of new directory?');
+    if (!path) {
+      return;
+    }
+
+    if (parent === undefined) {
+      var target = vm.data;
+      var full_path = path;
+    } else {
+      var target = parent.children;
+      var full_path = parent.path + '/' + path;
+    }
+
+    SipArrange.create_directory('/arrange/' + full_path, path, parent).then(function(result) {
+      target.push(result);
+    });
+  };
+
+  vm.delete_directory = function(element) {
+    SipArrange.remove('/arrange/' + element.path).then(function(success) {
+      // `element.parent` is undefined if this is a root-level directory
+      var parent = element.parent ? element.parent.children : vm.data;
+
+      var idx = parent.indexOf(element);
+      parent.splice(idx, 1);
+      vm.selected = undefined;
+    });
+  };
+
+  var hide_elements = function(node) {
+    node.display = false;
+    if (node.children) {
+      for (var i = 0; i < node.children.length; i++) {
+        hide_elements(node.children[i]);
       }
+    }
+  };
 
-      if (parent === undefined) {
-        var target = vm.data;
-        var full_path = path;
-      } else {
-        var target = parent.children;
-        var full_path = parent.path + '/' + path;
-      }
+  vm.start_sip = function(directory) {
+    var on_success = function(success) {
+      // Hide elements from the UI so user doesn't try to start it again
+      hide_elements(directory);
 
-      SipArrange.create_directory('/arrange/' + full_path, path, parent).then(function(result) {
-        target.push(result);
+      Alert.alerts.push({
+        'type': 'success',
+        'message': 'SIP successfully started!',
       });
     };
 
-    vm.delete_directory = function(element) {
-      SipArrange.remove('/arrange/' + element.path).then(function(success) {
-        // `element.parent` is undefined if this is a root-level directory
-        var parent = element.parent ? element.parent.children : vm.data;
-
-        var idx = parent.indexOf(element);
-        parent.splice(idx, 1);
-        vm.selected = undefined;
-      });
-    };
-
-    var hide_elements = function(node) {
-      node.display = false;
-      if (node.children) {
-        for (var i = 0; i < node.children.length; i++) {
-          hide_elements(node.children[i]);
-        }
-      }
-    };
-
-    vm.start_sip = function(directory) {
-      var on_success = function(success) {
-        // Hide elements from the UI so user doesn't try to start it again
-        hide_elements(directory);
-
-        Alert.alerts.push({
-          'type': 'success',
-          'message': 'SIP successfully started!',
-        });
-      };
-
-      var on_failure = function(error) {
-        Alert.alerts.push({
-          'type': 'danger',
-          'message': 'SIP could not be started! Check dashboard logs.',
-        });
-      };
-
-      SipArrange.start_sip('/arrange/' + directory.path + '/').then(on_success, on_failure);
-    };
-
-    // Filter the list of dragged files to contain only files with the "display"
-    // parameter, so that only visibly selected files are dragged over
-    var filter_files = function(file) {
-      if (!file.display) {
-        return {};
-      }
-
-      // Filter children recursively
-      if (file.children) {
-        var children = file.children;
-        file.children = [];
-        angular.forEach(children, function(child) {
-          child = filter_files(child);
-          // Omit empty objects, or directories whose children have all been filtered out
-          if (child.id && child.type === 'file' || (child.children && child.children.length > 0)) {
-            file.children.push(child);
-          }
-        });
-      }
-
-      return file;
-    };
-
-    vm.drop = function(unused, ui) {
-      if (ui.draggable.attr('file-type') === 'arrange') {
-        return drop_from_arrange.apply(this, [unused, ui]);
-      } else {
-        return drop_from_backlog.apply(this, [unused, ui]);
-      }
-    };
-
-    var on_copy_failure = function(error) {
+    var on_failure = function(error) {
       Alert.alerts.push({
         'type': 'danger',
-        'message': 'Failed to copy files to SIP arrange; check Dashboard logs.',
+        'message': 'SIP could not be started! Check dashboard logs.',
       });
     };
-    var on_copy_success = function(success) {
-      // Reload the tree, rather than recreating the structure locally,
-      // since it's possible the structure of the dragged files
-      // may differ from the structure of what actually entered arrange.
-      // TODO: when bugs about dragging contents into the wrong directory are
-      //       resolved, maybe want to reload only the directory into which
-      //       contents were dragged and not the entire tree.
-      load_data();
-    };
 
-    var drop_from_backlog = function(unused, ui) {
-      var file_uuid = ui.draggable.attr('uuid');
-      var file = Transfer.id_map[file_uuid];
-      // create a deep copy of the file and its children so we don't mutate
-      // the copies used in the backlog
-      file = filter_files(_.extend({}, file));
+    SipArrange.start_sip('/arrange/' + directory.path + '/').then(on_success, on_failure);
+  };
 
-      var source_path;
-      if (file.type === 'file') {
-        source_path = file.relative_path;
-      } else {
-        source_path = file.relative_path + '/';
-      }
+  // Filter the list of dragged files to contain only files with the "display"
+  // parameter, so that only visibly selected files are dragged over
+  var filter_files = function(file) {
+    if (!file.display) {
+      return {};
+    }
 
-      SipArrange.copy_to_arrange('/originals/' + source_path, '/arrange/' + this.path + '/').then(on_copy_success, on_copy_failure);
-    };
+    // Filter children recursively
+    if (file.children) {
+      var children = file.children;
+      file.children = [];
+      angular.forEach(children, function(child) {
+        child = filter_files(child);
+        // Omit empty objects, or directories whose children have all been filtered out
+        if (child.id && child.type === 'file' || (child.children && child.children.length > 0)) {
+          file.children.push(child);
+        }
+      });
+    }
 
-    var drop_from_arrange = function(unused, ui) {
-      var path = ui.draggable.attr('file-path');
+    return file;
+  };
 
-      SipArrange.copy_to_arrange('/arrange/' + path, '/arrange/' + this.path + '/').then(on_copy_success, on_copy_failure);
-    };
+  vm.drop = function(unused, ui) {
+    if (ui.draggable.attr('file-type') === 'arrange') {
+      return drop_from_arrange.apply(this, [unused, ui]);
+    } else {
+      return drop_from_backlog.apply(this, [unused, ui]);
+    }
+  };
 
+  var on_copy_failure = function(error) {
+    Alert.alerts.push({
+      'type': 'danger',
+      'message': 'Failed to copy files to SIP arrange; check Dashboard logs.',
+    });
+  };
+  var on_copy_success = function(success) {
+    // Reload the tree, rather than recreating the structure locally,
+    // since it's possible the structure of the dragged files
+    // may differ from the structure of what actually entered arrange.
+    // TODO: when bugs about dragging contents into the wrong directory are
+    //       resolved, maybe want to reload only the directory into which
+    //       contents were dragged and not the entire tree.
     load_data();
-  }]);
-})();
+  };
+
+  var drop_from_backlog = function(unused, ui) {
+    var file_uuid = ui.draggable.attr('uuid');
+    var file = Transfer.id_map[file_uuid];
+    // create a deep copy of the file and its children so we don't mutate
+    // the copies used in the backlog
+    file = filter_files(_.extend({}, file));
+
+    var source_path;
+    if (file.type === 'file') {
+      source_path = file.relative_path;
+    } else {
+      source_path = file.relative_path + '/';
+    }
+
+    SipArrange.copy_to_arrange('/originals/' + source_path, '/arrange/' + this.path + '/').then(on_copy_success, on_copy_failure);
+  };
+
+  var drop_from_arrange = function(unused, ui) {
+    var path = ui.draggable.attr('file-path');
+
+    SipArrange.copy_to_arrange('/arrange/' + path, '/arrange/' + this.path + '/').then(on_copy_success, on_copy_failure);
+  };
+
+  load_data();
+}]);

--- a/app/arrangement/arrangement.controller.js
+++ b/app/arrangement/arrangement.controller.js
@@ -1,5 +1,4 @@
 import angular from 'angular';
-import _ from 'lodash';
 
 angular.module('arrangementController', ['sipArrangeService']).
 
@@ -156,7 +155,7 @@ controller('ArrangementController', ['$scope', 'Alert', 'Transfer', 'SipArrange'
     var file = Transfer.id_map[file_uuid];
     // create a deep copy of the file and its children so we don't mutate
     // the copies used in the backlog
-    file = filter_files(_.extend({}, file));
+    file = filter_files(Object.assign({}, file));
 
     var source_path;
     if (file.type === 'file') {

--- a/app/checklist/checklist.directive.js
+++ b/app/checklist/checklist.directive.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import angular from 'angular';
 
 (function() {

--- a/app/checklist/checklist.directive.js
+++ b/app/checklist/checklist.directive.js
@@ -1,36 +1,34 @@
 import angular from 'angular';
 
-(function() {
-  angular.module('checklistDirective', []).
+angular.module('checklistDirective', []).
 
-  directive('checklist', ['$compile', '$parse', function($compile, $parse) {
-    return {
-      restrict: 'A',
-      link: function($scope, element, attrs) {
-        var get_record = $parse(attrs.ngModel);
-        var get_selected = $parse(attrs.selectedList);
-        var set_all_selected = $parse(attrs.allSelected).assign;
-        var get_record_count = $parse(attrs.recordCount);
+directive('checklist', ['$compile', '$parse', function($compile, $parse) {
+  return {
+    restrict: 'A',
+    link: function($scope, element, attrs) {
+      var get_record = $parse(attrs.ngModel);
+      var get_selected = $parse(attrs.selectedList);
+      var set_all_selected = $parse(attrs.allSelected).assign;
+      var get_record_count = $parse(attrs.recordCount);
 
-        element.attr('type', 'checkbox');
+      element.attr('type', 'checkbox');
 
-        element.bind('click', function() {
-          var selected = get_selected($scope);
-          var record = get_record($scope);
+      element.bind('click', function() {
+        var selected = get_selected($scope);
+        var record = get_record($scope);
 
-          var index = selected.indexOf(record.id);
-          $scope.$apply(function() {
-            // remove from selection
-            if (index > -1) {
-              selected.splice(index, 1);
-            } else {
-              selected.push(record.id);
-            }
+        var index = selected.indexOf(record.id);
+        $scope.$apply(function() {
+          // remove from selection
+          if (index > -1) {
+            selected.splice(index, 1);
+          } else {
+            selected.push(record.id);
+          }
 
-            set_all_selected($scope, !(selected.length < get_record_count($scope)));
-          });
+          set_all_selected($scope, !(selected.length < get_record_count($scope)));
         });
-      },
-    };
-  }]);
-})();
+      });
+    },
+  };
+}]);

--- a/app/checklist/checklist.directive.js
+++ b/app/checklist/checklist.directive.js
@@ -13,12 +13,12 @@ directive('checklist', ['$compile', '$parse', function($compile, $parse) {
 
       element.attr('type', 'checkbox');
 
-      element.bind('click', function() {
+      element.bind('click', () => {
         var selected = get_selected($scope);
         var record = get_record($scope);
 
         var index = selected.indexOf(record.id);
-        $scope.$apply(function() {
+        $scope.$apply(() => {
           // remove from selection
           if (index > -1) {
             selected.splice(index, 1);

--- a/app/examine_contents/examine_contents.controller.js
+++ b/app/examine_contents/examine_contents.controller.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import angular from 'angular';
 
 (function() {

--- a/app/examine_contents/examine_contents.controller.js
+++ b/app/examine_contents/examine_contents.controller.js
@@ -12,11 +12,9 @@ controller('ExamineContentsController', ['$routeSegment', 'FileList', 'SelectedF
   vm.selected = [];
   vm.all_selected = false;
 
-  vm.select_all = function(files) {
+  vm.select_all = files => {
     if (!vm.all_selected) {
-      vm.selected = files.map(function(file) {
-        return file.id;
-      });
+      vm.selected = files.map(file => file.id);
       vm.all_selected = true;
     } else {
       vm.selected = [];
@@ -24,7 +22,7 @@ controller('ExamineContentsController', ['$routeSegment', 'FileList', 'SelectedF
     }
   };
 
-  vm.submit = function(ids) {
+  vm.submit = ids => {
     var tag = this.tag;
     if (!tag) {
       return;
@@ -34,10 +32,8 @@ controller('ExamineContentsController', ['$routeSegment', 'FileList', 'SelectedF
     this.tag = '';
   };
 
-  vm.add_to_file_list = function(ids) {
-    FileList.files = SelectedFiles.selected.filter(function(file) {
-      return ids.indexOf(file.id) > -1;
-    });
+  vm.add_to_file_list = ids => {
+    FileList.files = SelectedFiles.selected.filter(file => ids.indexOf(file.id) > -1);
   };
 }]).
 
@@ -46,7 +42,7 @@ controller('ExamineContentsFileController', ['$routeSegment', 'File', function($
 
   vm.id = $routeSegment.$routeParams.id;
   vm.type = $routeSegment.$routeParams.type;
-  File.bulk_extractor_info(vm.id, [vm.type]).then(function(data) {
+  File.bulk_extractor_info(vm.id, [vm.type]).then(data => {
     vm.file = data;
   });
 }]);

--- a/app/examine_contents/examine_contents.controller.js
+++ b/app/examine_contents/examine_contents.controller.js
@@ -1,54 +1,52 @@
 import angular from 'angular';
 
-(function() {
-  angular.module('examineContentsController', []).
+angular.module('examineContentsController', []).
 
-  controller('ExamineContentsController', ['$routeSegment', 'FileList', 'SelectedFiles', 'Transfer', function($routeSegment, FileList, SelectedFiles, Transfer) {
-    var vm = this;
+controller('ExamineContentsController', ['$routeSegment', 'FileList', 'SelectedFiles', 'Transfer', function($routeSegment, FileList, SelectedFiles, Transfer) {
+  var vm = this;
 
-    vm.$routeSegment = $routeSegment;
-    vm.type = $routeSegment.$routeParams.type;
-    vm.SelectedFiles = SelectedFiles;
+  vm.$routeSegment = $routeSegment;
+  vm.type = $routeSegment.$routeParams.type;
+  vm.SelectedFiles = SelectedFiles;
 
-    vm.selected = [];
-    vm.all_selected = false;
+  vm.selected = [];
+  vm.all_selected = false;
 
-    vm.select_all = function(files) {
-      if (!vm.all_selected) {
-        vm.selected = files.map(function(file) {
-          return file.id;
-        });
-        vm.all_selected = true;
-      } else {
-        vm.selected = [];
-        vm.all_selected = false;
-      }
-    };
-
-    vm.submit = function(ids) {
-      var tag = this.tag;
-      if (!tag) {
-        return;
-      }
-
-      Transfer.add_list_of_tags(ids, tag);
-      this.tag = '';
-    };
-
-    vm.add_to_file_list = function(ids) {
-      FileList.files = SelectedFiles.selected.filter(function(file) {
-        return ids.indexOf(file.id) > -1;
+  vm.select_all = function(files) {
+    if (!vm.all_selected) {
+      vm.selected = files.map(function(file) {
+        return file.id;
       });
-    };
-  }]).
+      vm.all_selected = true;
+    } else {
+      vm.selected = [];
+      vm.all_selected = false;
+    }
+  };
 
-  controller('ExamineContentsFileController', ['$routeSegment', 'File', function($routeSegment, File) {
-    var vm = this;
+  vm.submit = function(ids) {
+    var tag = this.tag;
+    if (!tag) {
+      return;
+    }
 
-    vm.id = $routeSegment.$routeParams.id;
-    vm.type = $routeSegment.$routeParams.type;
-    File.bulk_extractor_info(vm.id, [vm.type]).then(function(data) {
-      vm.file = data;
+    Transfer.add_list_of_tags(ids, tag);
+    this.tag = '';
+  };
+
+  vm.add_to_file_list = function(ids) {
+    FileList.files = SelectedFiles.selected.filter(function(file) {
+      return ids.indexOf(file.id) > -1;
     });
-  }]);
-})();
+  };
+}]).
+
+controller('ExamineContentsFileController', ['$routeSegment', 'File', function($routeSegment, File) {
+  var vm = this;
+
+  vm.id = $routeSegment.$routeParams.id;
+  vm.type = $routeSegment.$routeParams.type;
+  File.bulk_extractor_info(vm.id, [vm.type]).then(function(data) {
+    vm.file = data;
+  });
+}]);

--- a/app/facet_selector/facet_selector.controller.js
+++ b/app/facet_selector/facet_selector.controller.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import angular from 'angular';
 
 (function() {

--- a/app/facet_selector/facet_selector.controller.js
+++ b/app/facet_selector/facet_selector.controller.js
@@ -1,24 +1,22 @@
 import angular from 'angular';
 
-(function() {
-  angular.module('facetController', ['tagService']).
+angular.module('facetController', ['tagService']).
 
-  controller('FacetController', ['$scope', 'Transfer', 'Facet', function($scope, Transfer, Facet) {
-      $scope.remove_facet = function(name, id) {
-        Facet.remove_by_id(name, id);
-        Transfer.filter();
-      };
-      $scope.Facet = Facet;
-      $scope.transfers = Transfer;
+controller('FacetController', ['$scope', 'Transfer', 'Facet', function($scope, Transfer, Facet) {
+  $scope.remove_facet = function(name, id) {
+    Facet.remove_by_id(name, id);
+    Transfer.filter();
+  };
+  $scope.Facet = Facet;
+  $scope.transfers = Transfer;
 
-      $scope.$watch('tag_facet', function(selected) {
-        if (!selected) {
-          return;
-        }
+  $scope.$watch('tag_facet', function(selected) {
+    if (!selected) {
+      return;
+    }
 
-        Facet.add('tags', selected, {name: 'Tag', text: selected});
-        Transfer.filter();
-        $scope.tag_facet = '';
-      });
-    }]);
-})();
+    Facet.add('tags', selected, {name: 'Tag', text: selected});
+    Transfer.filter();
+    $scope.tag_facet = '';
+  });
+}]);

--- a/app/file_list/file_list.controller.js
+++ b/app/file_list/file_list.controller.js
@@ -7,11 +7,11 @@ controller('FileListController', ['$scope', '$routeSegment', 'FileList', 'Transf
 
   vm.$routeSegment = $routeSegment;
   vm.file_list = FileList;
-  vm.remove_tag = function(id, tag) {
+  vm.remove_tag = (id, tag) => {
     Transfer.remove_tag(id, tag);
   };
 
-  $scope.$watch('file_list.files', function() {
+  $scope.$watch('file_list.files', () => {
     vm.selected = [];
     vm.all_selected = false;
   });
@@ -19,11 +19,9 @@ controller('FileListController', ['$scope', '$routeSegment', 'FileList', 'Transf
   vm.selected = [];
   vm.all_selected = false;
 
-  vm.select_all = function() {
+  vm.select_all = () => {
     if (!vm.all_selected) {
-      vm.selected = FileList.files.map(function(file) {
-        return file.id;
-      });
+      vm.selected = FileList.files.map(file => file.id);
       vm.all_selected = true;
     } else {
       vm.selected = [];
@@ -31,7 +29,7 @@ controller('FileListController', ['$scope', '$routeSegment', 'FileList', 'Transf
     }
   };
 
-  vm.submit = function(uuids) {
+  vm.submit = uuids => {
     var tag = this.tag;
     if (!tag) {
       return;
@@ -45,7 +43,7 @@ controller('FileListController', ['$scope', '$routeSegment', 'FileList', 'Transf
   vm.sort_property = 'title';
   vm.sort_reverse = false;
 
-  vm.set_sort_property = function(property) {
+  vm.set_sort_property = property => {
     if (vm.sort_property === property) {
       vm.sort_reverse = !vm.sort_reverse;
     } else {
@@ -56,7 +54,7 @@ controller('FileListController', ['$scope', '$routeSegment', 'FileList', 'Transf
 
   vm.date_regex = '\\d\\d\\d\\d([-\/]\\d\\d?)?([-\/]\\d\\d?)?';
 
-  var format_date = function(start, end) {
+  var format_date = (start, end) => {
     var s;
     if (!start) {
       s = ' -';
@@ -70,25 +68,25 @@ controller('FileListController', ['$scope', '$routeSegment', 'FileList', 'Transf
     return s;
   };
 
-  var date_is_valid = function(date) {
+  var date_is_valid = date => {
     if (date === undefined) {
       return false;
     } else {
       return date.length < 4 ? false : true;
     }
-  }
+  };
 
-  var default_filter = function() {
+  var default_filter = () => {
     return true;
   };
   vm.facet_filter = default_filter;
 
-  vm.reset_dates = function() {
+  vm.reset_dates = () => {
     vm.date_facet = '';
     vm.facet_filter = default_filter;
-  }
+  };
 
-  vm.set_date_filter = function(start_date, end_date) {
+  vm.set_date_filter = (start_date, end_date) => {
     // Remove the facet immediately, so that the facet is updated if a user
     // enters an invalid date
     vm.date_facet = '';
@@ -108,7 +106,7 @@ controller('FileListController', ['$scope', '$routeSegment', 'FileList', 'Transf
     }
 
     vm.date_facet = format_date(start_date, end_date);
-    vm.facet_filter = function(date) {
+    vm.facet_filter = date => {
       if (date === undefined) {
         return true;
       }

--- a/app/file_list/file_list.controller.js
+++ b/app/file_list/file_list.controller.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import angular from 'angular';
 
 (function() {

--- a/app/file_list/file_list.controller.js
+++ b/app/file_list/file_list.controller.js
@@ -1,123 +1,121 @@
 import angular from 'angular';
 
-(function() {
-  angular.module('fileListController', ['fileListService']).
+angular.module('fileListController', ['fileListService']).
 
-  controller('FileListController', ['$scope', '$routeSegment', 'FileList', 'Transfer', function($scope, $routeSegment, FileList, Transfer) {
-    var vm = this;
+controller('FileListController', ['$scope', '$routeSegment', 'FileList', 'Transfer', function($scope, $routeSegment, FileList, Transfer) {
+  var vm = this;
 
-    vm.$routeSegment = $routeSegment;
-    vm.file_list = FileList;
-    vm.remove_tag = function(id, tag) {
-      Transfer.remove_tag(id, tag);
-    };
+  vm.$routeSegment = $routeSegment;
+  vm.file_list = FileList;
+  vm.remove_tag = function(id, tag) {
+    Transfer.remove_tag(id, tag);
+  };
 
-    $scope.$watch('file_list.files', function() {
-      vm.selected = [];
-      vm.all_selected = false;
-    });
-
+  $scope.$watch('file_list.files', function() {
     vm.selected = [];
     vm.all_selected = false;
+  });
 
-    vm.select_all = function() {
-      if (!vm.all_selected) {
-        vm.selected = FileList.files.map(function(file) {
-          return file.id;
-        });
-        vm.all_selected = true;
-      } else {
-        vm.selected = [];
-        vm.all_selected = false;
-      }
-    };
+  vm.selected = [];
+  vm.all_selected = false;
 
-    vm.submit = function(uuids) {
-      var tag = this.tag;
-      if (!tag) {
-        return;
-      }
+  vm.select_all = function() {
+    if (!vm.all_selected) {
+      vm.selected = FileList.files.map(function(file) {
+        return file.id;
+      });
+      vm.all_selected = true;
+    } else {
+      vm.selected = [];
+      vm.all_selected = false;
+    }
+  };
 
-      Transfer.add_list_of_tags(uuids, tag);
-      this.tag = '';
-    };
-
-    // Sorting related
-    vm.sort_property = 'title';
-    vm.sort_reverse = false;
-
-    vm.set_sort_property = function(property) {
-      if (vm.sort_property === property) {
-        vm.sort_reverse = !vm.sort_reverse;
-      } else {
-        vm.sort_reverse = false;
-        vm.sort_property = property;
-      }
-    };
-
-    vm.date_regex = '\\d\\d\\d\\d([-\/]\\d\\d?)?([-\/]\\d\\d?)?';
-
-    var format_date = function(start, end) {
-      var s;
-      if (!start) {
-        s = ' -';
-      } else {
-        s = start + ' -';
-      }
-      if (end) {
-        s += ' ' + end;
-      }
-
-      return s;
-    };
-
-    var date_is_valid = function(date) {
-      if (date === undefined) {
-        return false;
-      } else {
-        return date.length < 4 ? false : true;
-      }
+  vm.submit = function(uuids) {
+    var tag = this.tag;
+    if (!tag) {
+      return;
     }
 
-    var default_filter = function() {
-      return true;
-    };
+    Transfer.add_list_of_tags(uuids, tag);
+    this.tag = '';
+  };
+
+  // Sorting related
+  vm.sort_property = 'title';
+  vm.sort_reverse = false;
+
+  vm.set_sort_property = function(property) {
+    if (vm.sort_property === property) {
+      vm.sort_reverse = !vm.sort_reverse;
+    } else {
+      vm.sort_reverse = false;
+      vm.sort_property = property;
+    }
+  };
+
+  vm.date_regex = '\\d\\d\\d\\d([-\/]\\d\\d?)?([-\/]\\d\\d?)?';
+
+  var format_date = function(start, end) {
+    var s;
+    if (!start) {
+      s = ' -';
+    } else {
+      s = start + ' -';
+    }
+    if (end) {
+      s += ' ' + end;
+    }
+
+    return s;
+  };
+
+  var date_is_valid = function(date) {
+    if (date === undefined) {
+      return false;
+    } else {
+      return date.length < 4 ? false : true;
+    }
+  }
+
+  var default_filter = function() {
+    return true;
+  };
+  vm.facet_filter = default_filter;
+
+  vm.reset_dates = function() {
+    vm.date_facet = '';
     vm.facet_filter = default_filter;
+  }
 
-    vm.reset_dates = function() {
-      vm.date_facet = '';
-      vm.facet_filter = default_filter;
+  vm.set_date_filter = function(start_date, end_date) {
+    // Remove the facet immediately, so that the facet is updated if a user
+    // enters an invalid date
+    vm.date_facet = '';
+    vm.facet_filter = default_filter;
+    if (!start_date && !end_date) {
+      return;
     }
 
-    vm.set_date_filter = function(start_date, end_date) {
-      // Remove the facet immediately, so that the facet is updated if a user
-      // enters an invalid date
-      vm.date_facet = '';
-      vm.facet_filter = default_filter;
-      if (!start_date && !end_date) {
-        return;
+    var default_start_date = -62167219200000; // BC 1
+    var default_end_date = 3093496473600000; // AD 99999
+    var start = date_is_valid(start_date) ? Date.parse(start_date) : default_start_date;
+    var end = date_is_valid(end_date) ? Date.parse(end_date) : default_end_date;
+
+    // Can occur if either date is invalid, for example 2015/99/99
+    if (isNaN(start) || isNaN(end)) {
+      return;
+    }
+
+    vm.date_facet = format_date(start_date, end_date);
+    vm.facet_filter = function(date) {
+      if (date === undefined) {
+        return true;
       }
 
-      var default_start_date = -62167219200000; // BC 1
-      var default_end_date = 3093496473600000; // AD 99999
-      var start = date_is_valid(start_date) ? Date.parse(start_date) : default_start_date;
-      var end = date_is_valid(end_date) ? Date.parse(end_date) : default_end_date;
-
-      // Can occur if either date is invalid, for example 2015/99/99
-      if (isNaN(start) || isNaN(end)) {
-        return;
-      }
-
-      vm.date_facet = format_date(start_date, end_date);
-      vm.facet_filter = function(date) {
-        if (date === undefined) {
-          return true;
-        }
-
-        // TODO: handle unparseable dates
-        var date_as_int = Date.parse(date);
-        return date_as_int >= start && date_as_int <= end;
-      };
+      // TODO: handle unparseable dates
+      var date_as_int = Date.parse(date);
+      return date_as_int >= start && date_as_int <= end;
     };
-  }]);
-})();
+  };
+}]);

--- a/app/filters/aggregation.filter.js
+++ b/app/filters/aggregation.filter.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import angular from 'angular';
 import _ from 'lodash';
 

--- a/app/filters/aggregation.filter.js
+++ b/app/filters/aggregation.filter.js
@@ -3,14 +3,14 @@ import _ from 'lodash';
 
 // The default hash function may confuse two arrays of objects
 // of the same length as the same set of records.
-var hash_fn = function(records) {
+var hash_fn = records => {
   return JSON.stringify(records);
 };
 
 angular.module('aggregationFilters', []).
 
 filter('format_data', function() {
-  var format_data_fn = function(records) {
+  var format_data_fn = records => {
     var format_data = {};
     for (var i in records) {
       var record = records[i];
@@ -34,21 +34,19 @@ filter('format_data', function() {
       out_data.push({format: key, data: format_data[key]});
     }
 
-    return _.sortBy(out_data, function(format) {
-      return format.format;
-    });
+    return _.sortBy(out_data, format => format.format);
   };
 
   return _.memoize(format_data_fn, hash_fn);
 }).
 
-filter('format_graph', function() {
-  var format_graph_fn = function(records) {
+filter('format_graph', () => {
+  var format_graph_fn = records => {
     var data = {
       series: ['Format'],
       data: [],
     };
-    angular.forEach(records, function(format_data, _) {
+    angular.forEach(records, (format_data, _) => {
       var readable_name = format_data.format;
       if (format_data.data.puid) {
        readable_name += ' (' + format_data.data.puid + ')';
@@ -67,12 +65,12 @@ filter('format_graph', function() {
 }).
 
 filter('size_graph', function($filter) {
-  var size_graph_fn = function(records) {
+  var size_graph_fn = records => {
     var data = {
       series: ['Format'],
       data: [],
     };
-    angular.forEach(records, function(format_data, _) {
+    angular.forEach(records, (format_data, _) => {
       var readable_name = format_data.format;
       if (format_data.data.puid) {
        readable_name += ' (' + format_data.data.puid + ')';
@@ -91,27 +89,19 @@ filter('size_graph', function($filter) {
 }).
 
 filter('find_transfers', function() {
-  var transfer_fn = function(records) {
-    return records.filter(function(el) {
-      return el.type === 'transfer';
-    });
-  };
+  var transfer_fn = records => records.filter(el => el.type === 'transfer');
 
   return _.memoize(transfer_fn, hash_fn);
 }).
 
 filter('find_files', function() {
-  var file_fn = function(records) {
-    return records.filter(function(el) {
-      return el.type === 'file' && el.bulk_extractor_reports;
-    });
-  };
+  var file_fn = records => records.filter(el => el.type === 'file' && el.bulk_extractor_reports);
 
   return _.memoize(file_fn, hash_fn);
 }).
 
 filter('tag_count', function() {
-  var tag_fn = function(records) {
+  var tag_fn = records => {
     var out = {};
     for (var i in records) {
       var record = records[i];
@@ -122,7 +112,7 @@ filter('tag_count', function() {
     }
 
     // Return as array so it is sortable
-    return _.map(out, function(count, tag) { return [tag, count]; });
+    return _.map(out, (count, tag) => [tag, count]);
   };
 
   return _.memoize(tag_fn, hash_fn);

--- a/app/filters/aggregation.filter.js
+++ b/app/filters/aggregation.filter.js
@@ -1,131 +1,129 @@
 import angular from 'angular';
 import _ from 'lodash';
 
-(function() {
-  // The default hash function may confuse two arrays of objects
-  // of the same length as the same set of records.
-  var hash_fn = function(records) {
-    return JSON.stringify(records);
+// The default hash function may confuse two arrays of objects
+// of the same length as the same set of records.
+var hash_fn = function(records) {
+  return JSON.stringify(records);
+};
+
+angular.module('aggregationFilters', []).
+
+filter('format_data', function() {
+  var format_data_fn = function(records) {
+    var format_data = {};
+    for (var i in records) {
+      var record = records[i];
+      if (!record.format) {
+        continue;
+      }
+
+      if (!format_data[record.format]) {
+        format_data[record.format] = {count: 0, size: 0};
+      }
+
+      format_data[record.format].count++;
+      format_data[record.format].puid = record.puid || '';
+      format_data[record.format].format = record.format;
+      format_data[record.format].group = record.group;
+      format_data[record.format].size += parseFloat(record.size) || 0;
+    }
+
+    var out_data = [];
+    for (var key in format_data) {
+      out_data.push({format: key, data: format_data[key]});
+    }
+
+    return _.sortBy(out_data, function(format) {
+      return format.format;
+    });
   };
 
-  angular.module('aggregationFilters', []).
+  return _.memoize(format_data_fn, hash_fn);
+}).
 
-  filter('format_data', function() {
-    var format_data_fn = function(records) {
-      var format_data = {};
-      for (var i in records) {
-        var record = records[i];
-        if (!record.format) {
-          continue;
-        }
-
-        if (!format_data[record.format]) {
-          format_data[record.format] = {count: 0, size: 0};
-        }
-
-        format_data[record.format].count++;
-        format_data[record.format].puid = record.puid || '';
-        format_data[record.format].format = record.format;
-        format_data[record.format].group = record.group;
-        format_data[record.format].size += parseFloat(record.size) || 0;
+filter('format_graph', function() {
+  var format_graph_fn = function(records) {
+    var data = {
+      series: ['Format'],
+      data: [],
+    };
+    angular.forEach(records, function(format_data, _) {
+      var readable_name = format_data.format;
+      if (format_data.data.puid) {
+       readable_name += ' (' + format_data.data.puid + ')';
       }
+      data.data.push({
+        format: format_data.format,
+        x: readable_name,
+        y: [format_data.data.count],
+        tooltip: readable_name,
+      });
+    });
+    return data;
+  };
 
-      var out_data = [];
-      for (var key in format_data) {
-        out_data.push({format: key, data: format_data[key]});
+  return _.memoize(format_graph_fn, hash_fn);
+}).
+
+filter('size_graph', function($filter) {
+  var size_graph_fn = function(records) {
+    var data = {
+      series: ['Format'],
+      data: [],
+    };
+    angular.forEach(records, function(format_data, _) {
+      var readable_name = format_data.format;
+      if (format_data.data.puid) {
+       readable_name += ' (' + format_data.data.puid + ')';
       }
-
-      return _.sortBy(out_data, function(format) {
-        return format.format;
+      data.data.push({
+        format: format_data.format,
+        x: readable_name,
+        y: [format_data.data.size],
+        tooltip: readable_name + ', ' + $filter('number')(format_data.data.size) + ' MB',
       });
-    };
+    });
+    return data;
+  };
 
-    return _.memoize(format_data_fn, hash_fn);
-  }).
+  return _.memoize(size_graph_fn, hash_fn);
+}).
 
-  filter('format_graph', function() {
-    var format_graph_fn = function(records) {
-      var data = {
-        series: ['Format'],
-        data: [],
-      };
-      angular.forEach(records, function(format_data, _) {
-        var readable_name = format_data.format;
-        if (format_data.data.puid) {
-         readable_name += ' (' + format_data.data.puid + ')';
-        }
-        data.data.push({
-          format: format_data.format,
-          x: readable_name,
-          y: [format_data.data.count],
-          tooltip: readable_name,
-        });
-      });
-      return data;
-    };
+filter('find_transfers', function() {
+  var transfer_fn = function(records) {
+    return records.filter(function(el) {
+      return el.type === 'transfer';
+    });
+  };
 
-    return _.memoize(format_graph_fn, hash_fn);
-  }).
+  return _.memoize(transfer_fn, hash_fn);
+}).
 
-  filter('size_graph', function($filter) {
-    var size_graph_fn = function(records) {
-      var data = {
-        series: ['Format'],
-        data: [],
-      };
-      angular.forEach(records, function(format_data, _) {
-        var readable_name = format_data.format;
-        if (format_data.data.puid) {
-         readable_name += ' (' + format_data.data.puid + ')';
-        }
-        data.data.push({
-          format: format_data.format,
-          x: readable_name,
-          y: [format_data.data.size],
-          tooltip: readable_name + ', ' + $filter('number')(format_data.data.size) + ' MB',
-        });
-      });
-      return data;
-    };
+filter('find_files', function() {
+  var file_fn = function(records) {
+    return records.filter(function(el) {
+      return el.type === 'file' && el.bulk_extractor_reports;
+    });
+  };
 
-    return _.memoize(size_graph_fn, hash_fn);
-  }).
+  return _.memoize(file_fn, hash_fn);
+}).
 
-  filter('find_transfers', function() {
-    var transfer_fn = function(records) {
-      return records.filter(function(el) {
-        return el.type === 'transfer';
-      });
-    };
-
-    return _.memoize(transfer_fn, hash_fn);
-  }).
-
-  filter('find_files', function() {
-    var file_fn = function(records) {
-      return records.filter(function(el) {
-        return el.type === 'file' && el.bulk_extractor_reports;
-      });
-    };
-
-    return _.memoize(file_fn, hash_fn);
-  }).
-
-  filter('tag_count', function() {
-    var tag_fn = function(records) {
-      var out = {};
-      for (var i in records) {
-        var record = records[i];
-        for (var tag_index in record.tags) {
-          var tag = record.tags[tag_index];
-          out[tag] ? out[tag]++ : out[tag] = 1;
-        }
+filter('tag_count', function() {
+  var tag_fn = function(records) {
+    var out = {};
+    for (var i in records) {
+      var record = records[i];
+      for (var tag_index in record.tags) {
+        var tag = record.tags[tag_index];
+        out[tag] ? out[tag]++ : out[tag] = 1;
       }
+    }
 
-      // Return as array so it is sortable
-      return _.map(out, function(count, tag) { return [tag, count]; });
-    };
+    // Return as array so it is sortable
+    return _.map(out, function(count, tag) { return [tag, count]; });
+  };
 
-    return _.memoize(tag_fn, hash_fn);
-  });
-})();
+  return _.memoize(tag_fn, hash_fn);
+});

--- a/app/filters/facet.filter.js
+++ b/app/filters/facet.filter.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import angular from 'angular';
 import _ from 'lodash';
 

--- a/app/filters/facet.filter.js
+++ b/app/filters/facet.filter.js
@@ -4,13 +4,11 @@ import _ from 'lodash';
 angular.module('facetFilter', []).
 
 filter('facet', ['Facet', function(Facet) {
-  var facet_filter_fn = function(records) {
-    return Facet.filter(records);
-  };
+  var facet_filter_fn = records => Facet.filter(records);
 
   // The default hash function may confuse two arrays of objects
   // of the same length as the same set of records.
-  var hash_fn = function(records) {
+  var hash_fn = records => {
     return JSON.stringify(records) + JSON.stringify(Facet.facets);
   };
 

--- a/app/filters/facet.filter.js
+++ b/app/filters/facet.filter.js
@@ -1,20 +1,18 @@
 import angular from 'angular';
 import _ from 'lodash';
 
-(function() {
-  angular.module('facetFilter', []).
+angular.module('facetFilter', []).
 
-  filter('facet', ['Facet', function(Facet) {
-      var facet_filter_fn = function(records) {
-        return Facet.filter(records);
-      };
+filter('facet', ['Facet', function(Facet) {
+  var facet_filter_fn = function(records) {
+    return Facet.filter(records);
+  };
 
-      // The default hash function may confuse two arrays of objects
-      // of the same length as the same set of records.
-      var hash_fn = function(records) {
-        return JSON.stringify(records) + JSON.stringify(Facet.facets);
-      };
+  // The default hash function may confuse two arrays of objects
+  // of the same length as the same set of records.
+  var hash_fn = function(records) {
+    return JSON.stringify(records) + JSON.stringify(Facet.facets);
+  };
 
-      return _.memoize(facet_filter_fn, hash_fn);
-    }]);
-})();
+  return _.memoize(facet_filter_fn, hash_fn);
+}]);

--- a/app/preview/preview.controller.js
+++ b/app/preview/preview.controller.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import angular from 'angular';
 
 (function() {

--- a/app/preview/preview.controller.js
+++ b/app/preview/preview.controller.js
@@ -1,36 +1,34 @@
 import angular from 'angular';
 
-(function() {
-  angular.module('previewController', ['route-segment', 'fileListService']).
+angular.module('previewController', ['route-segment', 'fileListService']).
 
-  controller('PreviewController', ['$scope', '$routeSegment', 'Alert', 'File', 'FileList', function($scope, $routeSegment, Alert, File, FileList) {
-    var vm = this;
+controller('PreviewController', ['$scope', '$routeSegment', 'Alert', 'File', 'FileList', function($scope, $routeSegment, Alert, File, FileList) {
+  var vm = this;
 
-    vm.set_file_data = function(file) {
-      $scope.file = file;
-      $scope.url = '/filesystem/' + file.id + '/download';
-    };
+  vm.set_file_data = function(file) {
+    $scope.file = file;
+    $scope.url = '/filesystem/' + file.id + '/download';
+  };
 
-    $scope.$routeSegment = $routeSegment;
-    $scope.id = $routeSegment.$routeParams.id;
-    if ($scope.id !== undefined) {
-      // Try to get file from the file list first, to avoid pinging the server.
-      var file = FileList.get($scope.id);
-      if (file) {
+  $scope.$routeSegment = $routeSegment;
+  $scope.id = $routeSegment.$routeParams.id;
+  if ($scope.id !== undefined) {
+    // Try to get file from the file list first, to avoid pinging the server.
+    var file = FileList.get($scope.id);
+    if (file) {
+      vm.set_file_data(file);
+    } else {
+      // If the data isn't available, contact the server to fetch file info;
+      // it may not have been loaded.
+      var on_failure = function(error) {
+        Alert.alerts.push({
+          type: 'danger',
+          message: 'Unable to retrieve metadata for file with UUID ' + $scope.id,
+        });
+      };
+      File.get($scope.id).then(function (file) {
         vm.set_file_data(file);
-      } else {
-        // If the data isn't available, contact the server to fetch file info;
-        // it may not have been loaded.
-        var on_failure = function(error) {
-          Alert.alerts.push({
-            type: 'danger',
-            message: 'Unable to retrieve metadata for file with UUID ' + $scope.id,
-          });
-        };
-        File.get($scope.id).then(function (file) {
-          vm.set_file_data(file);
-        }, on_failure);
-      }
+      }, on_failure);
     }
-  }]);
-})();
+  }
+}]);

--- a/app/preview/preview.controller.js
+++ b/app/preview/preview.controller.js
@@ -5,7 +5,7 @@ angular.module('previewController', ['route-segment', 'fileListService']).
 controller('PreviewController', ['$scope', '$routeSegment', 'Alert', 'File', 'FileList', function($scope, $routeSegment, Alert, File, FileList) {
   var vm = this;
 
-  vm.set_file_data = function(file) {
+  vm.set_file_data = file => {
     $scope.file = file;
     $scope.url = '/filesystem/' + file.id + '/download';
   };
@@ -20,13 +20,13 @@ controller('PreviewController', ['$scope', '$routeSegment', 'Alert', 'File', 'Fi
     } else {
       // If the data isn't available, contact the server to fetch file info;
       // it may not have been loaded.
-      var on_failure = function(error) {
+      var on_failure = error => {
         Alert.alerts.push({
           type: 'danger',
           message: 'Unable to retrieve metadata for file with UUID ' + $scope.id,
         });
       };
-      File.get($scope.id).then(function (file) {
+      File.get($scope.id).then(file => {
         vm.set_file_data(file);
       }, on_failure);
     }

--- a/app/report/report.controller.js
+++ b/app/report/report.controller.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import angular from 'angular';
 
 (function() {

--- a/app/report/report.controller.js
+++ b/app/report/report.controller.js
@@ -37,14 +37,10 @@ controller('ReportController', ['$scope', 'FileList', 'SelectedFiles', function(
   };
 
   $scope.set_file_list = function(type, attr) {
-    FileList.files = SelectedFiles.selected.filter(function(file) {
-      return file[attr] === type;
-    });
+    FileList.files = SelectedFiles.selected.filter(file => file[attr] === type);
   };
 
   $scope.add_tags_to_file_list = function(tag) {
-    FileList.files = SelectedFiles.selected.filter(function(file) {
-      return file.tags.indexOf(tag) > -1;
-    });
+    FileList.files = SelectedFiles.selected.filter(file => file.tags.indexOf(tag) > -1);
   };
 }]);

--- a/app/report/report.controller.js
+++ b/app/report/report.controller.js
@@ -1,52 +1,50 @@
 import angular from 'angular';
 
-(function() {
-  angular.module('reportController', ['selectedFilesService']).
+angular.module('reportController', ['selectedFilesService']).
 
-  controller('ReportSelectionController', ['$scope', '$routeSegment', function($scope, $routeSegment) {
-    $scope.$routeSegment = $routeSegment;
-  }]).
+controller('ReportSelectionController', ['$scope', '$routeSegment', function($scope, $routeSegment) {
+  $scope.$routeSegment = $routeSegment;
+}]).
 
-  controller('ReportController', ['$scope', 'FileList', 'SelectedFiles', function($scope, FileList, SelectedFiles) {
-    $scope.records = SelectedFiles;
+controller('ReportController', ['$scope', 'FileList', 'SelectedFiles', function($scope, FileList, SelectedFiles) {
+  $scope.records = SelectedFiles;
 
-    $scope.format_sort_property = 'format';
-    $scope.format_reverse = false;
-    $scope.format_sort_fn = function(record) {
-      var sort_prop = $scope.format_sort_property;
-      if (sort_prop === 'puid') {
-        return record.puid;
-      } else {
-        return record.data[sort_prop];
-      }
-    };
+  $scope.format_sort_property = 'format';
+  $scope.format_reverse = false;
+  $scope.format_sort_fn = function(record) {
+    var sort_prop = $scope.format_sort_property;
+    if (sort_prop === 'puid') {
+      return record.puid;
+    } else {
+      return record.data[sort_prop];
+    }
+  };
 
-    $scope.set_sort_property = function(property, sort_prop, reverse_prop) {
-      if ($scope[sort_prop] === property) {
-        $scope[reverse_prop] = !$scope[reverse_prop];
-      } else {
-        $scope[reverse_prop] = false;
-        $scope[sort_prop] = property;
-      }
-    };
+  $scope.set_sort_property = function(property, sort_prop, reverse_prop) {
+    if ($scope[sort_prop] === property) {
+      $scope[reverse_prop] = !$scope[reverse_prop];
+    } else {
+      $scope[reverse_prop] = false;
+      $scope[sort_prop] = property;
+    }
+  };
 
-    $scope.tag_sort_property = 'tag';
-    $scope.tag_reverse = false;
-    $scope.tag_sort_fn = function(args) {
-      var tag = args[0], count = args[1];
-      return $scope.tag_sort_property === 'tag' ? tag : count;
-    };
+  $scope.tag_sort_property = 'tag';
+  $scope.tag_reverse = false;
+  $scope.tag_sort_fn = function(args) {
+    var tag = args[0], count = args[1];
+    return $scope.tag_sort_property === 'tag' ? tag : count;
+  };
 
-    $scope.set_file_list = function(type, attr) {
-      FileList.files = SelectedFiles.selected.filter(function(file) {
-        return file[attr] === type;
-      });
-    };
+  $scope.set_file_list = function(type, attr) {
+    FileList.files = SelectedFiles.selected.filter(function(file) {
+      return file[attr] === type;
+    });
+  };
 
-    $scope.add_tags_to_file_list = function(tag) {
-      FileList.files = SelectedFiles.selected.filter(function(file) {
-        return file.tags.indexOf(tag) > -1;
-      });
-    };
-  }]);
-})();
+  $scope.add_tags_to_file_list = function(tag) {
+    FileList.files = SelectedFiles.selected.filter(function(file) {
+      return file.tags.indexOf(tag) > -1;
+    });
+  };
+}]);

--- a/app/search/search.controller.js
+++ b/app/search/search.controller.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import angular from 'angular';
 
 (function() {

--- a/app/search/search.controller.js
+++ b/app/search/search.controller.js
@@ -1,24 +1,22 @@
 import angular from 'angular';
 
-(function() {
-  angular.module('searchController', ['alertService', 'transferService']).
+angular.module('searchController', ['alertService', 'transferService']).
 
-  controller('SearchController', ['$scope', 'Alert', 'Transfer', function($scope, Alert, Transfer) {
-    var on_request = function(data) {
-      $scope.$apply(function() {
-        Transfer.resolve(data);
+controller('SearchController', ['$scope', 'Alert', 'Transfer', function($scope, Alert, Transfer) {
+  var on_request = function(data) {
+    $scope.$apply(function() {
+      Transfer.resolve(data);
+    });
+  };
+
+  var on_error = function() {
+    $scope.$apply(function() {
+      Alert.alerts.push({
+        type: 'danger',
+        message: 'Unable to retrieve transfer data from Archivematica.',
       });
-    };
+    });
+  };
 
-    var on_error = function() {
-      $scope.$apply(function() {
-        Alert.alerts.push({
-          type: 'danger',
-          message: 'Unable to retrieve transfer data from Archivematica.',
-        });
-      });
-    };
-
-    renderBacklogSearchForm('/ingest/appraisal_list/', on_request, on_error);
-  }]);
-})();
+  renderBacklogSearchForm('/ingest/appraisal_list/', on_request, on_error);
+}]);

--- a/app/search/search.controller.js
+++ b/app/search/search.controller.js
@@ -3,14 +3,14 @@ import angular from 'angular';
 angular.module('searchController', ['alertService', 'transferService']).
 
 controller('SearchController', ['$scope', 'Alert', 'Transfer', function($scope, Alert, Transfer) {
-  var on_request = function(data) {
-    $scope.$apply(function() {
+  var on_request = data => {
+    $scope.$apply(() => {
       Transfer.resolve(data);
     });
   };
 
-  var on_error = function() {
-    $scope.$apply(function() {
+  var on_error = () => {
+    $scope.$apply(() => {
       Alert.alerts.push({
         type: 'danger',
         message: 'Unable to retrieve transfer data from Archivematica.',

--- a/app/search/search.controller.js
+++ b/app/search/search.controller.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import angular from 'angular';
+
 (function() {
   angular.module('searchController', ['alertService', 'transferService']).
 

--- a/app/services/alert.service.js
+++ b/app/services/alert.service.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import angular from 'angular';
 
 (function() {

--- a/app/services/alert.service.js
+++ b/app/services/alert.service.js
@@ -1,11 +1,9 @@
 import angular from 'angular';
 
-(function() {
-  angular.module('alertService', []).
+angular.module('alertService', []).
 
-  service('Alert', function() {
-    return {
-      alerts: [],
-    };
-  });
-})();
+service('Alert', function() {
+  return {
+    alerts: [],
+  };
+});

--- a/app/services/archivesspace.service.js
+++ b/app/services/archivesspace.service.js
@@ -6,18 +6,18 @@ import 'restangular';
 angular.module('archivesSpaceService', ['restangular']).
 
 factory('ArchivesSpace', ['Restangular', function(Restangular) {
-    var id_to_urlsafe = function(id) {
+    var id_to_urlsafe = id => {
       return id.replace(/\//g, '-');
     };
 
     // TODO don't clone these from SIPArrange
-    var decode_entry_response = function(response) {
+    var decode_entry_response = response => {
       var new_response = _.extend({}, response);
 
-      angular.forEach(['entries', 'directories'], function(key) {
+      angular.forEach(['entries', 'directories'], key => {
         new_response[key] = response[key].map(Base64.decode);
       });
-      angular.forEach(response.properties, function(value, key) {
+      angular.forEach(response.properties, (value, key) => {
         new_response.properties[Base64.decode(key)] = value;
       });
 
@@ -25,8 +25,8 @@ factory('ArchivesSpace', ['Restangular', function(Restangular) {
     };
 
     // TODO don't dupe this from SipArrange
-    var format_results = function(data) {
-      return data.entries.map(function(element) {
+    var format_results = data => {
+      return data.entries.map(element => {
         var child = {
           title: element,
           path: parent ? parent.path + '/' + element : element,

--- a/app/services/archivesspace.service.js
+++ b/app/services/archivesspace.service.js
@@ -12,7 +12,7 @@ factory('ArchivesSpace', ['Restangular', function(Restangular) {
 
     // TODO don't clone these from SIPArrange
     var decode_entry_response = response => {
-      var new_response = _.extend({}, response);
+      var new_response = Object.assign({}, response);
 
       angular.forEach(['entries', 'directories'], key => {
         new_response[key] = response[key].map(Base64.decode);

--- a/app/services/archivesspace.service.js
+++ b/app/services/archivesspace.service.js
@@ -3,122 +3,120 @@ import $ from 'jquery';
 import _ from 'lodash';
 import 'restangular';
 
-(function() {
-  angular.module('archivesSpaceService', ['restangular']).
+angular.module('archivesSpaceService', ['restangular']).
 
-  factory('ArchivesSpace', ['Restangular', function(Restangular) {
-      var id_to_urlsafe = function(id) {
-        return id.replace(/\//g, '-');
-      };
+factory('ArchivesSpace', ['Restangular', function(Restangular) {
+    var id_to_urlsafe = function(id) {
+      return id.replace(/\//g, '-');
+    };
 
-      // TODO don't clone these from SIPArrange
-      var decode_entry_response = function(response) {
-        var new_response = _.extend({}, response);
+    // TODO don't clone these from SIPArrange
+    var decode_entry_response = function(response) {
+      var new_response = _.extend({}, response);
 
-        angular.forEach(['entries', 'directories'], function(key) {
-          new_response[key] = response[key].map(Base64.decode);
-        });
-        angular.forEach(response.properties, function(value, key) {
-          new_response.properties[Base64.decode(key)] = value;
-        });
+      angular.forEach(['entries', 'directories'], function(key) {
+        new_response[key] = response[key].map(Base64.decode);
+      });
+      angular.forEach(response.properties, function(value, key) {
+        new_response.properties[Base64.decode(key)] = value;
+      });
 
-        return new_response;
-      };
+      return new_response;
+    };
 
-      // TODO don't dupe this from SipArrange
-      var format_results = function(data) {
-        return data.entries.map(function(element) {
-          var child = {
-            title: element,
-            path: parent ? parent.path + '/' + element : element,
-            parent: parent,
-            display: true,
-            properties: data.properties[element],
-            type: 'arrange_entry',
-          };
+    // TODO don't dupe this from SipArrange
+    var format_results = function(data) {
+      return data.entries.map(function(element) {
+        var child = {
+          title: element,
+          path: parent ? parent.path + '/' + element : element,
+          parent: parent,
+          display: true,
+          properties: data.properties[element],
+          type: 'arrange_entry',
+        };
 
-          if (data.directories.indexOf(element) > -1) {
-            // directory
-            child.has_children = true;
-            child.children = [];
-            child.children_fetched = false;
-          } else {
-            // file
-            child.has_children = false;
-          }
+        if (data.directories.indexOf(element) > -1) {
+          // directory
+          child.has_children = true;
+          child.children = [];
+          child.children_fetched = false;
+        } else {
+          // file
+          child.has_children = false;
+        }
 
-          return child;
-        });
-      };
+        return child;
+      });
+    };
 
-      var ArchivesSpace = Restangular.all('access').all('archivesspace');
-      return {
-        all: function() {
-          return ArchivesSpace.getList();
-        },
-        get: function(id) {
-          var url_fragment = id_to_urlsafe(id);
-          return ArchivesSpace.one(url_fragment).get();
-        },
-        get_by_accession: function(accession) {
-          return ArchivesSpace.one('accession').one(accession).getList();
-        },
-        get_children: function(id) {
-          var url_fragment = id_to_urlsafe(id);
-          return ArchivesSpace.one(url_fragment).one('children').getList();
-        },
-        get_levels_of_description: function() {
-          return ArchivesSpace.one('levels').getList();
-        },
-        edit: function(id, record) {
-          var url_fragment = id_to_urlsafe(id);
-          return ArchivesSpace.one(url_fragment).customPUT(record);
-        },
-        add_child: function(id, record) {
-          var url_fragment = id_to_urlsafe(id);
-          return ArchivesSpace.one(url_fragment).one('children').customPOST(record);
-        },
-        create_directory: function(id) {
-          var url_fragment = id_to_urlsafe(id);
-          return ArchivesSpace.one(url_fragment).one('create_directory_within_arrange').customPOST();
-        },
-        digital_object_components: function(id) {
-          var url_fragment = id_to_urlsafe(id);
-          return ArchivesSpace.one(url_fragment).one('digital_object_components').get();
-        },
-        create_digital_object_component: function(id, record) {
-          var url_fragment = id_to_urlsafe(id);
-          return ArchivesSpace.one(url_fragment).one('digital_object_components').customPOST(record);
-        },
-        edit_digital_object_component: function(id, record) {
-          var url_fragment = id_to_urlsafe(id);
-          return ArchivesSpace.one(url_fragment).one('digital_object_components').customPUT(record);
-        },
-        list_digital_object_component_contents: function(id, component_id) {
-          var id_fragment = id_to_urlsafe(id);
-          return ArchivesSpace.one(id_fragment).one('digital_object_components').one(String(component_id)).one('files').get().then(decode_entry_response).then(format_results);
-        },
-        copy_to_arrange: function(id, filepath) {
-          var url_fragment = id_to_urlsafe(id);
-          return ArchivesSpace.one(url_fragment).customPOST(
-            $.param({filepath: Base64.encode(filepath)}),
-            'copy_to_arrange',
-            {},
-            {'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'}
-          );
-        },
-        list_arrange_contents: function(id, parent) {
-          var url_fragment = id_to_urlsafe(id);
-          return ArchivesSpace.one(url_fragment).one('contents').one('arrange').get(url_fragment).then(decode_entry_response).then(format_results);
-        },
-        remove: function(id) {
-          var url_fragment = id_to_urlsafe(id);
-          return ArchivesSpace.one(url_fragment).remove();
-        },
-        start_sip: function(id) {
-          var url_fragment = id_to_urlsafe(id);
-          return ArchivesSpace.one(url_fragment).one('copy_from_arrange').post();
-        },
-      };
-  }]);
-})();
+    var ArchivesSpace = Restangular.all('access').all('archivesspace');
+    return {
+      all: function() {
+        return ArchivesSpace.getList();
+      },
+      get: function(id) {
+        var url_fragment = id_to_urlsafe(id);
+        return ArchivesSpace.one(url_fragment).get();
+      },
+      get_by_accession: function(accession) {
+        return ArchivesSpace.one('accession').one(accession).getList();
+      },
+      get_children: function(id) {
+        var url_fragment = id_to_urlsafe(id);
+        return ArchivesSpace.one(url_fragment).one('children').getList();
+      },
+      get_levels_of_description: function() {
+        return ArchivesSpace.one('levels').getList();
+      },
+      edit: function(id, record) {
+        var url_fragment = id_to_urlsafe(id);
+        return ArchivesSpace.one(url_fragment).customPUT(record);
+      },
+      add_child: function(id, record) {
+        var url_fragment = id_to_urlsafe(id);
+        return ArchivesSpace.one(url_fragment).one('children').customPOST(record);
+      },
+      create_directory: function(id) {
+        var url_fragment = id_to_urlsafe(id);
+        return ArchivesSpace.one(url_fragment).one('create_directory_within_arrange').customPOST();
+      },
+      digital_object_components: function(id) {
+        var url_fragment = id_to_urlsafe(id);
+        return ArchivesSpace.one(url_fragment).one('digital_object_components').get();
+      },
+      create_digital_object_component: function(id, record) {
+        var url_fragment = id_to_urlsafe(id);
+        return ArchivesSpace.one(url_fragment).one('digital_object_components').customPOST(record);
+      },
+      edit_digital_object_component: function(id, record) {
+        var url_fragment = id_to_urlsafe(id);
+        return ArchivesSpace.one(url_fragment).one('digital_object_components').customPUT(record);
+      },
+      list_digital_object_component_contents: function(id, component_id) {
+        var id_fragment = id_to_urlsafe(id);
+        return ArchivesSpace.one(id_fragment).one('digital_object_components').one(String(component_id)).one('files').get().then(decode_entry_response).then(format_results);
+      },
+      copy_to_arrange: function(id, filepath) {
+        var url_fragment = id_to_urlsafe(id);
+        return ArchivesSpace.one(url_fragment).customPOST(
+          $.param({filepath: Base64.encode(filepath)}),
+          'copy_to_arrange',
+          {},
+          {'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'}
+        );
+      },
+      list_arrange_contents: function(id, parent) {
+        var url_fragment = id_to_urlsafe(id);
+        return ArchivesSpace.one(url_fragment).one('contents').one('arrange').get(url_fragment).then(decode_entry_response).then(format_results);
+      },
+      remove: function(id) {
+        var url_fragment = id_to_urlsafe(id);
+        return ArchivesSpace.one(url_fragment).remove();
+      },
+      start_sip: function(id) {
+        var url_fragment = id_to_urlsafe(id);
+        return ArchivesSpace.one(url_fragment).one('copy_from_arrange').post();
+      },
+    };
+}]);

--- a/app/services/archivesspace.service.js
+++ b/app/services/archivesspace.service.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import angular from 'angular';
 import $ from 'jquery';
 import _ from 'lodash';

--- a/app/services/facet.service.js
+++ b/app/services/facet.service.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import angular from 'angular';
 
 (function() {

--- a/app/services/facet.service.js
+++ b/app/services/facet.service.js
@@ -1,181 +1,179 @@
 import angular from 'angular';
 
-(function() {
-  angular.module('facetService', []).
+angular.module('facetService', []).
 
-  factory('Facet', function() {
-    var add = function(name, value, data, id) {
-      data = data || {};
+factory('Facet', function() {
+  var add = function(name, value, data, id) {
+    data = data || {};
 
-      if (undefined === this.facets[name]) {
-        this.facets[name] = [];
-      }
-      // Don't add the same filter more than once
-      if (this.facets[name].indexOf(value) !== -1) {
-        return;
-      }
-      data.id = id || generate_id();
-      data.value = value;
-      data.facet = name;
-      this.facets[name].push(data);
-      this.facet_list.push(data);
+    if (undefined === this.facets[name]) {
+      this.facets[name] = [];
+    }
+    // Don't add the same filter more than once
+    if (this.facets[name].indexOf(value) !== -1) {
+      return;
+    }
+    data.id = id || generate_id();
+    data.value = value;
+    data.facet = name;
+    this.facets[name].push(data);
+    this.facet_list.push(data);
 
-      return data.id;
-    };
+    return data.id;
+  };
 
-    var get = function(name, value) {
-      // If the facet doesn't exist, just return nothing
-      if (undefined === this.facets[name]) {
-        return;
-      }
-      // If no value is requested, return all facets for this field
-      if (undefined === value) {
-        return this.facets[name].map(function(element) {
-          return element.value;
-        });
-      }
-      // Return undefined if the requested facet isn't present
-      var facets = this.facets[name].filter(function(element) {
-        return element.value === value;
+  var get = function(name, value) {
+    // If the facet doesn't exist, just return nothing
+    if (undefined === this.facets[name]) {
+      return;
+    }
+    // If no value is requested, return all facets for this field
+    if (undefined === value) {
+      return this.facets[name].map(function(element) {
+        return element.value;
       });
-      if (facets.length === 0) {
-        return;
-      } else {
-        return facets[0].value;
-      }
-    };
-
-    var get_by_id = function(name, id) {
-      var facets = this.facets[name].filter(function(element) {
-        return element.id === id;
-      });
+    }
+    // Return undefined if the requested facet isn't present
+    var facets = this.facets[name].filter(function(element) {
+      return element.value === value;
+    });
+    if (facets.length === 0) {
+      return;
+    } else {
       return facets[0].value;
-    };
+    }
+  };
 
-    var remove = function(name, value) {
-      // If no value is provided, delete all values
-      if (undefined === value) {
-        delete this.facets[name];
-        this.facet_list = this.facet_list.filter(function(element) {
-          return element.facet !== name;
-        });
-      } else if (undefined !== this.facets[name]) {
-        var filter_fn = function(element) {
-          return element.facet !== name || element.value !== value;
-        };
-        // TODO: filtering over two arrays is unnecessarily expensive;
-        //       see about ways to optimize this later
-        this.facets[name] = this.facets[name].filter(filter_fn);
-        if (this.facets[name].length === 0) {
-          delete this.facets[name];
-        }
-        this.facet_list = this.facet_list.filter(filter_fn);
-      }
-    };
+  var get_by_id = function(name, id) {
+    var facets = this.facets[name].filter(function(element) {
+      return element.id === id;
+    });
+    return facets[0].value;
+  };
 
-    var remove_by_id = function(name, id) {
+  var remove = function(name, value) {
+    // If no value is provided, delete all values
+    if (undefined === value) {
+      delete this.facets[name];
+      this.facet_list = this.facet_list.filter(function(element) {
+        return element.facet !== name;
+      });
+    } else if (undefined !== this.facets[name]) {
       var filter_fn = function(element) {
-        return element.id !== id;
+        return element.facet !== name || element.value !== value;
       };
+      // TODO: filtering over two arrays is unnecessarily expensive;
+      //       see about ways to optimize this later
       this.facets[name] = this.facets[name].filter(filter_fn);
       if (this.facets[name].length === 0) {
         delete this.facets[name];
       }
       this.facet_list = this.facet_list.filter(filter_fn);
-    };
+    }
+  };
 
-    var clear = function() {
-      this.facets = {};
-      this.facet_list = [];
+  var remove_by_id = function(name, id) {
+    var filter_fn = function(element) {
+      return element.id !== id;
     };
+    this.facets[name] = this.facets[name].filter(filter_fn);
+    if (this.facets[name].length === 0) {
+      delete this.facets[name];
+    }
+    this.facet_list = this.facet_list.filter(filter_fn);
+  };
 
-    var filter = function(values) {
-      var self = this; // needs to be defined outside the filter function
-      return values.filter(function(element, index, array) {
-        return self.passes_filters(element);
+  var clear = function() {
+    this.facets = {};
+    this.facet_list = [];
+  };
+
+  var filter = function(values) {
+    var self = this; // needs to be defined outside the filter function
+    return values.filter(function(element, index, array) {
+      return self.passes_filters(element);
+    });
+  };
+
+  var passes_filters = function(object) {
+    var keys = Object.keys(this.facets);
+    var key, value;
+    // If no filters, everything passes
+    if (keys.length === 0) {
+      return true;
+    }
+    for (var i = 0; i < keys.length; i++) {
+      key = keys[i];
+      value = object[key];
+      if (filter_value.apply(this, [key, value]) === true) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  // private
+
+  var filter_value = function(key, value) {
+    if (undefined === this.facets[key]) {
+      // no facet for this key
+      return true;
+    }
+    // if this is a collection, test to see if any of the matches are false
+    if (value.map !== undefined) {
+      // if the collection is empty it cannot possibly match anything
+      if (value.length === 0) {
+        return false;
+      }
+
+      var self = this;
+      var results = value.map(function(element) {
+        return filter_value.apply(self, [key, element]);
       });
-    };
+      // if there are no false elements, return true
+      return results.indexOf(false) === -1;
+    }
 
-    var passes_filters = function(object) {
-      var keys = Object.keys(this.facets);
-      var key, value;
-      // If no filters, everything passes
-      if (keys.length === 0) {
+    for (var i in this.facets[key]) {
+      var result;
+      var filter = this.facets[key][i].value;
+      // filter is a function
+      if (filter.call) {
+        result = filter(value);
+      } else if (typeof filter === 'string') {
+        result = value === filter;
+      } else {
+        result = !!value.match(filter);
+      }
+      // return immediately if any filter returns true,
+      // otherwise keep going
+      if (result === true) {
         return true;
       }
-      for (var i = 0; i < keys.length; i++) {
-        key = keys[i];
-        value = object[key];
-        if (filter_value.apply(this, [key, value]) === true) {
-          return true;
-        }
-      }
-      return false;
-    };
+    }
 
-    // private
+    return false;
+  };
 
-    var filter_value = function(key, value) {
-      if (undefined === this.facets[key]) {
-        // no facet for this key
-        return true;
-      }
-      // if this is a collection, test to see if any of the matches are false
-      if (value.map !== undefined) {
-        // if the collection is empty it cannot possibly match anything
-        if (value.length === 0) {
-          return false;
-        }
+  var generate_id = function() {
+    var s = '';
+    for (var i = 0; i < 16; i++) {
+      s += String.fromCharCode(Math.random() * 255);
+    }
 
-        var self = this;
-        var results = value.map(function(element) {
-          return filter_value.apply(self, [key, element]);
-        });
-        // if there are no false elements, return true
-        return results.indexOf(false) === -1;
-      }
+    return s;
+  };
 
-      for (var i in this.facets[key]) {
-        var result;
-        var filter = this.facets[key][i].value;
-        // filter is a function
-        if (filter.call) {
-          result = filter(value);
-        } else if (typeof filter === 'string') {
-          result = value === filter;
-        } else {
-          result = !!value.match(filter);
-        }
-        // return immediately if any filter returns true,
-        // otherwise keep going
-        if (result === true) {
-          return true;
-        }
-      }
-
-      return false;
-    };
-
-    var generate_id = function() {
-      var s = '';
-      for (var i = 0; i < 16; i++) {
-        s += String.fromCharCode(Math.random() * 255);
-      }
-
-      return s;
-    };
-
-    return {
-      facets: {},
-      facet_list: [],
-      add: add,
-      get: get,
-      get_by_id: get_by_id,
-      remove: remove,
-      remove_by_id: remove_by_id,
-      clear: clear,
-      filter: filter,
-      passes_filters: passes_filters,
-    };
-  });
-})();
+  return {
+    facets: {},
+    facet_list: [],
+    add: add,
+    get: get,
+    get_by_id: get_by_id,
+    remove: remove,
+    remove_by_id: remove_by_id,
+    clear: clear,
+    filter: filter,
+    passes_filters: passes_filters,
+  };
+});

--- a/app/services/file.service.js
+++ b/app/services/file.service.js
@@ -1,20 +1,18 @@
 import angular from 'angular';
 import 'restangular';
 
-(function() {
-  angular.module('fileService', ['restangular']).
+angular.module('fileService', ['restangular']).
 
-  factory('File', ['Restangular', function(Restangular) {
-    var File = Restangular.one('file');
-    return {
-      get: function(uuid) {
-        return File.one(uuid).get();
-      },
-      bulk_extractor_info: function(uuid, reports) {
-        reports = reports || [];
-        reports = reports.join(',');
-        return File.one(uuid).one('bulk_extractor').get({reports: reports});
-      },
-    };
-  }]);
-})();
+factory('File', ['Restangular', function(Restangular) {
+  var File = Restangular.one('file');
+  return {
+    get: function(uuid) {
+      return File.one(uuid).get();
+    },
+    bulk_extractor_info: function(uuid, reports) {
+      reports = reports || [];
+      reports = reports.join(',');
+      return File.one(uuid).one('bulk_extractor').get({reports: reports});
+    },
+  };
+}]);

--- a/app/services/file.service.js
+++ b/app/services/file.service.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import angular from 'angular';
 import 'restangular';
 

--- a/app/services/file_list.service.js
+++ b/app/services/file_list.service.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import angular from 'angular';
 
 (function() {

--- a/app/services/file_list.service.js
+++ b/app/services/file_list.service.js
@@ -16,9 +16,7 @@ service('FileList', function() {
       }
     },
     remove: function(id) {
-      this.files = this.files.filter(function(file) {
-        return file.id !== id;
-      });
+      this.files = this.files.filter(file => file.id !== id);
     },
     clear: function() {
       this.files = [];

--- a/app/services/file_list.service.js
+++ b/app/services/file_list.service.js
@@ -1,29 +1,27 @@
 import angular from 'angular';
 
-(function() {
-  angular.module('fileListService', []).
+angular.module('fileListService', []).
 
-  service('FileList', function() {
-    return {
-      files: [],
-      // How slow will this get? Do we need to look at storing a list
-      // optimized for quick lookup?
-      get: function(id) {
-        for (var i = 0; i < this.files.length; i++) {
-          var file = this.files[i];
-          if (file.id === id) {
-            return file;
-          }
+service('FileList', function() {
+  return {
+    files: [],
+    // How slow will this get? Do we need to look at storing a list
+    // optimized for quick lookup?
+    get: function(id) {
+      for (var i = 0; i < this.files.length; i++) {
+        var file = this.files[i];
+        if (file.id === id) {
+          return file;
         }
-      },
-      remove: function(id) {
-        this.files = this.files.filter(function(file) {
-          return file.id !== id;
-        });
-      },
-      clear: function() {
-        this.files = [];
-      },
-    };
-  });
-})();
+      }
+    },
+    remove: function(id) {
+      this.files = this.files.filter(function(file) {
+        return file.id !== id;
+      });
+    },
+    clear: function() {
+      this.files = [];
+    },
+  };
+});

--- a/app/services/selected.service.js
+++ b/app/services/selected.service.js
@@ -1,39 +1,37 @@
 import angular from 'angular';
 
-(function() {
-  angular.module('selectedFilesService', []).
+angular.module('selectedFilesService', []).
 
-  service('SelectedFiles', [function() {
-    return {
-      add: function(file) {
-        // Remove any occurrences of this file if they already exist
-        this.remove(file.id);
-        this.selected.push(file);
-      },
-      remove: function(uuid) {
-        this.selected = this.selected.filter(function(el) {
-          return el.id !== uuid;
-        });
-      },
-      list_file_ids: function() {
-        var ids = [];
-        angular.forEach(this.selected, function(file) {
-          if (file.type === 'file') {
-            ids.push(file.id);
-          }
-        });
-        return ids;
-      },
-      // TODO: look at optimizing file lookup-by-id if this gets used a lot
-      get: function(id) {
-        for (var i = 0; i < this.selected.length; i++) {
-          var item = this.selected[i];
-          if (item.id === id) {
-            return item;
-          }
+service('SelectedFiles', [function() {
+  return {
+    add: function(file) {
+      // Remove any occurrences of this file if they already exist
+      this.remove(file.id);
+      this.selected.push(file);
+    },
+    remove: function(uuid) {
+      this.selected = this.selected.filter(function(el) {
+        return el.id !== uuid;
+      });
+    },
+    list_file_ids: function() {
+      var ids = [];
+      angular.forEach(this.selected, function(file) {
+        if (file.type === 'file') {
+          ids.push(file.id);
         }
-      },
-      selected: [],
-    };
-  }]);
-})();
+      });
+      return ids;
+    },
+    // TODO: look at optimizing file lookup-by-id if this gets used a lot
+    get: function(id) {
+      for (var i = 0; i < this.selected.length; i++) {
+        var item = this.selected[i];
+        if (item.id === id) {
+          return item;
+        }
+      }
+    },
+    selected: [],
+  };
+}]);

--- a/app/services/selected.service.js
+++ b/app/services/selected.service.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import angular from 'angular';
 
 (function() {

--- a/app/services/selected.service.js
+++ b/app/services/selected.service.js
@@ -10,13 +10,11 @@ service('SelectedFiles', [function() {
       this.selected.push(file);
     },
     remove: function(uuid) {
-      this.selected = this.selected.filter(function(el) {
-        return el.id !== uuid;
-      });
+      this.selected = this.selected.filter(el => el.id !== uuid);
     },
     list_file_ids: function() {
       var ids = [];
-      angular.forEach(this.selected, function(file) {
+      angular.forEach(this.selected, file => {
         if (file.type === 'file') {
           ids.push(file.id);
         }

--- a/app/services/sip_arrange.service.js
+++ b/app/services/sip_arrange.service.js
@@ -3,135 +3,133 @@ import $ from 'jquery';
 import _ from 'lodash';
 import 'restangular';
 
-(function() {
-  angular.module('sipArrangeService', ['restangular']).
+angular.module('sipArrangeService', ['restangular']).
 
-  factory('SipArrange', ['Restangular', function(Restangular) {
-    var SipArrange = Restangular.one('filesystem');
+factory('SipArrange', ['Restangular', function(Restangular) {
+  var SipArrange = Restangular.one('filesystem');
 
-    // public
+  // public
 
-    var create_directory = function(path, title, parent) {
-      // Return a formatted directory object
-      var on_success = function(success) {
+  var create_directory = function(path, title, parent) {
+    // Return a formatted directory object
+    var on_success = function(success) {
+      return {
+        title: title,
+        has_children: true,
+        children: [],
+        path: path.replace(/^\/arrange\//, ''),
+        parent: parent,
+        display: true,
+        children_fetched: false,
+        type: 'arrange_entry',
+        directory: true,
+      };
+    };
+
+    return post_form(SipArrange, 'create_directory_within_arrange', {path: Base64.encode(path)}).then(on_success);
+  };
+
+  var copy_to_arrange = function(source, destination) {
+    var params = {
+      'filepath': Base64.encode(source),
+      'destination': Base64.encode(destination),
+    };
+    return post_form(SipArrange, 'copy_to_arrange', params);
+  };
+
+  var list_contents = function(path, parent) {
+    var format_root = function(data) {
+      return data.directories.map(function(directory) {
         return {
-          title: title,
+          title: directory,
           has_children: true,
           children: [],
-          path: path.replace(/^\/arrange\//, ''),
-          parent: parent,
+          // "path" tracks the full path to the directory, including
+          // all of its parents.
+          // Since these are top-level directories, their paths are the
+          // same as their names.
+          path: directory,
           display: true,
+          properties: data.properties[directory],
           children_fetched: false,
           type: 'arrange_entry',
           directory: true,
         };
-      };
-
-      return post_form(SipArrange, 'create_directory_within_arrange', {path: Base64.encode(path)}).then(on_success);
-    };
-
-    var copy_to_arrange = function(source, destination) {
-      var params = {
-        'filepath': Base64.encode(source),
-        'destination': Base64.encode(destination),
-      };
-      return post_form(SipArrange, 'copy_to_arrange', params);
-    };
-
-    var list_contents = function(path, parent) {
-      var format_root = function(data) {
-        return data.directories.map(function(directory) {
-          return {
-            title: directory,
-            has_children: true,
-            children: [],
-            // "path" tracks the full path to the directory, including
-            // all of its parents.
-            // Since these are top-level directories, their paths are the
-            // same as their names.
-            path: directory,
-            display: true,
-            properties: data.properties[directory],
-            children_fetched: false,
-            type: 'arrange_entry',
-            directory: true,
-          };
-        });
-      };
-
-      var format_entries = function(data) {
-        return data.entries.map(function(element) {
-          var child = {
-            title: element,
-            path: parent ? parent.path + '/' + element : element,
-            parent: parent,
-            display: true,
-            properties: data.properties[element],
-            type: 'arrange_entry',
-          };
-
-          if (data.directories.indexOf(element) > -1) {
-            // directory
-            child.has_children = true;
-            child.children = [];
-            child.children_fetched = false;
-            child.directory = true;
-          } else {
-            // file
-            child.has_children = false;
-            child.directory = false;
-          }
-
-          return child;
-        });
-      };
-
-      path = path || '';
-      var on_success = path === '' ? format_root : format_entries;
-      return SipArrange.one('contents').one('arrange').get({path: Base64.encode(path)}).then(decode_entry_response).then(on_success);
-    };
-
-    var remove = function(target) {
-      return post_form(SipArrange.one('delete'), 'arrange', {filepath: Base64.encode(target)});
-    };
-
-    var start_sip = function(target) {
-      return post_form(SipArrange, 'copy_from_arrange', {filepath: Base64.encode(target)});
-    };
-
-    // private
-
-    // Helper function to POST content with a form-encoded body
-    // instead of a JSON-encoded body.
-    var post_form = function(model, path, body) {
-      return model.customPOST(
-        // form-encode body
-        $.param(body),
-        path,
-        {}, // URL parameters - always empty
-        {'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'}
-      )
-    };
-
-    var decode_entry_response = function(response) {
-      var new_response = _.extend({}, response);
-
-      angular.forEach(['entries', 'directories'], function(key) {
-        new_response[key] = response[key].map(Base64.decode);
       });
-      angular.forEach(response.properties, function(value, key) {
-        new_response.properties[Base64.decode(key)] = value;
+    };
+
+    var format_entries = function(data) {
+      return data.entries.map(function(element) {
+        var child = {
+          title: element,
+          path: parent ? parent.path + '/' + element : element,
+          parent: parent,
+          display: true,
+          properties: data.properties[element],
+          type: 'arrange_entry',
+        };
+
+        if (data.directories.indexOf(element) > -1) {
+          // directory
+          child.has_children = true;
+          child.children = [];
+          child.children_fetched = false;
+          child.directory = true;
+        } else {
+          // file
+          child.has_children = false;
+          child.directory = false;
+        }
+
+        return child;
       });
-
-      return new_response;
     };
 
-    return {
-      create_directory: create_directory,
-      copy_to_arrange: copy_to_arrange,
-      list_contents: list_contents,
-      remove: remove,
-      start_sip: start_sip,
-    };
-  }]);
-})();
+    path = path || '';
+    var on_success = path === '' ? format_root : format_entries;
+    return SipArrange.one('contents').one('arrange').get({path: Base64.encode(path)}).then(decode_entry_response).then(on_success);
+  };
+
+  var remove = function(target) {
+    return post_form(SipArrange.one('delete'), 'arrange', {filepath: Base64.encode(target)});
+  };
+
+  var start_sip = function(target) {
+    return post_form(SipArrange, 'copy_from_arrange', {filepath: Base64.encode(target)});
+  };
+
+  // private
+
+  // Helper function to POST content with a form-encoded body
+  // instead of a JSON-encoded body.
+  var post_form = function(model, path, body) {
+    return model.customPOST(
+      // form-encode body
+      $.param(body),
+      path,
+      {}, // URL parameters - always empty
+      {'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'}
+    )
+  };
+
+  var decode_entry_response = function(response) {
+    var new_response = _.extend({}, response);
+
+    angular.forEach(['entries', 'directories'], function(key) {
+      new_response[key] = response[key].map(Base64.decode);
+    });
+    angular.forEach(response.properties, function(value, key) {
+      new_response.properties[Base64.decode(key)] = value;
+    });
+
+    return new_response;
+  };
+
+  return {
+    create_directory: create_directory,
+    copy_to_arrange: copy_to_arrange,
+    list_contents: list_contents,
+    remove: remove,
+    start_sip: start_sip,
+  };
+}]);

--- a/app/services/sip_arrange.service.js
+++ b/app/services/sip_arrange.service.js
@@ -1,6 +1,6 @@
 import angular from 'angular';
 import $ from 'jquery';
-import _ from 'lodash';
+import 'lodash';
 import 'restangular';
 
 angular.module('sipArrangeService', ['restangular']).

--- a/app/services/sip_arrange.service.js
+++ b/app/services/sip_arrange.service.js
@@ -12,7 +12,7 @@ factory('SipArrange', ['Restangular', function(Restangular) {
 
   var create_directory = function(path, title, parent) {
     // Return a formatted directory object
-    var on_success = function(success) {
+    var on_success = success => {
       return {
         title: title,
         has_children: true,
@@ -38,8 +38,8 @@ factory('SipArrange', ['Restangular', function(Restangular) {
   };
 
   var list_contents = function(path, parent) {
-    var format_root = function(data) {
-      return data.directories.map(function(directory) {
+    var format_root = data => {
+      return data.directories.map(directory => {
         return {
           title: directory,
           has_children: true,
@@ -58,8 +58,8 @@ factory('SipArrange', ['Restangular', function(Restangular) {
       });
     };
 
-    var format_entries = function(data) {
-      return data.entries.map(function(element) {
+    var format_entries = data => {
+      return data.entries.map(element => {
         var child = {
           title: element,
           path: parent ? parent.path + '/' + element : element,

--- a/app/services/sip_arrange.service.js
+++ b/app/services/sip_arrange.service.js
@@ -113,7 +113,7 @@ factory('SipArrange', ['Restangular', function(Restangular) {
   };
 
   var decode_entry_response = function(response) {
-    var new_response = _.extend({}, response);
+    var new_response = Object.assign({}, response);
 
     angular.forEach(['entries', 'directories'], function(key) {
       new_response[key] = response[key].map(Base64.decode);

--- a/app/services/sip_arrange.service.js
+++ b/app/services/sip_arrange.service.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import angular from 'angular';
 import $ from 'jquery';
 import _ from 'lodash';

--- a/app/services/tag.service.js
+++ b/app/services/tag.service.js
@@ -1,35 +1,33 @@
 import angular from 'angular';
 import 'restangular';
 
-(function() {
-  angular.module('tagService', ['restangular']).
+angular.module('tagService', ['restangular']).
 
-  factory('Tag', ['$log', 'Restangular', function($log, Restangular) {
-    var Tag = Restangular.all('file');
+factory('Tag', ['$log', 'Restangular', function($log, Restangular) {
+  var Tag = Restangular.all('file');
 
-    // public
+  // public
 
-    var get = function(id, tags) {
-      return Tag.one(id).one('tags').getList();
-    };
+  var get = function(id, tags) {
+    return Tag.one(id).one('tags').getList();
+  };
 
-    var submit = function(id, tags) {
-      Tag.one(id).one('tags').customPUT(tags).then(null, function(response) {
-        // TODO display error handling
-        $log.error('Submitting tags for file ' + String(id) + ' failed with response: ', response.status);
-      });
-    };
+  var submit = function(id, tags) {
+    Tag.one(id).one('tags').customPUT(tags).then(null, function(response) {
+      // TODO display error handling
+      $log.error('Submitting tags for file ' + String(id) + ' failed with response: ', response.status);
+    });
+  };
 
-    var remove = function(id) {
-      Tag.one(id).one('tags').remove().then(null, function(response) {
-        $log.error('Deleting tags for file ' + String(id) + ' failed with response: ' + response.status);
-      });
-    };
+  var remove = function(id) {
+    Tag.one(id).one('tags').remove().then(null, function(response) {
+      $log.error('Deleting tags for file ' + String(id) + ' failed with response: ' + response.status);
+    });
+  };
 
-    return {
-      get: get,
-      submit: submit,
-      remove: remove,
-    };
-  }]);
-})();
+  return {
+    get: get,
+    submit: submit,
+    remove: remove,
+  };
+}]);

--- a/app/services/tag.service.js
+++ b/app/services/tag.service.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import angular from 'angular';
 import 'restangular';
 

--- a/app/services/tag.service.js
+++ b/app/services/tag.service.js
@@ -13,14 +13,14 @@ factory('Tag', ['$log', 'Restangular', function($log, Restangular) {
   };
 
   var submit = function(id, tags) {
-    Tag.one(id).one('tags').customPUT(tags).then(null, function(response) {
+    Tag.one(id).one('tags').customPUT(tags).then(null, response => {
       // TODO display error handling
       $log.error('Submitting tags for file ' + String(id) + ' failed with response: ', response.status);
     });
   };
 
   var remove = function(id) {
-    Tag.one(id).one('tags').remove().then(null, function(response) {
+    Tag.one(id).one('tags').remove().then(null, response => {
       $log.error('Deleting tags for file ' + String(id) + ' failed with response: ' + response.status);
     });
   };

--- a/app/services/transfer.service.js
+++ b/app/services/transfer.service.js
@@ -15,12 +15,12 @@ factory('Transfer', ['Alert', 'Facet', 'Restangular', 'Tag', function(Alert, Fac
     }
   };
 
-  var create_flat_map = function(records, map) {
+  var create_flat_map = (records, map) => {
     if (map === undefined) {
       map = {};
     }
 
-    angular.forEach(records, function(record) {
+    angular.forEach(records, record => {
       map[record.id] = record;
       create_flat_map(record.children, map);
     });
@@ -28,8 +28,8 @@ factory('Transfer', ['Alert', 'Facet', 'Restangular', 'Tag', function(Alert, Fac
     return map;
   };
 
-  var populate_tag_list = function(records, list) {
-    angular.forEach(records, function(record, id) {
+  var populate_tag_list = (records, list) => {
+    angular.forEach(records, (record, id) => {
       if (!record.tags) {
         return;
       }
@@ -42,18 +42,16 @@ factory('Transfer', ['Alert', 'Facet', 'Restangular', 'Tag', function(Alert, Fac
     });
   };
 
-  var clean_record_titles = function(records) {
-    angular.forEach(records, function(record) {
+  var clean_record_titles = records => {
+    angular.forEach(records, record => {
       record.title = Base64.decode(record.title);
       record.relative_path = Base64.decode(record.relative_path);
     });
   };
 
-  var remove_tag_if_necessary = function(self, tag) {
+  var remove_tag_if_necessary = (self, tag) => {
     if (self.list_tags(tag).length === 0) {
-      self.tags = self.tags.filter(function(element) {
-        return element !== tag;
-      });
+      self.tags = self.tags.filter(element => element !== tag);
     }
   };
 
@@ -78,7 +76,7 @@ factory('Transfer', ['Alert', 'Facet', 'Restangular', 'Tag', function(Alert, Fac
       this.filter();
     },
     filter: function() {
-      angular.forEach(this.id_map, function(file) {
+      angular.forEach(this.id_map, file => {
         if (file.type === 'file') {
           file.display = Facet.passes_filters(file);
         } else {
@@ -106,22 +104,20 @@ factory('Transfer', ['Alert', 'Facet', 'Restangular', 'Tag', function(Alert, Fac
       }
     },
     add_list_of_tags: function(ids, tag, skip_submit) {
-      var self = this;
-      angular.forEach(ids, function(id) {
-        self.add_tag(id, tag, skip_submit);
+      angular.forEach(ids, id => {
+        this.add_tag(id, tag, skip_submit);
       });
     },
     remove_tag: function(id, tag, skip_submit) {
-      var self = this;
       var record = get_record.apply(this, [id]);
 
       if (!tag) {
         var record = get_record.apply(this, [id]);
         var tags_for_id = record.tags;
 
-        remove_all.apply(self, [id]);
-        angular.forEach(tags_for_id, function(tag) {
-          remove_tag_if_necessary(self, tag);
+        remove_all.apply(this, [id]);
+        angular.forEach(tags_for_id, tag => {
+          remove_tag_if_necessary(this, tag);
         });
 
         if (!skip_submit) {
@@ -138,7 +134,7 @@ factory('Transfer', ['Alert', 'Facet', 'Restangular', 'Tag', function(Alert, Fac
       record.tags.pop(tag);
 
       // If this is the last occurrence of this tag, delete it from the tag list
-      remove_tag_if_necessary(self, tag);
+      remove_tag_if_necessary(this, tag);
 
       if (!skip_submit) {
         Tag.submit(id, record.tags);
@@ -150,7 +146,7 @@ factory('Transfer', ['Alert', 'Facet', 'Restangular', 'Tag', function(Alert, Fac
     },
     list_tags: function(tag) {
       var results = [];
-      angular.forEach(this.id_map, function(record, id) {
+      angular.forEach(this.id_map, (record, id) => {
         var tags = record.tags || [];
         if (tags.indexOf(tag) !== -1) {
           results.push(id);

--- a/app/services/transfer.service.js
+++ b/app/services/transfer.service.js
@@ -3,166 +3,164 @@ import '../services/alert.service';
 import '../services/facet.service';
 import '../services/tag.service';
 
-(function() {
-  angular.module('transferService', ['alertService', 'facetService', 'tagService']).
+angular.module('transferService', ['alertService', 'facetService', 'tagService']).
 
-  factory('Transfer', ['Alert', 'Facet', 'Restangular', 'Tag', function(Alert, Facet, Restangular, Tag) {
-    var get_record = function(id) {
-      var record = this.id_map[id];
-      if (!record) {
-        throw 'Unable to find a record of name ' + String(id) + ' in Transfer\'s ID map';
-      } else {
-        return record;
+factory('Transfer', ['Alert', 'Facet', 'Restangular', 'Tag', function(Alert, Facet, Restangular, Tag) {
+  var get_record = function(id) {
+    var record = this.id_map[id];
+    if (!record) {
+      throw 'Unable to find a record of name ' + String(id) + ' in Transfer\'s ID map';
+    } else {
+      return record;
+    }
+  };
+
+  var create_flat_map = function(records, map) {
+    if (map === undefined) {
+      map = {};
+    }
+
+    angular.forEach(records, function(record) {
+      map[record.id] = record;
+      create_flat_map(record.children, map);
+    });
+
+    return map;
+  };
+
+  var populate_tag_list = function(records, list) {
+    angular.forEach(records, function(record, id) {
+      if (!record.tags) {
+        return;
       }
-    };
-
-    var create_flat_map = function(records, map) {
-      if (map === undefined) {
-        map = {};
-      }
-
-      angular.forEach(records, function(record) {
-        map[record.id] = record;
-        create_flat_map(record.children, map);
-      });
-
-      return map;
-    };
-
-    var populate_tag_list = function(records, list) {
-      angular.forEach(records, function(record, id) {
-        if (!record.tags) {
-          return;
+      for (var i = 0; i < record.tags.length; i++) {
+        var tag = record.tags[i];
+        if (list.indexOf(tag) === -1) {
+          list.push(tag);
         }
-        for (var i = 0; i < record.tags.length; i++) {
-          var tag = record.tags[i];
-          if (list.indexOf(tag) === -1) {
-            list.push(tag);
-          }
+      }
+    });
+  };
+
+  var clean_record_titles = function(records) {
+    angular.forEach(records, function(record) {
+      record.title = Base64.decode(record.title);
+      record.relative_path = Base64.decode(record.relative_path);
+    });
+  };
+
+  var remove_tag_if_necessary = function(self, tag) {
+    if (self.list_tags(tag).length === 0) {
+      self.tags = self.tags.filter(function(element) {
+        return element !== tag;
+      });
+    }
+  };
+
+  var remove_all = function(id) {
+    var record = this.id_map[id];
+    if (record) {
+      record.tags = [];
+    }
+  };
+
+  return {
+    data: [],
+    formats: [],
+    id_map: {},
+    tags: [],
+    resolve: function(data) {
+      this.data = data.transfers;
+      this.formats = data.formats;
+      this.id_map = create_flat_map(data.transfers);
+      populate_tag_list(this.id_map, this.tags);
+      clean_record_titles(this.id_map);
+      this.filter();
+    },
+    filter: function() {
+      angular.forEach(this.id_map, function(file) {
+        if (file.type === 'file') {
+          file.display = Facet.passes_filters(file);
+        } else {
+          file.display = true;
         }
       });
-    };
+    },
 
-    var clean_record_titles = function(records) {
-      angular.forEach(records, function(record) {
-        record.title = Base64.decode(record.title);
-        record.relative_path = Base64.decode(record.relative_path);
+    add_tag: function(id, tag, skip_submit) {
+      var record = get_record.apply(this, [id]);
+      record.tags = record.tags || [];
+
+      if (record.tags.indexOf(tag) !== -1) {
+        return;
+      }
+      record.tags.push(tag);
+
+      // Add this tag to the flat list of current tags if not already present
+      if (this.tags.indexOf(tag) === -1) {
+        this.tags.push(tag);
+      }
+
+      if (!skip_submit) {
+        Tag.submit(id, record.tags);
+      }
+    },
+    add_list_of_tags: function(ids, tag, skip_submit) {
+      var self = this;
+      angular.forEach(ids, function(id) {
+        self.add_tag(id, tag, skip_submit);
       });
-    };
+    },
+    remove_tag: function(id, tag, skip_submit) {
+      var self = this;
+      var record = get_record.apply(this, [id]);
 
-    var remove_tag_if_necessary = function(self, tag) {
-      if (self.list_tags(tag).length === 0) {
-        self.tags = self.tags.filter(function(element) {
-          return element !== tag;
-        });
-      }
-    };
-
-    var remove_all = function(id) {
-      var record = this.id_map[id];
-      if (record) {
-        record.tags = [];
-      }
-    };
-
-    return {
-      data: [],
-      formats: [],
-      id_map: {},
-      tags: [],
-      resolve: function(data) {
-        this.data = data.transfers;
-        this.formats = data.formats;
-        this.id_map = create_flat_map(data.transfers);
-        populate_tag_list(this.id_map, this.tags);
-        clean_record_titles(this.id_map);
-        this.filter();
-      },
-      filter: function() {
-        angular.forEach(this.id_map, function(file) {
-          if (file.type === 'file') {
-            file.display = Facet.passes_filters(file);
-          } else {
-            file.display = true;
-          }
-        });
-      },
-
-      add_tag: function(id, tag, skip_submit) {
+      if (!tag) {
         var record = get_record.apply(this, [id]);
-        record.tags = record.tags || [];
+        var tags_for_id = record.tags;
 
-        if (record.tags.indexOf(tag) !== -1) {
-          return;
-        }
-        record.tags.push(tag);
-
-        // Add this tag to the flat list of current tags if not already present
-        if (this.tags.indexOf(tag) === -1) {
-          this.tags.push(tag);
-        }
+        remove_all.apply(self, [id]);
+        angular.forEach(tags_for_id, function(tag) {
+          remove_tag_if_necessary(self, tag);
+        });
 
         if (!skip_submit) {
-          Tag.submit(id, record.tags);
-        }
-      },
-      add_list_of_tags: function(ids, tag, skip_submit) {
-        var self = this;
-        angular.forEach(ids, function(id) {
-          self.add_tag(id, tag, skip_submit);
-        });
-      },
-      remove_tag: function(id, tag, skip_submit) {
-        var self = this;
-        var record = get_record.apply(this, [id]);
-
-        if (!tag) {
-          var record = get_record.apply(this, [id]);
-          var tags_for_id = record.tags;
-
-          remove_all.apply(self, [id]);
-          angular.forEach(tags_for_id, function(tag) {
-            remove_tag_if_necessary(self, tag);
-          });
-
-          if (!skip_submit) {
-            Tag.remove(id);
-          }
-
-          return;
+          Tag.remove(id);
         }
 
-        if (record.tags === undefined) {
-          $log.warn('Tried to remove tag for file with ID ' + String(id) + ' but no tags are specified for that file');
-          return;
+        return;
+      }
+
+      if (record.tags === undefined) {
+        $log.warn('Tried to remove tag for file with ID ' + String(id) + ' but no tags are specified for that file');
+        return;
+      }
+      record.tags.pop(tag);
+
+      // If this is the last occurrence of this tag, delete it from the tag list
+      remove_tag_if_necessary(self, tag);
+
+      if (!skip_submit) {
+        Tag.submit(id, record.tags);
+      }
+    },
+    get_tag: function(id) {
+      var record = get_record.apply(this, [id]);
+      return record.tags || [];
+    },
+    list_tags: function(tag) {
+      var results = [];
+      angular.forEach(this.id_map, function(record, id) {
+        var tags = record.tags || [];
+        if (tags.indexOf(tag) !== -1) {
+          results.push(id);
         }
-        record.tags.pop(tag);
+      });
 
-        // If this is the last occurrence of this tag, delete it from the tag list
-        remove_tag_if_necessary(self, tag);
-
-        if (!skip_submit) {
-          Tag.submit(id, record.tags);
-        }
-      },
-      get_tag: function(id) {
-        var record = get_record.apply(this, [id]);
-        return record.tags || [];
-      },
-      list_tags: function(tag) {
-        var results = [];
-        angular.forEach(this.id_map, function(record, id) {
-          var tags = record.tags || [];
-          if (tags.indexOf(tag) !== -1) {
-            results.push(id);
-          }
-        });
-
-        return results;
-      },
-      clear_tags: function() {
-        this.tags = [];
-      },
-    };
-  }]);
-})();
+      return results;
+    },
+    clear_tags: function() {
+      this.tags = [];
+    },
+  };
+}]);

--- a/app/services/transfer.service.js
+++ b/app/services/transfer.service.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import angular from 'angular';
 import '../services/alert.service';
 import '../services/facet.service';

--- a/app/tree/tree.controller.js
+++ b/app/tree/tree.controller.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import angular from 'angular';
 
 (function() {

--- a/app/tree/tree.controller.js
+++ b/app/tree/tree.controller.js
@@ -30,7 +30,7 @@ controller('TreeController', ['$scope', 'SelectedFiles', 'Transfer', function($s
     Transfer.remove_tag(id, tag);
   };
 
-  var add_file = function(node) {
+  var add_file = node => {
     SelectedFiles.add(node);
     if (node.children) {
       for (var i = 0; i < node.children.length; i++) {
@@ -40,7 +40,7 @@ controller('TreeController', ['$scope', 'SelectedFiles', 'Transfer', function($s
     }
   };
 
-  var remove_file = function(node) {
+  var remove_file = node => {
     SelectedFiles.remove(node.id);
     if (node.children) {
       for (var i = 0; i < node.children.length; i++) {

--- a/app/tree/tree.controller.js
+++ b/app/tree/tree.controller.js
@@ -1,79 +1,77 @@
 import angular from 'angular';
 
-(function() {
-  var treeController = angular.module('treeController', []).
+var treeController = angular.module('treeController', []).
 
-  controller('TreeController', ['$scope', 'SelectedFiles', 'Transfer', function($scope, SelectedFiles, Transfer) {
-    $scope.helper = function() {
-      var uuid = $(this).attr('uuid');
-      var file = Transfer.id_map[uuid];
-      // TODO: style this element
-      return $('<div>' + file.title + '</div>');
-    };
+controller('TreeController', ['$scope', 'SelectedFiles', 'Transfer', function($scope, SelectedFiles, Transfer) {
+  $scope.helper = function() {
+    var uuid = $(this).attr('uuid');
+    var file = Transfer.id_map[uuid];
+    // TODO: style this element
+    return $('<div>' + file.title + '</div>');
+  };
 
-    $scope.options = {
-      dirSelectable: true,
-      multiSelection: true,
-      equality: function(a, b) {
-        if (a === undefined || b === undefined) {
-          return false;
-        }
-        return a.id === b.id;
-      },
-      injectClasses: {
-        li: 'file',
-      },
-    };
-    $scope.filter_expression = {display: true};
-    $scope.filter_comparator = true;
-
-    $scope.remove_tag = function(id, tag) {
-      Transfer.remove_tag(id, tag);
-    };
-
-    var add_file = function(node) {
-      SelectedFiles.add(node);
-      if (node.children) {
-        for (var i = 0; i < node.children.length; i++) {
-          var child = node.children[i];
-          add_file(child);
-        }
+  $scope.options = {
+    dirSelectable: true,
+    multiSelection: true,
+    equality: function(a, b) {
+      if (a === undefined || b === undefined) {
+        return false;
       }
-    };
+      return a.id === b.id;
+    },
+    injectClasses: {
+      li: 'file',
+    },
+  };
+  $scope.filter_expression = {display: true};
+  $scope.filter_comparator = true;
 
-    var remove_file = function(node) {
-      SelectedFiles.remove(node.id);
-      if (node.children) {
-        for (var i = 0; i < node.children.length; i++) {
-          var child = node.children[i];
-          remove_file(child);
-        }
+  $scope.remove_tag = function(id, tag) {
+    Transfer.remove_tag(id, tag);
+  };
+
+  var add_file = function(node) {
+    SelectedFiles.add(node);
+    if (node.children) {
+      for (var i = 0; i < node.children.length; i++) {
+        var child = node.children[i];
+        add_file(child);
       }
-    };
+    }
+  };
 
-    // TODO: * this does select all files, but it doesn't select them in the UI
-    $scope.track_selected = function(node, selected) {
-      if (selected) {
-        add_file(node);
-      } else {
-        remove_file(node);
+  var remove_file = function(node) {
+    SelectedFiles.remove(node.id);
+    if (node.children) {
+      for (var i = 0; i < node.children.length; i++) {
+        var child = node.children[i];
+        remove_file(child);
       }
-    };
-    $scope.transfers = Transfer;
+    }
+  };
 
-    $scope.deselect = function() {
-      SelectedFiles.selected = [];
-    };
+  // TODO: * this does select all files, but it doesn't select them in the UI
+  $scope.track_selected = function(node, selected) {
+    if (selected) {
+      add_file(node);
+    } else {
+      remove_file(node);
+    }
+  };
+  $scope.transfers = Transfer;
 
-    $scope.files = SelectedFiles;
-    $scope.submit = function() {
-      var tag = this.tag;
-      if (!tag) {
-        return;
-      }
+  $scope.deselect = function() {
+    SelectedFiles.selected = [];
+  };
 
-      Transfer.add_list_of_tags(SelectedFiles.list_file_ids(), tag);
-      this.tag = '';
-    };
-  }]);
-})();
+  $scope.files = SelectedFiles;
+  $scope.submit = function() {
+    var tag = this.tag;
+    if (!tag) {
+      return;
+    }
+
+    Transfer.add_list_of_tags(SelectedFiles.list_file_ids(), tag);
+    this.tag = '';
+  };
+}]);

--- a/app/tree/tree.controller.js
+++ b/app/tree/tree.controller.js
@@ -1,6 +1,6 @@
 import angular from 'angular';
 
-var treeController = angular.module('treeController', []).
+angular.module('treeController', []).
 
 controller('TreeController', ['$scope', 'SelectedFiles', 'Transfer', function($scope, SelectedFiles, Transfer) {
   $scope.helper = function() {

--- a/app/tree/tree.directive.js
+++ b/app/tree/tree.directive.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import angular from 'angular';
 import $ from 'jquery';
 

--- a/app/tree/tree.directive.js
+++ b/app/tree/tree.directive.js
@@ -1,36 +1,34 @@
 import angular from 'angular';
 import $ from 'jquery';
 
-(function() {
-  angular.module('treeDirectives', []).
+angular.module('treeDirectives', []).
 
-  directive('treeDraggable', ['$parse', function($parse) {
-    return {
-      restrict: 'A',
-      link: function($scope, element, attrs) {
-        var helper_fn = $parse(attrs.helper)($scope);
+directive('treeDraggable', ['$parse', function($parse) {
+  return {
+    restrict: 'A',
+    link: function($scope, element, attrs) {
+      var helper_fn = $parse(attrs.helper)($scope);
 
-        $(element).draggable({
-          appendTo: 'body',
-          containment: false,
-          cursor: 'move',
-          helper: helper_fn,
-          revert: 'invalid',
-        });
-      },
-    };
-  }]).
+      $(element).draggable({
+        appendTo: 'body',
+        containment: false,
+        cursor: 'move',
+        helper: helper_fn,
+        revert: 'invalid',
+      });
+    },
+  };
+}]).
 
-  directive('treeDroppable', ['$parse', function($parse) {
-    return {
-      restrict: 'A',
-      link: function($scope, element, attrs) {
-        var drop_fn = $parse(attrs.onDrop)($scope);
+directive('treeDroppable', ['$parse', function($parse) {
+  return {
+    restrict: 'A',
+    link: function($scope, element, attrs) {
+      var drop_fn = $parse(attrs.onDrop)($scope);
 
-        $(element).droppable({
-          drop: drop_fn.bind($scope.node),
-        });
-      },
-    };
-  }]);
-})();
+      $(element).droppable({
+        drop: drop_fn.bind($scope.node),
+      });
+    },
+  };
+}]);

--- a/app/ui/ui.directive.js
+++ b/app/ui/ui.directive.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import angular from 'angular';
 
 (function() {

--- a/app/ui/ui.directive.js
+++ b/app/ui/ui.directive.js
@@ -1,65 +1,62 @@
 import angular from 'angular';
 
-(function() {
-  angular.module('uiDirectives', []).
+angular.module('uiDirectives', []).
 
-  directive('uiMinimizeBar', [function() {
-    return {
-      restrict: 'E',
-      transclude: true,
-      templateUrl: 'ui/minimize-bar.html',
-      controller: function($scope) {
-        var panes = $scope.panes = [];
+directive('uiMinimizeBar', [function() {
+  return {
+    restrict: 'E',
+    transclude: true,
+    templateUrl: 'ui/minimize-bar.html',
+    controller: function($scope) {
+      var panes = $scope.panes = [];
 
-        $scope.toggle = function(pane) {
-          pane.selected = !pane.selected;
-          var width = 100 / panes.filter(function(e) { return e.selected; }).length + '%';
-          // Update child element widths
-          angular.forEach(panes, function(p) {
-            p.width = width;
-          });
-        };
-
-        this.addPane = function(pane, open) {
-          panes.push(pane);
-          if (open) {
-            $scope.toggle(pane);
-          }
-        };
-      },
-    };
-  }]).
-
-  directive('uiMinimizePanel', [function() {
-    return {
-      require: '^uiMinimizeBar',
-      restrict: 'E',
-      transclude: true,
-      scope: {
-        title: '@',
-      },
-      templateUrl: 'ui/minimize-panel.html',
-      link: function(scope, element, attrs, minimizeBar) {
-        minimizeBar.addPane(scope, attrs.open === 'true');
-      },
-    };
-  }]).
-
-  directive('ngConfirmClick', [function() {
-    // From http://zachsnow.com/#!/blog/2013/confirming-ng-click/
-    return {
-      priority: -1,
-      restrict: 'A',
-      link: function(scope, element, attrs) {
-        element.bind('click', function(e){
-          var message = attrs.ngConfirmClick;
-          if(message && !confirm(message)){
-            e.stopImmediatePropagation();
-            e.preventDefault();
-          }
+      $scope.toggle = function(pane) {
+        pane.selected = !pane.selected;
+        var width = 100 / panes.filter(function(e) { return e.selected; }).length + '%';
+        // Update child element widths
+        angular.forEach(panes, function(p) {
+          p.width = width;
         });
-      }
-    };
-  }]);
+      };
 
-})();
+      this.addPane = function(pane, open) {
+        panes.push(pane);
+        if (open) {
+          $scope.toggle(pane);
+        }
+      };
+    },
+  };
+}]).
+
+directive('uiMinimizePanel', [function() {
+  return {
+    require: '^uiMinimizeBar',
+    restrict: 'E',
+    transclude: true,
+    scope: {
+      title: '@',
+    },
+    templateUrl: 'ui/minimize-panel.html',
+    link: function(scope, element, attrs, minimizeBar) {
+      minimizeBar.addPane(scope, attrs.open === 'true');
+    },
+  };
+}]).
+
+directive('ngConfirmClick', [function() {
+  // From http://zachsnow.com/#!/blog/2013/confirming-ng-click/
+  return {
+    priority: -1,
+    restrict: 'A',
+    link: function(scope, element, attrs) {
+      element.bind('click', function(e){
+        var message = attrs.ngConfirmClick;
+        if(message && !confirm(message)){
+          e.stopImmediatePropagation();
+          e.preventDefault();
+        }
+      });
+    }
+  };
+}]);

--- a/app/ui/ui.directive.js
+++ b/app/ui/ui.directive.js
@@ -12,11 +12,9 @@ directive('uiMinimizeBar', [function() {
 
       $scope.toggle = function(pane) {
         pane.selected = !pane.selected;
-        var width = 100 / panes.filter(function(e) { return e.selected; }).length + '%';
+        var width = 100 / panes.filter(e => e.selected).length + '%';
         // Update child element widths
-        angular.forEach(panes, function(p) {
-          p.width = width;
-        });
+        angular.forEach(panes, p => p.width = width);
       };
 
       this.addPane = function(pane, open) {
@@ -50,7 +48,7 @@ directive('ngConfirmClick', [function() {
     priority: -1,
     restrict: 'A',
     link: function(scope, element, attrs) {
-      element.bind('click', function(e){
+      element.bind('click', e => {
         var message = attrs.ngConfirmClick;
         if(message && !confirm(message)){
           e.stopImmediatePropagation();

--- a/app/visualizations/visualizations.controller.js
+++ b/app/visualizations/visualizations.controller.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import angular from 'angular';
 
 (function() {

--- a/app/visualizations/visualizations.controller.js
+++ b/app/visualizations/visualizations.controller.js
@@ -1,48 +1,46 @@
 import angular from 'angular';
 
-(function() {
-  angular.module('visualizationsController', [
-    'angularCharts',
-    'fileListService',
-    'selectedFilesService',
-  ]).
+angular.module('visualizationsController', [
+  'angularCharts',
+  'fileListService',
+  'selectedFilesService',
+]).
 
-  controller('VisualizationsController', ['$scope', 'FileList', 'SelectedFiles', function($scope, FileList, SelectedFiles) {
-    // Displays aggregate information about file formats;
-    // the selected record data is filtered/reformatted in the view.
-    $scope.records = SelectedFiles;
-    $scope.format_chart_type = 'pie';
-    $scope.format_config = {
-      // Formats (total)
-      click: function(d) {
-        FileList.files = SelectedFiles.selected.filter(function (file) {
-          return file.format === d.data.format;
-        });
-      },
-      tooltips: true,
-      labels: false,
-      legend: {
-        display: true,
-        position: 'right',
-      },
-      colors: d3.scale.category20().range(),
-    };
+controller('VisualizationsController', ['$scope', 'FileList', 'SelectedFiles', function($scope, FileList, SelectedFiles) {
+  // Displays aggregate information about file formats;
+  // the selected record data is filtered/reformatted in the view.
+  $scope.records = SelectedFiles;
+  $scope.format_chart_type = 'pie';
+  $scope.format_config = {
+    // Formats (total)
+    click: function(d) {
+      FileList.files = SelectedFiles.selected.filter(function (file) {
+        return file.format === d.data.format;
+      });
+    },
+    tooltips: true,
+    labels: false,
+    legend: {
+      display: true,
+      position: 'right',
+    },
+    colors: d3.scale.category20().range(),
+  };
 
-    $scope.size_chart_type = 'pie';
-    $scope.size_config = {
-      // Formats (by size)
-      click: function(d) {
-        FileList.files = SelectedFiles.selected.filter(function (file) {
-          return file.format === d.data.format;
-        });
-      },
-      tooltips: true,
-      labels: false,
-      legend: {
-        display: true,
-        position: 'right',
-      },
-      colors: d3.scale.category20().range(),
-    };
-  }]);
-})();
+  $scope.size_chart_type = 'pie';
+  $scope.size_config = {
+    // Formats (by size)
+    click: function(d) {
+      FileList.files = SelectedFiles.selected.filter(function (file) {
+        return file.format === d.data.format;
+      });
+    },
+    tooltips: true,
+    labels: false,
+    legend: {
+      display: true,
+      position: 'right',
+    },
+    colors: d3.scale.category20().range(),
+  };
+}]);

--- a/app/visualizations/visualizations.controller.js
+++ b/app/visualizations/visualizations.controller.js
@@ -14,9 +14,7 @@ controller('VisualizationsController', ['$scope', 'FileList', 'SelectedFiles', f
   $scope.format_config = {
     // Formats (total)
     click: function(d) {
-      FileList.files = SelectedFiles.selected.filter(function (file) {
-        return file.format === d.data.format;
-      });
+      FileList.files = SelectedFiles.selected.filter(file => file.format === d.data.format);
     },
     tooltips: true,
     labels: false,
@@ -31,9 +29,7 @@ controller('VisualizationsController', ['$scope', 'FileList', 'SelectedFiles', f
   $scope.size_config = {
     // Formats (by size)
     click: function(d) {
-      FileList.files = SelectedFiles.selected.filter(function (file) {
-        return file.format === d.data.format;
-      });
+      FileList.files = SelectedFiles.selected.filter(file => file.format === d.data.format);
     },
     tooltips: true,
     labels: false,


### PR DESCRIPTION
This makes several changes now that we're using ES6:
- Removes `use strict`
- Removes IIFEs
- Replaces function literals with arrow functions, where safe (e.g., where we're not using their `this` properties)
- Replaces uses of `_.extend` with `Object.assign`
