### PR TITLE
Backlog: filter only on tags

### DIFF
--- a/app/services/facet.service.js
+++ b/app/services/facet.service.js
@@ -137,8 +137,8 @@ factory('Facet', function() {
   // which the object doesn't have.
   // Returns true if the object passes at least one facet defined for its
   // keys, false otherwise.
-  var passes_filters = function(object) {
-    var keys = Object.keys(this.facets);
+  // Optionally, keys can be passed, and it will only check filters for those keys.
+  var passes_filters = function(object, keys = Object.keys(this.facets)) {
     var key, value;
     // If no filters, everything passes
     if (keys.length === 0) {

--- a/app/services/transfer.service.js
+++ b/app/services/transfer.service.js
@@ -100,7 +100,7 @@ factory('Transfer', ['Facet', 'Tag', function(Facet, Tag) {
     filter: function() {
       angular.forEach(this.id_map, file => {
         if (file.type === 'file') {
-          file.display = Facet.passes_filters(file);
+          file.display = Facet.passes_filters(file, ['tags']);
         } else {
           file.display = true;
         }

--- a/test/unit/facetSpec.js
+++ b/test/unit/facetSpec.js
@@ -140,6 +140,14 @@ describe('Facet', function() {
     expect(Facet.passes_filters({'key': []})).toBe(false);
   }));
 
+  it('should be able to only filter on a subset of filters', inject(function(Facet) {
+    Facet.add('tag', 'test');
+    Facet.add('format', 'jpg');
+    expect(Facet.passes_filters({'tag': 'false', 'format': 'jpg'})).toBe(true);
+    expect(Facet.passes_filters({'tag': 'false', 'format': 'jpg'}, ['tag'])).toBe(false);
+    expect(Facet.passes_filters({'tag': 'test', 'format': 'jpg'}, ['tag'])).toBe(true);
+  }));
+
   it('should delete the facet key if all filters for that facet have been removed', inject(function(Facet) {
     expect(Facet.facets['key']).toBeUndefined();
     Facet.add('key', 'value');


### PR DESCRIPTION
The backlog will only be filtered based on tags, not on file format etc. Finishes work mentioned in #132 
