### PR TITLE
File list: display full path in table

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -194,7 +194,7 @@
                    all-selected="vm.all_selected">
             </td>
             <td>
-              <a href="#{{ vm.$routeSegment.getSegmentUrl('preview', {id: file.id}) }}">{{ file.title }}</a>
+              <a href="#{{ vm.$routeSegment.getSegmentUrl('preview', {id: file.id}) }}">{{ file.relative_path }}</a>
             </td>
             <td>{{ file.size | number}} MB</td>
             <td>{{ file.last_modified }}</td>


### PR DESCRIPTION
This leaves the sort property alone, because it seems more intuitive to me to continue sorting on filename.

Fixes #9430.
