### PR TITLE
Fix resolving template locations

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -46,18 +46,18 @@ import './filters/aggregation.filter.js';
 import './filters/facet.filter.js';
 
 // partials
-import 'ng-cache!./analysis/analysis.html';
-import 'ng-cache!./archivesspace/digital_object_form.html';
-import 'ng-cache!./archivesspace/form.html';
-import 'ng-cache!./examine_contents/file_info.html';
-import 'ng-cache!./preview/preview.html';
-import 'ng-cache!./report/format.html';
-import 'ng-cache!./report/tags.html';
-import 'ng-cache!./ui/minimize-bar.html';
-import 'ng-cache!./ui/minimize-panel.html';
-import 'ng-cache!./visualizations/formats_by_files.html';
-import 'ng-cache!./visualizations/formats_by_size.html';
-import 'ng-cache!./visualizations/visualizations.html';
+import 'ng-cache?prefix=[dir]!./analysis/analysis.html';
+import 'ng-cache?prefix=[dir]!./archivesspace/digital_object_form.html';
+import 'ng-cache?prefix=[dir]!./archivesspace/form.html';
+import 'ng-cache?prefix=[dir]!./examine_contents/file_info.html';
+import 'ng-cache?prefix=[dir]!./preview/preview.html';
+import 'ng-cache?prefix=[dir]!./report/format.html';
+import 'ng-cache?prefix=[dir]!./report/tags.html';
+import 'ng-cache?prefix=[dir]!./ui/minimize-bar.html';
+import 'ng-cache?prefix=[dir]!./ui/minimize-panel.html';
+import 'ng-cache?prefix=[dir]!./visualizations/formats_by_files.html';
+import 'ng-cache?prefix=[dir]!./visualizations/formats_by_size.html';
+import 'ng-cache?prefix=[dir]!./visualizations/visualizations.html';
 
 // services
 import './services/alert.service.js';


### PR DESCRIPTION
ng-cache-loader caches these under their basenames, not relative paths.
