### PR TITLE
Remove tag-deletion button from tree view

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -97,10 +97,10 @@
                      filter-expression="filter_expression"
                      filter-comparator="filter_comparator">
           <span tree-draggable helper="helper" file-type="backlog" uuid="{{ node.id }}" ng-if="!node.not_draggable">
-            {{ node.title }} <span class="tag" ng-repeat="tag in node.tags">{{ tag }} <span ng-click="remove_tag(id, tag)"><i class="fa fa-minus-square"></i></span></span>
+            {{ node.title }} <span class="tag" ng-repeat="tag in node.tags">{{ tag }}</span>
           </span>
           <span class="disabled" ng-if="node.not_draggable">
-            {{ node.title }} <span class="tag" ng-repeat="tag in node.tags">{{ tag }} <span ng-click="remove_tag(id, tag)"><i class="fa fa-minus-square"></i></span></span>
+            {{ node.title }} <span class="tag" ng-repeat="tag in node.tags">{{ tag }}</span>
           </span>
         </treecontrol>
       </div>


### PR DESCRIPTION
For technical reasons, we can't include any ng-click elements within the treeview; the entire node element is already wrapped in an onclick.
