### PR TITLE
Fix checklist with certain jQuery versions

### DIFF
--- a/app/checklist/checklist.directive.js
+++ b/app/checklist/checklist.directive.js
@@ -11,8 +11,6 @@ directive('checklist', ['$compile', '$parse', function($compile, $parse) {
       var set_all_selected = $parse(attrs.allSelected).assign;
       var get_record_count = $parse(attrs.recordCount);
 
-      element.attr('type', 'checkbox');
-
       element.bind('click', () => {
         var selected = get_selected($scope);
         var record = get_record($scope);

--- a/app/examine_contents/examine_contents.html
+++ b/app/examine_contents/examine_contents.html
@@ -50,6 +50,7 @@
     <tr ng-repeat="record in vm.SelectedFiles.selected | find_files | filter:{bulk_extractor_reports: vm.type}">
       <td>
         <input checklist
+             type="checkbox"
              name="checked_files[]"
              ng-model="record"
              ng-checked="vm.selected.indexOf(record.id) > -1"

--- a/app/index.html
+++ b/app/index.html
@@ -185,6 +185,7 @@
           <tr ng-repeat="file in vm.file_list.files | filter: {'date': '*'} : vm.facet_filter | orderBy: vm.sort_property : vm.sort_reverse">
             <td>
               <input checklist
+                   type="checkbox"
                    name="checked_files[]"
                    ng-model="file"
                    ng-checked="vm.selected.indexOf(file.id) > -1"


### PR DESCRIPTION
Certain versions of jQuery disallow dynamically setting the type of an `<input>` element, which caused the checklist directive to break.
