### PR TITLE
tree-droppable: adjust tolerance

### DIFF
--- a/app/tree/tree.directive.js
+++ b/app/tree/tree.directive.js
@@ -28,6 +28,7 @@ directive('treeDroppable', ['$parse', function($parse) {
 
       $(element).droppable({
         drop: drop_fn.bind($scope.node),
+        tolerance: 'pointer',
       });
     },
   };


### PR DESCRIPTION
The default tolerance is 'intersect', which is documented as firing if the "Draggable overlaps the droppable at least 50% in both directions". This isn't nearly good enough for the elements we're dragging; it's more intuitive for the user if we instead consider the mouse cursor to be the focal point of dragging.

See the docs: http://api.jqueryui.com/droppable/
