### PR TITLE
Include polyfill for Object.assign

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "devDependencies": {
     "babel-core": "^6.3.26",
     "babel-loader": "^6.2.0",
+    "babel-plugin-transform-object-assign": "^6.3.13",
     "babel-preset-es2015": "^6.3.13",
     "css-loader": "^0.23.1",
     "file-loader": "^0.8.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
     loaders: [
       {
         test: /\.js$/,
-        loader: 'babel?presets[]=es2015',
+        loader: 'babel?presets[]=es2015,plugins=transform-object-assign',
         exclude: /node_modules/,
       },
       {


### PR DESCRIPTION
This is available in current versions of major browsers, but including the polyfill would be useful in case users are on older versions.
