### PR TITLE
Add filtering to the file list

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -181,7 +181,7 @@
             <th><a ng-click="vm.set_sort_property('last_modified')">Last modified</a></th>
             <th>Tags</th>
           </tr>
-          <tr ng-repeat="file in vm.selected_files.selected | filter: {'date': '*'} : vm.facet_filter | orderBy: vm.sort_property : vm.sort_reverse">
+          <tr ng-repeat="file in vm.selected_files.selected | facet | filter: {'date': '*'} : vm.facet_filter | filter: {'type': 'file'} | orderBy: vm.sort_property : vm.sort_reverse">
             <td>
               <input checklist
                    type="checkbox"

--- a/app/report/format.html
+++ b/app/report/format.html
@@ -7,9 +7,9 @@
     <th><a ng-click="set_sort_property('size', 'format_sort_property', 'format_reverse')">Size</a></th>
   </tr>
   <tr ng-repeat="record in records.selected | facet | format_data | orderBy: format_sort_fn : format_reverse">
-    <td>{{ record.format }}</td>
+    <td><a ng-click="add_format_facet(record.format)">{{ record.format }}</a></td>
     <td><a target="_blank" href="http://apps.nationalarchives.gov.uk/pronom/{{ record.data.puid }}">{{ record.data.puid }}</a> <i ng-if='record.data.puid' class='fa fa-external-link'></i></td>
-    <td>{{ record.data.group }}</td>
+    <td><a ng-click="add_group_facet(record.data.group)">{{ record.data.group }}</a></td>
     <td><ng-pluralize count="record.data.count" when="{'1': '1 object', 'other': '{} objects'}"></ng-pluralize></td>
     <td>{{ record.data.size | number }} MB</td>
   </tr>

--- a/app/report/report.controller.js
+++ b/app/report/report.controller.js
@@ -6,7 +6,7 @@ controller('ReportSelectionController', ['$scope', '$routeSegment', function($sc
   $scope.$routeSegment = $routeSegment;
 }]).
 
-controller('ReportController', ['$scope', 'SelectedFiles', function($scope, SelectedFiles) {
+controller('ReportController', ['$scope', 'Facet', 'SelectedFiles', 'Transfer', function($scope, Facet, SelectedFiles, Transfer) {
   $scope.records = SelectedFiles;
 
   $scope.format_sort_property = 'format';
@@ -34,5 +34,15 @@ controller('ReportController', ['$scope', 'SelectedFiles', function($scope, Sele
   $scope.tag_sort_fn = function(args) {
     var tag = args[0], count = args[1];
     return $scope.tag_sort_property === 'tag' ? tag : count;
+  };
+
+  $scope.add_format_facet = format => {
+    Facet.add('format', format, {name: 'Format', text: format});
+    Transfer.filter();
+  };
+
+  $scope.add_group_facet = group => {
+    Facet.add('group', group, {name: 'Format group', text: group});
+    Transfer.filter();
   };
 }]);

--- a/app/services/facet.service.js
+++ b/app/services/facet.service.js
@@ -157,7 +157,7 @@ factory('Facet', function() {
   // private
 
   var filter_value = function(key, value) {
-    if (undefined === this.facets[key]) {
+    if (undefined === this.facets[key] || undefined === value) {
       // no facet for this key
       return true;
     }

--- a/app/visualizations/visualizations.controller.js
+++ b/app/visualizations/visualizations.controller.js
@@ -5,13 +5,17 @@ angular.module('visualizationsController', [
   'selectedFilesService',
 ]).
 
-controller('VisualizationsController', ['$scope', 'SelectedFiles', function($scope, SelectedFiles) {
+controller('VisualizationsController', ['$scope', 'Facet', 'SelectedFiles', 'Transfer', function($scope, Facet, SelectedFiles, Transfer) {
   // Displays aggregate information about file formats;
   // the selected record data is filtered/reformatted in the view.
   $scope.records = SelectedFiles;
   $scope.format_chart_type = 'pie';
   $scope.format_config = {
     // Formats (total)
+    click: record => {
+      Facet.add('format', record.data.format, {name: 'Format', text: record.data.format});
+      Transfer.filter();
+    },
     tooltips: true,
     labels: false,
     legend: {
@@ -24,6 +28,10 @@ controller('VisualizationsController', ['$scope', 'SelectedFiles', function($sco
   $scope.size_chart_type = 'pie';
   $scope.size_config = {
     // Formats (by size)
+    click: record => {
+      Facet.add('format', record.data.format, {name: 'Format', text: record.data.format});
+      Transfer.filter();
+    },
     tooltips: true,
     labels: false,
     legend: {


### PR DESCRIPTION
- Fixes a bug in the `Facet` service, which would cause exceptions to be raised if some of the objects in the set being filtered were missing one of the keys to be filtered.
- In the portions of the UI which formerly added files to the file list, such as the file format sections of the table, added functionality to add filters to the selection which will be reflected in the file list.
- Added facet filtering to the file list table.
