### PR TITLE
Fix tests with responses which return arrays

### DIFF
--- a/test/unit/archivesspaceSpec.js
+++ b/test/unit/archivesspaceSpec.js
@@ -45,19 +45,21 @@ describe('ArchivesSpace', function() {
         'id': '/repositories/2/resources/3',
       },
       ]);
-    _$httpBackend_.when('GET', '/access/archivesspace/levels').respond([
-      'class',
-      'collection',
-      'file',
-      'fonds',
-      'item',
-      'otherlevel',
-      'recordgrp',
-      'series',
-      'subfonds',
-      'subgrp',
-      'subseries',
-    ]);
+    _$httpBackend_.when('GET', '/access/archivesspace/levels').respond(function() {
+      return [
+        'class',
+        'collection',
+        'file',
+        'fonds',
+        'item',
+        'otherlevel',
+        'recordgrp',
+        'series',
+        'subfonds',
+        'subgrp',
+        'subseries',
+      ];
+    });
     _$httpBackend_.when('POST', '/access/archivesspace/-repositories-2-archival_objects-4/children').respond({
       'success': true,
       'id': '/repositories/2/archival_objects/5',

--- a/test/unit/tagSpec.js
+++ b/test/unit/tagSpec.js
@@ -5,9 +5,11 @@ import '../../app/services/tag.service.js';
 describe('Tag', function() {
   beforeEach(angular.mock.module('tagService'));
   beforeEach(angular.mock.inject(function(_$httpBackend_) {
-    _$httpBackend_.when('GET', '/file/e9010578-e065-4fa1-91c8-a105665037d6/tags').respond([
-      'fetched_tag_1', 'fetched_tag_2',
-      ]);
+    _$httpBackend_.when('GET', '/file/e9010578-e065-4fa1-91c8-a105665037d6/tags').respond(function() {
+      return [
+        'fetched_tag_1', 'fetched_tag_2',
+      ];
+    });
     _$httpBackend_.when('PUT', '/file/f5e06285-10e7-4996-b184-1c07951dc75e/tags').respond({'success': true});
     _$httpBackend_.when('DELETE', '/file/51228e59-f9c5-4e79-9b2c-73ac8d217147/tags').respond({'success': true});
   }));


### PR DESCRIPTION
respond() doesn't treat an array as the returned parsed object, unlike its behaviour when returning an object. We can work around that by using the callback form of respond() and returning an array from that.
