### PR TITLE
Copy from backlog allows filtering

### DIFF
--- a/app/archivesspace/archivesspace.controller.js
+++ b/app/archivesspace/archivesspace.controller.js
@@ -28,6 +28,9 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
     if (record === undefined) {
       return '';
     }
+    if (record.type !== 'resource' && record.type !== 'resource_component') {
+      return '';
+    }
     return `/access/archivesspace/${record.id.replace(/\//g, '-')}/rights/`;
   };
 

--- a/app/front_page/content.html
+++ b/app/front_page/content.html
@@ -2,7 +2,7 @@
   <form id='search_form'>
   <div id='search_form_container'></div>
   <div id='search_form_submit_container'>
-    <input type='button' id='search_submit' value='Search transfer backlog'>
+    <input class='form-control btn-primary' type='button' id='search_submit' value='Search transfer backlog'>
   </div>
   </form>
 

--- a/app/services/sip_arrange.service.js
+++ b/app/services/sip_arrange.service.js
@@ -84,7 +84,9 @@ factory('SipArrange', ['Restangular', function(Restangular) {
     };
 
     let format_files = data => {
-      let entries = format_entries(data, parent.path, parent);
+      // format_entries expects a directory that does not end in /
+      let parent_path = parent.path && parent.path.slice(-1) === '/' ? parent.path.slice(0, -1) : parent.path;
+      let entries = format_entries(data, parent_path, parent);
       entries.forEach(entry => entry.type = 'arrange_entry');
       return entries;
     };

--- a/app/services/sip_arrange.service.js
+++ b/app/services/sip_arrange.service.js
@@ -38,13 +38,21 @@ factory('SipArrange', ['Restangular', function(Restangular) {
     return post_form(SipArrange, 'create_directory_within_arrange', {path: Base64.encode(path)}).then(on_success);
   };
 
-  // Copies a file (or a directory, and its children) from `source` to `destination`.
-  // `source` must begin with /originals/, and `destination` must begin with /arrange/.
+  // Copies files listed in `source` to `destination`.
+  // Paths in `source` must begin with /originals/ and paths in `destination` must begin with /arrange/
   var copy_to_arrange = function(source, destination) {
-    var params = {
-      'filepath': Base64.encode(source),
-      'destination': Base64.encode(destination),
-    };
+    var params = {};
+    if (typeof source === 'string' && typeof destination === 'string') {
+      params = {
+        'filepath': Base64.encode(source),
+        'destination': Base64.encode(destination),
+      };
+    } else {
+      params = {
+        'filepath': source.map(path => Base64.encode(path)),
+        'destination': destination.map(path => Base64.encode(path)),
+      };
+    }
     return post_form(SipArrange, 'copy_to_arrange', params);
   };
 

--- a/test/unit/sip_arrangeSpec.js
+++ b/test/unit/sip_arrangeSpec.js
@@ -26,6 +26,9 @@ describe('SipArrange', function() {
     _$httpBackend_.when('POST', '/filesystem/copy_to_arrange', 'filepath=c291cmNl&destination=ZGVzdGluYXRpb24%3D').respond({
       'message': 'Files added to the SIP.',
     });
+    _$httpBackend_.when('POST', '/filesystem/copy_to_arrange', 'filepath%5B%5D=cGF0aDE%3D&filepath%5B%5D=cGF0aDI%3D&destination%5B%5D=ZGVzdDE%3D&destination%5B%5D=ZGVzdDI%3D').respond({
+      'message': 'Files added to the SIP.',
+    });
     _$httpBackend_.when('POST', '/filesystem/copy_from_arrange', 'filepath=dGFyZ2V0').respond({
       'message': 'SIP created.',
     });
@@ -70,6 +73,12 @@ describe('SipArrange', function() {
 
   it('should be able to add files to a SIP', inject(function(_$httpBackend_, SipArrange) {
     SipArrange.copy_to_arrange('source', 'destination').then(function(response) {
+      expect(response.message).toEqual('Files added to the SIP.');
+    });
+    _$httpBackend_.flush();
+  }));
+  it('should be able to add a list of files to a SIP', inject(function(_$httpBackend_, SipArrange) {
+    SipArrange.copy_to_arrange(['path1', 'path2'], ['dest1', 'dest2']).then(function(response) {
       expect(response.message).toEqual('Files added to the SIP.');
     });
     _$httpBackend_.flush();


### PR DESCRIPTION
Drag from backlog now sends a list of files instead the root of a tree.  This allows the list to be filtered before it's sent to Archivematica. SipArrange.copy_to_arrange and Archivematica still accept a single string in addition to a list of strings for backwards compatibility.

Also: 
- Style search form with bootstrap
- Misc errors: don't get rights edit if not a resource, correctly generate sip arrange paths
