### PR TITLE
Checklist: rename ng-model to ng-element

### DIFF
--- a/app/checklist/checklist.directive.js
+++ b/app/checklist/checklist.directive.js
@@ -6,7 +6,7 @@ directive('checklist', ['$compile', '$parse', function($compile, $parse) {
   return {
     restrict: 'A',
     link: function($scope, element, attrs) {
-      var get_record = $parse(attrs.ngModel);
+      var get_record = $parse(attrs.ngElement);
       var get_selected = $parse(attrs.selectedList);
       var set_all_selected = $parse(attrs.allSelected).assign;
       var get_record_count = $parse(attrs.recordCount);

--- a/app/examine_contents/examine_contents.html
+++ b/app/examine_contents/examine_contents.html
@@ -52,7 +52,7 @@
         <input checklist
              type="checkbox"
              name="checked_files[]"
-             ng-model="record"
+             ng-element="record"
              ng-checked="vm.selected.indexOf(record.id) > -1"
              record-count="(vm.SelectedFiles.selected | find_files | filter:{bulk_extractor_reports: vm.type}).length"
              selected-list="vm.selected"

--- a/app/index.html
+++ b/app/index.html
@@ -187,7 +187,7 @@
               <input checklist
                    type="checkbox"
                    name="checked_files[]"
-                   ng-model="file"
+                   ng-element="file"
                    ng-checked="vm.selected.indexOf(file.id) > -1"
                    record-count="vm.file_list.files.length"
                    selected-list="vm.selected"


### PR DESCRIPTION
The previous attribute clashed with ng-input's ng-model attribute. This didn't cause a problem before, possibly because we used to dynamically set the type of the `<input>` element, causing it to revert to a bare `<input>` element; we no longer do that as of 86d4af3661b10680c3552f938aa9e9cc439519d6.

Fixes #9387.
