### PR TITLE
ArchivesSpace: add search support

### DIFF
--- a/app/archivesspace/archivesspace.controller.js
+++ b/app/archivesspace/archivesspace.controller.js
@@ -315,14 +315,6 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
       }
     };
 
-    $scope.refresh = function(node) {
-      if (node) {
-        load_element_children(node);
-      } else {
-        load_data();
-      }
-    };
-
     $scope.on_toggle = function(node, expanded) {
       if ((!expanded || !node.has_children || node.children_fetched) && node.type !== 'digital_object') {
         return;
@@ -331,17 +323,25 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
       load_element_children(node);
     };
 
-    var load_data = () => {
-      // TODO: handle failure to contact ArchivesSpace here;
-      //       probably want to scope this to only happen if ASpace pane is opened.
-      //       (The controller is always instantiated before the pane opens,
-      //       so adding an alert here would always render even if ArchivesSpace
-      //       wasn't clicked.)
-      $scope.loading = true;
-      ArchivesSpace.all().then(data => {
+    $scope.load_data = (query) => {
+      let on_success = data => {
         $scope.data = data;
         $scope.loading = false;
-      });
+      };
+      let on_failure = response => {
+        $scope.loading = false;
+        Alert.alerts.push({
+          type: 'danger',
+          message: 'Unable to access ArchivesSpace; check dashboard logs!',
+        });
+      };
+
+      $scope.loading = true;
+      if (query === undefined) {
+        return ArchivesSpace.all().then(on_success, on_failure);
+      } else {
+        return ArchivesSpace.search(query).then(on_success, on_failure);
+      }
     };
 
     // Prevent a given file or its descendants from being dragged more than once

--- a/app/archivesspace/archivesspace.controller.js
+++ b/app/archivesspace/archivesspace.controller.js
@@ -343,7 +343,6 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
         $scope.loading = false;
       });
     };
-    load_data();
 
     // Prevent a given file or its descendants from being dragged more than once
     var dragged_ids = [];

--- a/app/index.html
+++ b/app/index.html
@@ -216,6 +216,19 @@
     <div class='panel panel-default' ng-controller="ArchivesSpaceController">
       <div class='panel-heading'>
         ArchivesSpace <span ng-if="loading"><i class="fa fa-spinner fa-spin"></i></span>
+
+        <form ng-submit="load_data({title: title_query, identifier: id_query})">
+          <input type="text"
+                 ng-model="title_query"
+                 placeholder="Title">
+          <input type="text"
+                 ng-model="id_query"
+                 placeholder="Identifier">
+          <input type="submit"
+                 class='btn btn-sm btn-primary'
+                 id="archivesspace_search"
+                 value="Search ArchivesSpace">
+         </form>
       </div>
       <div class="transfer-tree panel-body">
         <input type='button'
@@ -255,11 +268,6 @@
                ng-disabled="selected.type !== 'resource' &amp;&amp; selected.type !== 'resource_component'"
                ng-click="finalize_arrangement(selected)"
                value='Finalize Arrangement'>
-        <input type='button'
-               class='btn btn-primary'
-               id='refresh'
-               ng-click="refresh(selected)"
-               value='Reload'>
         <treecontrol id="archivesspace-tree"
                class="tree-light"
                tree-model="data"

--- a/app/services/archivesspace.service.js
+++ b/app/services/archivesspace.service.js
@@ -20,6 +20,9 @@ factory('ArchivesSpace', ['Restangular', function(Restangular) {
       all: function() {
         return ArchivesSpace.getList();
       },
+      search: function(opts) {
+        return ArchivesSpace.getList({'title': opts.title, 'identifier': opts.identifier});
+      },
       // Returns a single record, given its ID (e.g., /repositories/2/resources/1)
       get: function(id) {
         var url_fragment = id_to_urlsafe(id);

--- a/test/unit/archivesspaceSpec.js
+++ b/test/unit/archivesspaceSpec.js
@@ -16,6 +16,39 @@ describe('ArchivesSpace', function() {
         'id': '/repositories/2/resources/1',
       },
     ]);
+    _$httpBackend_.when('GET', '/access/archivesspace?title=Test+record').respond([
+      {
+        'dates': '2015-01-01',
+        'title': 'Test record',
+        'levelOfDescription': 'series',
+        'children': [],
+        'sortPosition': 2,
+        'identifier': 'F8',
+        'id': '/repositories/2/resources/9',
+      },
+    ]);
+    _$httpBackend_.when('GET', '/access/archivesspace?identifier=F9').respond([
+      {
+        'dates': '2015-01-01',
+        'title': 'Artefactual fonds',
+        'levelOfDescription': 'fonds',
+        'children': [],
+        'sortPosition': 2,
+        'identifier': 'F9',
+        'id': '/repositories/2/resources/10',
+      },
+    ]);
+    _$httpBackend_.when('GET', '/access/archivesspace?identifier=F10&title=Record').respond([
+      {
+        'dates': '2015-01-01',
+        'title': 'Record with a matching identifier and title',
+        'levelOfDescription': 'fonds',
+        'children': [],
+        'sortPosition': 2,
+        'identifier': 'F10',
+        'id': '/repositories/2/resources/11',
+      },
+    ]);
     _$httpBackend_.when('GET', '/access/archivesspace/-repositories-2-archival_objects-4').respond({
         'dates': '',
         'title': 'Test file',
@@ -98,6 +131,30 @@ describe('ArchivesSpace', function() {
     ArchivesSpace.all().then(function(objects) {
       expect(objects.length).toEqual(1);
       expect(objects[0].title).toEqual('Test fonds');
+    });
+    _$httpBackend_.flush();
+  }));
+
+  it('should be able to search for ArchivesSpace records by title', inject(function(_$httpBackend_, ArchivesSpace) {
+    ArchivesSpace.search({'title': 'Test record'}).then(function(objects) {
+      expect(objects.length).toEqual(1);
+      expect(objects[0].title).toEqual('Test record');
+    });
+    _$httpBackend_.flush();
+  }));
+
+  it('should be able to search for ArchivesSpace records by identifier', inject(function(_$httpBackend_, ArchivesSpace) {
+    ArchivesSpace.search({'identifier': 'F9'}).then(function(objects) {
+      expect(objects.length).toEqual(1);
+      expect(objects[0].title).toEqual('Artefactual fonds');
+    });
+    _$httpBackend_.flush();
+  }));
+
+  it('should be able to search for ArchivesSpace records by title and identifier', inject(function(_$httpBackend_, ArchivesSpace) {
+    ArchivesSpace.search({'identifier': 'F10', 'title': 'Record'}).then(function(objects) {
+      expect(objects.length).toEqual(1);
+      expect(objects[0].title).toEqual('Record with a matching identifier and title');
     });
     _$httpBackend_.flush();
   }));


### PR DESCRIPTION
With this PR, the ArchivesSpace pane no longer loads all records on startup. Instead, a search form has been added with "title" and "identifier" options; the user can specify either, or both.

As a part of this, the "reload" button has been removed since it's no longer relevant, and proper error handling has been added when records fail to load.
