### PR TITLE
Define multiple entry points

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,10 +1,3 @@
-// styles
-import './app.css';
-import 'bootstrap/dist/css/bootstrap.css';
-import 'font-awesome/css/font-awesome.min.css';
-import './vendor/angular-tree-control/css/tree-control.css';
-import './vendor/angular-tree-control/css/tree-control-attribute.css';
-
 // third-party modules
 import angular from 'angular';
 import './vendor/angular-charts/angular-charts.js';
@@ -38,22 +31,6 @@ import './ui/ui.directive.js';
 // filters
 import './filters/aggregation.filter.js';
 import './filters/facet.filter.js';
-
-// partials
-import 'ng-cache?prefix=[dir]!./analysis/analysis.html';
-import 'ng-cache?prefix=[dir]!./archivesspace/digital_object_form.html';
-import 'ng-cache?prefix=[dir]!./archivesspace/form.html';
-import 'ng-cache?prefix=[dir]!./examine_contents/examine_contents.html';
-import 'ng-cache?prefix=[dir]!./examine_contents/file_info.html';
-import 'ng-cache?prefix=[dir]!./front_page/content.html';
-import 'ng-cache?prefix=[dir]!./preview/preview.html';
-import 'ng-cache?prefix=[dir]!./report/format.html';
-import 'ng-cache?prefix=[dir]!./report/tags.html';
-import 'ng-cache?prefix=[dir]!./ui/minimize-bar.html';
-import 'ng-cache?prefix=[dir]!./ui/minimize-panel.html';
-import 'ng-cache?prefix=[dir]!./visualizations/formats_by_files.html';
-import 'ng-cache?prefix=[dir]!./visualizations/formats_by_size.html';
-import 'ng-cache?prefix=[dir]!./visualizations/visualizations.html';
 
 // services
 import './services/alert.service.js';

--- a/app/embeddable.entry.js
+++ b/app/embeddable.entry.js
@@ -1,0 +1,27 @@
+// styles
+import './app.css';
+import 'font-awesome/css/font-awesome.min.css';
+import './vendor/angular-tree-control/css/tree-control.css';
+import './vendor/angular-tree-control/css/tree-control-attribute.css';
+
+// Angular must be available to cache the partials
+import 'angular';
+
+// partials
+import 'ng-cache?prefix=[dir]!./analysis/analysis.html';
+import 'ng-cache?prefix=[dir]!./archivesspace/digital_object_form.html';
+import 'ng-cache?prefix=[dir]!./archivesspace/form.html';
+import 'ng-cache?prefix=[dir]!./examine_contents/examine_contents.html';
+import 'ng-cache?prefix=[dir]!./examine_contents/file_info.html';
+import 'ng-cache?prefix=[dir]!./front_page/content.html';
+import 'ng-cache?prefix=[dir]!./preview/preview.html';
+import 'ng-cache?prefix=[dir]!./report/format.html';
+import 'ng-cache?prefix=[dir]!./report/tags.html';
+import 'ng-cache?prefix=[dir]!./ui/minimize-bar.html';
+import 'ng-cache?prefix=[dir]!./ui/minimize-panel.html';
+import 'ng-cache?prefix=[dir]!./visualizations/formats_by_files.html';
+import 'ng-cache?prefix=[dir]!./visualizations/formats_by_size.html';
+import 'ng-cache?prefix=[dir]!./visualizations/visualizations.html';
+
+// Finally, import the main entry point
+import './app.js';

--- a/app/standalone.entry.js
+++ b/app/standalone.entry.js
@@ -1,0 +1,28 @@
+// styles
+import './app.css';
+import 'bootstrap/dist/css/bootstrap.css';
+import 'font-awesome/css/font-awesome.min.css';
+import './vendor/angular-tree-control/css/tree-control.css';
+import './vendor/angular-tree-control/css/tree-control-attribute.css';
+
+// Angular must be available to cache the partials
+import 'angular';
+
+// partials
+import 'ng-cache?prefix=[dir]!./analysis/analysis.html';
+import 'ng-cache?prefix=[dir]!./archivesspace/digital_object_form.html';
+import 'ng-cache?prefix=[dir]!./archivesspace/form.html';
+import 'ng-cache?prefix=[dir]!./examine_contents/examine_contents.html';
+import 'ng-cache?prefix=[dir]!./examine_contents/file_info.html';
+import 'ng-cache?prefix=[dir]!./front_page/content.html';
+import 'ng-cache?prefix=[dir]!./preview/preview.html';
+import 'ng-cache?prefix=[dir]!./report/format.html';
+import 'ng-cache?prefix=[dir]!./report/tags.html';
+import 'ng-cache?prefix=[dir]!./ui/minimize-bar.html';
+import 'ng-cache?prefix=[dir]!./ui/minimize-panel.html';
+import 'ng-cache?prefix=[dir]!./visualizations/formats_by_files.html';
+import 'ng-cache?prefix=[dir]!./visualizations/formats_by_size.html';
+import 'ng-cache?prefix=[dir]!./visualizations/visualizations.html';
+
+// Finally, import the main entry point
+import './app.js';

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "webpack": "^1.12.9"
   },
   "scripts": {
-    "prepublish": "webpack --progress --colors",
+    "prepublish": "webpack --progress --colors --entry ./embeddable.entry.js",
     "prestart": "npm install",
     "start": "http-server -a localhost -p 8000 -c-1",
     "pretest": "npm install",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,6 @@ var APP = __dirname + '/app';
 
 module.exports = {
   context: APP,
-  entry: './app.js',
   output: {
     path: APP,
     filename: 'appraisal_tab.js',


### PR DESCRIPTION
The "standalone" entry point includes additional third-party libraries which might conflict with an external system, like Bootstrap. The "embeddable" entry point omits these libraries. "Embeddable" is the default entry point for `npm install`.

In addition, move all style and partial imports into the separate entry points. This ensures that app.js is importable as a module outside the context of webpack.
