### PR TITLE
ASpace date fixes and Backlog expand/collapse all

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -103,6 +103,14 @@ fieldset {
 .aspace-panel form,
 .aspace-panel form input,
 .aspace-panel .aspace-actions,
-.aspace-panel .aspace-actions .btn {
+.aspace-panel .aspace-actions .btn,
+.transfer-panel form,
+.transfer-panel form input,
+.transfer-panel .transfer-actions,
+.transfer-panel .transfer-actions .btn {
   margin-top: 5px;
+}
+
+.transfer-panel .transfer-counts {
+  float: right;
 }

--- a/app/app.css
+++ b/app/app.css
@@ -57,7 +57,7 @@ treecontrol>ul>li {
   padding-left: 0px;
 }
 
-.form-control {
+.facet-box .form-control {
   width: auto;
   display: inline;
 }

--- a/app/app.css
+++ b/app/app.css
@@ -99,3 +99,10 @@ fieldset {
   border: 1px solid #f5f5f5;
   background-color: #fff;
 }
+
+.aspace-panel form,
+.aspace-panel form input,
+.aspace-panel .aspace-actions,
+.aspace-panel .aspace-actions .btn {
+  margin-top: 5px;
+}

--- a/app/app.js
+++ b/app/app.js
@@ -4,9 +4,11 @@ import './vendor/angular-charts/angular-charts.js';
 import 'angular-route';
 import 'angular-route-segment';
 import './vendor/angular-tree-control/angular-tree-control.js';
+import 'angular-ui-validate';
 import 'd3';
 import 'jquery';
 import 'jquery-ui';
+import 'moment';
 import 'restangular';
 
 // controllers
@@ -56,6 +58,7 @@ module.exports = angular.module('appraisalTab', [
   'restangular',
   'treeControl',
   'ui.bootstrap',
+  'ui.validate',
   'appraisalTab.version',
   'checklistDirective',
   'treeDirectives',

--- a/app/archivesspace/archivesspace.controller.js
+++ b/app/archivesspace/archivesspace.controller.js
@@ -56,7 +56,12 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
     delete copy.accessrestrict_note;
 
     if (form.start_date) {
-      copy.dates = form.start_date.toISOString().slice(0, 10) + '-' + form.end_date.toISOString().slice(0, 10);
+      copy.start_date = form.start_date.toISOString().slice(0, 10);
+      copy.dates = copy.start_date + '-';
+      if (form.end_date) {
+        copy.end_date = form.end_date.toISOString().slice(0, 10);
+        copy.dates = copy.dates + copy.end_date;
+      }
     }
 
     return copy;

--- a/app/archivesspace/archivesspace.controller.js
+++ b/app/archivesspace/archivesspace.controller.js
@@ -57,10 +57,8 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
 
     if (form.start_date) {
       copy.start_date = form.start_date.toISOString().slice(0, 10);
-      copy.dates = copy.start_date + '-';
       if (form.end_date) {
         copy.end_date = form.end_date.toISOString().slice(0, 10);
-        copy.dates = copy.dates + copy.end_date;
       }
     }
 

--- a/app/archivesspace/archivesspace.controller.js
+++ b/app/archivesspace/archivesspace.controller.js
@@ -187,10 +187,10 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
           return '';
         },
         start_date: () => {
-          return new Date();
+          return '';
         },
         end_date: () => {
-          return new Date();
+          return '';
         },
         date_expression: () => {
           return '';

--- a/app/archivesspace/archivesspace.controller.js
+++ b/app/archivesspace/archivesspace.controller.js
@@ -97,7 +97,7 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
           return false;
         },
         date_expression: () => {
-          return node.date_expression;
+          return false;
         },
         note: () => {
           if (node.notes) {

--- a/app/archivesspace/archivesspace.controller.js
+++ b/app/archivesspace/archivesspace.controller.js
@@ -56,6 +56,15 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
     }
     delete copy.accessrestrict_note;
 
+    if (form.date_expression) {
+      copy.dates = form.date_expression;
+    } else if (form.start_date) {
+      copy.dates = copy.start_date;
+      if (form.end_date) {
+        copy.dates += ' - ' + copy.end_date;
+      }
+    }
+
     return copy;
   };
 
@@ -207,6 +216,13 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
         result.id = response.id;
         result.parent = node;
         result.type = 'resource_component';
+        result.display_title = result.title;
+        if (result.dates) {
+          if (result.title) {
+            result.display_title += ', '; 
+          }
+          result.display_title += result.dates; 
+        }
         append_child(node, result);
       };
 

--- a/app/archivesspace/archivesspace.controller.js
+++ b/app/archivesspace/archivesspace.controller.js
@@ -585,12 +585,4 @@ controller('ArchivesSpaceEditController', ['$uibModalInstance', 'levels', 'level
   vm.cancel = function() {
     $uibModalInstance.dismiss('cancel');
   };
-  vm.open_datepicker = (picker, $event) => {
-    var prop = picker + '_date_opened';
-    this.status[prop] = true;
-  };
-  vm.status = {
-    start_date_opened: false,
-    end_date_opened: false,
-  };
 }]);

--- a/app/archivesspace/archivesspace.controller.js
+++ b/app/archivesspace/archivesspace.controller.js
@@ -56,13 +56,6 @@ controller('ArchivesSpaceController', ['$scope', '$uibModal', 'Alert', 'Archives
     }
     delete copy.accessrestrict_note;
 
-    if (form.start_date) {
-      copy.start_date = form.start_date.toISOString().slice(0, 10);
-      if (form.end_date) {
-        copy.end_date = form.end_date.toISOString().slice(0, 10);
-      }
-    }
-
     return copy;
   };
 

--- a/app/archivesspace/archivesspace.controller.js
+++ b/app/archivesspace/archivesspace.controller.js
@@ -1,4 +1,5 @@
 import angular from 'angular';
+import moment from 'moment';
 import '../vendor/angular-ui-bootstrap/ui-bootstrap-custom-tpls-0.14.3.min.js';
 
 angular.module('archivesSpaceController', ['alertService', 'sipArrangeService', 'transferService', 'ui.bootstrap']).
@@ -584,5 +585,8 @@ controller('ArchivesSpaceEditController', ['$uibModalInstance', 'levels', 'level
   };
   vm.cancel = function() {
     $uibModalInstance.dismiss('cancel');
+  };
+  vm.validateDate = function(value) {
+    return !value || (/^\d{4}(-\d{2}(-\d{2})?)?$/.test(value) && moment(value, 'YYYY-MM-DD').isValid());
   };
 }]);

--- a/app/archivesspace/form.html
+++ b/app/archivesspace/form.html
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-md-6 form-group">
       <label for="title">Title:</label>
-      <input type="text" class="form-control" id="title" ng-model="form.title" ng-required="!form.date_expression"/>
+      <input type="text" class="form-control" id="title" ng-model="form.title" ng-required="!form.date_expression &amp;&amp; !form.start_date &amp;&amp; !form.end_date"/>
     </div>
     <div class="col-md-6 form-group">
       <label for="lod">Level of description:</label>
@@ -19,17 +19,17 @@
     <!-- Start and end dates are only in the form for creating a new item, not editing -->
     <div class="col-md-6 form-group" ng-if="form.start_date !== false">
       <label for="start-date">Start date:</label>
-      <input type="text" class="form-control" id="start-date" ng-model="form.start_date" ui-validate="'form.validateDate($value)'"/>
+      <input type="text" class="form-control" id="start-date" ng-model="form.start_date" ui-validate="'form.validateDate($value)'" ng-required="!form.date_expression &amp;&amp; !form.title &amp;&amp; !form.end_date"/>
       <p class="help-block">e.g. YYYY, YYYY-MM, or YYYY-MM-DD</p>
     </div>
     <div class="col-md-6 form-group" ng-if="form.start_date !== false">
       <label for="end-date">End date:</label>
-      <input type="text" class="form-control" id="end-date" ng-model="form.end_date" ui-validate="'form.validateDate($value)'"/>
+      <input type="text" class="form-control" id="end-date" ng-model="form.end_date" ui-validate="'form.validateDate($value)'" ng-required="!form.date_expression &amp;&amp; !form.start_date &amp;&amp; !form.title"/>
       <p class="help-block">e.g. YYYY, YYYY-MM, or YYYY-MM-DD</p>
     </div>
     <div class="col-md-12 form-group" ng-if="form.start_date !== false">
       <label for="expression">Date expression:</label>
-      <textarea class="form-control" id="expression" ng-model="form.date_expression" ng-required="!form.title"></textarea>
+      <textarea class="form-control" id="expression" ng-model="form.date_expression" ng-required="!form.title &amp;&amp; !form.start_date &amp;&amp; !form.end_date"></textarea>
     </div>
   </div>
   <div class="btn-group" role="group">

--- a/app/archivesspace/form.html
+++ b/app/archivesspace/form.html
@@ -20,10 +20,12 @@
     <div class="col-md-6 form-group" ng-if="form.start_date !== false">
       <label for="start-date">Start date:</label>
       <input type="text" class="form-control" id="start-date" ng-model="form.start_date"/>
+      <p class="help-block">e.g. YYYY, YYYY-MM, or YYYY-MM-DD</p>
     </div>
     <div class="col-md-6 form-group" ng-if="form.start_date !== false">
       <label for="end-date">End date:</label>
       <input type="text" class="form-control" id="end-date" ng-model="form.end_date"/>
+      <p class="help-block">e.g. YYYY, YYYY-MM, or YYYY-MM-DD</p>
     </div>
     <div class="col-md-12 form-group" ng-if="form.start_date !== false">
       <label for="expression">Date expression:</label>

--- a/app/archivesspace/form.html
+++ b/app/archivesspace/form.html
@@ -19,12 +19,12 @@
     <!-- Start and end dates are only in the form for creating a new item, not editing -->
     <div class="col-md-6 form-group" ng-if="form.start_date !== false">
       <label for="start-date">Start date:</label>
-      <input type="text" class="form-control" id="start-date" ng-model="form.start_date"/>
+      <input type="text" class="form-control" id="start-date" ng-model="form.start_date" ui-validate="'form.validateDate($value)'"/>
       <p class="help-block">e.g. YYYY, YYYY-MM, or YYYY-MM-DD</p>
     </div>
     <div class="col-md-6 form-group" ng-if="form.start_date !== false">
       <label for="end-date">End date:</label>
-      <input type="text" class="form-control" id="end-date" ng-model="form.end_date"/>
+      <input type="text" class="form-control" id="end-date" ng-model="form.end_date" ui-validate="'form.validateDate($value)'"/>
       <p class="help-block">e.g. YYYY, YYYY-MM, or YYYY-MM-DD</p>
     </div>
     <div class="col-md-12 form-group" ng-if="form.start_date !== false">

--- a/app/archivesspace/form.html
+++ b/app/archivesspace/form.html
@@ -16,18 +16,18 @@
       <label for="accessrestrict-note">Conditions governing access note:</label>
       <textarea class="form-control" id="accessrestrict-note" ng-model="accessrestrict_note.note"></textarea>
     </div>
-    <!-- Start and end dates are only in the form for creating a new item, not editing -->
+    <!-- Date fields are only in the form for creating a new item, not editing -->
     <div class="col-md-6 form-group" ng-if="form.start_date !== false">
       <label for="start-date">Start date:</label>
       <input type="text" class="form-control" id="start-date" ng-model="form.start_date" ui-validate="'form.validateDate($value)'" ng-required="!form.date_expression &amp;&amp; !form.title &amp;&amp; !form.end_date"/>
       <p class="help-block">e.g. YYYY, YYYY-MM, or YYYY-MM-DD</p>
     </div>
-    <div class="col-md-6 form-group" ng-if="form.start_date !== false">
+    <div class="col-md-6 form-group" ng-if="form.end_date !== false">
       <label for="end-date">End date:</label>
       <input type="text" class="form-control" id="end-date" ng-model="form.end_date" ui-validate="'form.validateDate($value)'" ng-required="!form.date_expression &amp;&amp; !form.start_date &amp;&amp; !form.title"/>
       <p class="help-block">e.g. YYYY, YYYY-MM, or YYYY-MM-DD</p>
     </div>
-    <div class="col-md-12 form-group" ng-if="form.start_date !== false">
+    <div class="col-md-12 form-group" ng-if="form.date_expression !== false">
       <label for="expression">Date expression:</label>
       <textarea class="form-control" id="expression" ng-model="form.date_expression" ng-required="!form.title &amp;&amp; !form.start_date &amp;&amp; !form.end_date"></textarea>
     </div>

--- a/app/archivesspace/form.html
+++ b/app/archivesspace/form.html
@@ -1,36 +1,34 @@
 <form class="resource-form" name="resource_form">
   <div class="row">
-    <div class="col-md-6">
-      <label>Title:</label> <input type="text" ng-model="form.title" ng-required="!form.date_expression">
+    <div class="col-md-6 form-group">
+      <label for="title">Title:</label>
+      <input type="text" class="form-control" id="title" ng-model="form.title" ng-required="!form.date_expression"/>
     </div>
-    <div class="col-md-6">
-      <label>Level of description:</label> <select ng-model="form.level"
-                                  ng-options="level for level in form.levels"
-                                  required>
-                                  </select>
+    <div class="col-md-6 form-group">
+      <label for="lod">Level of description:</label>
+      <select class="form-control" id="lod" ng-model="form.level" ng-options="level for level in form.levels" ng-required="true"></select>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-md-6">
-      <label>General note:</label><br> <textarea ng-model="form.note"></textarea>
+    <div class="col-md-6 form-group">
+      <label for="general-note">General note:</label>
+      <textarea class="form-control" id="general-note" ng-model="form.note"></textarea>
     </div>
-    <div class="col-md-6">
-      <label>Conditions governing access note:</label><br> <textarea ng-model="form.accessrestrict_note"></textarea>
+    <div class="col-md-6 form-group">
+      <label for="accessrestrict-note">Conditions governing access note:</label>
+      <textarea class="form-control" id="accessrestrict-note" ng-model="accessrestrict_note.note"></textarea>
     </div>
-  </div>
-  <!-- Start and end dates are only in the form for creating a new item, not editing -->
-  <div class="row" ng-if="form.start_date !== false &amp;&amp; form.end_date !== false">
-  <div class="col-md-6">
-    <label>Dates:</label>
-    <input type="text" class="form-control" uib-datepicker-popup ng-model="form.start_date" is-open="form.status.start_date_opened" close-text="Close"/>
-    <button type="button" class="btn btn-default" ng-click="form.open_datepicker('start', $event)"><i class="fa fa-calendar"></i></button>
-  </div>
-  <div class="col-md-6">
-    <label>Dates:</label>
-    <input type="text" class="form-control" uib-datepicker-popup ng-model="form.end_date" is-open="form.status.end_date_opened" close-text="Close"/>
-    <button type="button" class="btn btn-default" ng-click="form.open_datepicker('end', $event)"><i class="fa fa-calendar"></i></button>
-    <label>Expression:</label> <input type="text" ng-model="form.date_expression" ng-required="!form.title">
-  </div>
+    <!-- Start and end dates are only in the form for creating a new item, not editing -->
+    <div class="col-md-6 form-group" ng-if="form.start_date !== false">
+      <label for="start-date">Start date:</label>
+      <input type="text" class="form-control" id="start-date" ng-model="form.start_date"/>
+    </div>
+    <div class="col-md-6 form-group" ng-if="form.start_date !== false">
+      <label for="end-date">End date:</label>
+      <input type="text" class="form-control" id="end-date" ng-model="form.end_date"/>
+    </div>
+    <div class="col-md-12 form-group" ng-if="form.start_date !== false">
+      <label for="expression">Date expression:</label>
+      <textarea class="form-control" id="expression" ng-model="form.date_expression" ng-required="!form.title"></textarea>
+    </div>
   </div>
   <div class="btn-group" role="group">
     <button type="submit" class="btn btn-success" ng-click="form.ok()" ng-disabled="resource_form.$invalid">Save</button>

--- a/app/archivesspace/form.html
+++ b/app/archivesspace/form.html
@@ -22,12 +22,12 @@
   <div class="row" ng-if="form.start_date !== false &amp;&amp; form.end_date !== false">
   <div class="col-md-6">
     <label>Dates:</label>
-    <input type="text" class="form-control" uib-datepicker-popup ng-model="form.start_date" is-open="form.status.start_date_opened" ng-required="true" close-text="Close"/>
+    <input type="text" class="form-control" uib-datepicker-popup ng-model="form.start_date" is-open="form.status.start_date_opened" close-text="Close"/>
     <button type="button" class="btn btn-default" ng-click="form.open_datepicker('start', $event)"><i class="fa fa-calendar"></i></button>
   </div>
   <div class="col-md-6">
     <label>Dates:</label>
-    <input type="text" class="form-control" uib-datepicker-popup ng-model="form.end_date" is-open="form.status.end_date_opened" ng-required="false" close-text="Close"/>
+    <input type="text" class="form-control" uib-datepicker-popup ng-model="form.end_date" is-open="form.status.end_date_opened" close-text="Close"/>
     <button type="button" class="btn btn-default" ng-click="form.open_datepicker('end', $event)"><i class="fa fa-calendar"></i></button>
     <label>Expression:</label> <input type="text" ng-model="form.date_expression" ng-required="!form.title">
   </div>

--- a/app/front_page/content.html
+++ b/app/front_page/content.html
@@ -175,62 +175,58 @@
   </div>
 </ui-minimize-panel>
 
-<ui-minimize-panel title='ArchivesSpace'>
+<ui-minimize-panel title='ArchivesSpace' class="aspace-panel">
   <div class='panel panel-default' ng-controller="ArchivesSpaceController">
     <div class='panel-heading'>
       ArchivesSpace <span ng-if="loading"><i class="fa fa-spinner fa-spin"></i></span>
 
-      <form ng-submit="load_data({title: title_query, identifier: id_query})">
-        <input type="text"
-               ng-model="title_query"
-               placeholder="Title">
-        <input type="text"
-               ng-model="id_query"
-               placeholder="Identifier">
-        <input type="submit"
-               class='btn btn-sm btn-primary'
-               id="archivesspace_search"
-               value="Search ArchivesSpace">
-       </form>
+      <form ng-submit="load_data({title: title_query, identifier: id_query})" class="form-inline">
+        <input type="text" ng-model="title_query" placeholder="Title" class="form-control input-sm"/>
+        <input type="text" ng-model="id_query" placeholder="Identifier" class="form-control input-sm"/>
+        <input type="submit" class='btn btn-sm btn-primary' id="archivesspace_search" value="Search ArchivesSpace"/>
+      </form>
+
+      <div class="aspace-actions">
+        <input type='button'
+               class='btn btn-primary btn-sm'
+               id='add_child_record'
+               ng-disabled="!selected"
+               ng-click="add_child(selected)"
+               value='Add New Child Record'>
+        <input type='button'
+               class='btn btn-primary btn-sm'
+               id='add_child_record'
+               ng-disabled="selected.type !== 'resource' &amp;&amp; selected.type !== 'resource_component'"
+               ng-click="add_digital_object(selected)"
+               value='Add New Digital Object'>
+        <a class='btn btn-primary btn-sm'
+           href="{{ get_rights_url(selected) }}"
+           ng-disabled="selected.type !== 'resource' &amp;&amp; selected.type !== 'resource_component'"
+           target='_blank'>
+          Edit Rights Metadata
+        </a>
+        <input type='button'
+               class='btn btn-primary btn-sm'
+               id='edit_record'
+               ng-disabled="!selected || selected.request_pending || selected.type === 'digital_object'"
+               ng-click="edit(selected)"
+               value='Edit Metadata'>
+        <input type='button'
+               class='btn btn-primary btn-sm'
+               id='delete_record'
+               ng-disabled="!selected || selected.request_pending"
+               ng-confirm-click="Are you sure you want to delete this?"
+               ng-click="remove(selected)"
+               value='Delete selected'>
+        <input type='button'
+               class='btn btn-primary btn-sm'
+               id='finalize_arrange'
+               ng-disabled="selected.request_pending || (selected.type !== 'resource' &amp;&amp; selected.type !== 'resource_component')"
+               ng-click="finalize_arrangement(selected)"
+               value='Finalize Arrangement'>
+       </div>
     </div>
     <div class="transfer-tree panel-body">
-      <input type='button'
-             class='btn btn-primary'
-             id='add_child_record'
-             ng-disabled="!selected"
-             ng-click="add_child(selected)"
-             value='Add New Child Record'>
-      <input type='button'
-             class='btn btn-primary'
-             id='add_child_record'
-             ng-disabled="selected.type !== 'resource' &amp;&amp; selected.type !== 'resource_component'"
-             ng-click="add_digital_object(selected)"
-             value='Add New Digital Object'>
-      <a class='btn btn-primary'
-         href="{{ get_rights_url(selected) }}"
-         ng-disabled="selected.type !== 'resource' &amp;&amp; selected.type !== 'resource_component'"
-         target='_blank'>
-        Edit Rights Metadata
-      </a>
-      <input type='button'
-             class='btn btn-primary'
-             id='edit_record'
-             ng-disabled="!selected || selected.request_pending || selected.type === 'digital_object'"
-             ng-click="edit(selected)"
-             value='Edit Metadata'>
-      <input type='button'
-             class='btn btn-primary'
-             id='delete_record'
-             ng-disabled="!selected || selected.request_pending"
-             ng-confirm-click="Are you sure you want to delete this?"
-             ng-click="remove(selected)"
-             value='Delete selected'>
-      <input type='button'
-             class='btn btn-primary'
-             id='finalize_arrange'
-             ng-disabled="selected.request_pending || (selected.type !== 'resource' &amp;&amp; selected.type !== 'resource_component')"
-             ng-click="finalize_arrangement(selected)"
-             value='Finalize Arrangement'>
       <treecontrol id="archivesspace-tree"
              class="tree-light"
              tree-model="data"

--- a/app/front_page/content.html
+++ b/app/front_page/content.html
@@ -49,8 +49,8 @@
 
       <div class='transfer-actions'>
         <input class='btn btn-sm btn-default' type="button" value="Deselect all" ng-click="deselect()" ng-disabled="files.selected.length < 1">
-        <input class='btn btn-sm btn-default' type="button" value="Collapse all" ng-click="collapse_all_nodes()">
-        <input class='btn btn-sm btn-default' type="button" value="Expand all" ng-click="expand_all_nodes()">
+        <input class='btn btn-sm btn-default' type="button" value="Collapse all" ng-click="transfers.collapse_all_nodes()">
+        <input class='btn btn-sm btn-default' type="button" value="Expand all" ng-click="transfers.expand_all_nodes()">
       </div>
     </div>
 
@@ -62,7 +62,7 @@
                    selected-nodes="files.selected"
                    filter-expression="filter_expression"
                    filter-comparator="filter_comparator"
-                   expanded-nodes="expanded_nodes">
+                   expanded-nodes="transfers.expanded_nodes">
         <span tree-draggable file-type="backlog" uuid="{{ node.id }}" ng-if="!node.not_draggable">
           {{ node.title }} <span class="tag" ng-repeat="tag in node.tags">{{ tag }}</span>
         </span>

--- a/app/front_page/content.html
+++ b/app/front_page/content.html
@@ -55,6 +55,8 @@
       </form>
 
       <input class='btn btn-sm btn-default' type="button" value="Deselect all" ng-click="deselect()">
+      <input class='btn btn-sm btn-default' type="button" value="Collapse all" ng-click="collapse_all_nodes()">
+      <input class='btn btn-sm btn-default' type="button" value="Expand all" ng-click="expand_all_nodes()">
 
       <treecontrol class="tree-classic"
                    tree-model="transfers.data"
@@ -62,7 +64,8 @@
                    on-selection="track_selected(node, selected)"
                    selected-nodes="files.selected"
                    filter-expression="filter_expression"
-                   filter-comparator="filter_comparator">
+                   filter-comparator="filter_comparator"
+                   expanded-nodes="expanded_nodes">
         <span tree-draggable file-type="backlog" uuid="{{ node.id }}" ng-if="!node.not_draggable">
           {{ node.title }} <span class="tag" ng-repeat="tag in node.tags">{{ tag }}</span>
         </span>

--- a/app/front_page/content.html
+++ b/app/front_page/content.html
@@ -35,29 +35,26 @@
 
 <ui-minimize-bar>
 
-<ui-minimize-panel title='Backlog' open='true'>
-  <div class='panel panel-default'>
+<ui-minimize-panel title='Backlog' open='true' class="transfer-panel">
+  <div class='panel panel-default' ng-controller="TreeController">
     <div class='panel-heading'>
       Backlog
-    </div>
-    <div class="transfer-tree panel-body" ng-controller="TreeController">
-      <p><b><ng-pluralize count="(files.selected | filter:{'type': 'transfer'}).length" when="{'1': '1 transfer', 'other': '{} transfers'}"></ng-pluralize></b>, <ng-pluralize count="files.selected.length" when="{'1': '1 object', 'other': '{} objects'}"></ng-pluralize></b> selected</p>
 
-      <form ng-submit="submit()">
-        <input type="text"
-               ng-model="tag"
-               ng-disabled="files.selected.length < 1">
-        <input type="submit"
-               id="submit-tag"
-               value="Add tag to selected files"
-               ng-disabled="files.selected.length < 1"
-               class='btn btn-sm btn-default'>
+      <span class="transfer-counts"><b><ng-pluralize count="(files.selected | filter:{'type': 'transfer'}).length" when="{'1': '1 transfer', 'other': '{} transfers'}"></ng-pluralize></b>, <ng-pluralize count="files.selected.length" when="{'1': '1 object', 'other': '{} objects'}"></ng-pluralize></b> selected</span>
+
+      <form ng-submit="submit()" class="form-inline">
+        <input type="text" ng-model="tag" ng-disabled="files.selected.length < 1" class="form-control input-sm">
+        <input type="submit" id="submit-tag" value="Add tag to selected files" ng-disabled="files.selected.length < 1" class='btn btn-sm btn-default'>
       </form>
 
-      <input class='btn btn-sm btn-default' type="button" value="Deselect all" ng-click="deselect()">
-      <input class='btn btn-sm btn-default' type="button" value="Collapse all" ng-click="collapse_all_nodes()">
-      <input class='btn btn-sm btn-default' type="button" value="Expand all" ng-click="expand_all_nodes()">
+      <div class='transfer-actions'>
+        <input class='btn btn-sm btn-default' type="button" value="Deselect all" ng-click="deselect()" ng-disabled="files.selected.length < 1">
+        <input class='btn btn-sm btn-default' type="button" value="Collapse all" ng-click="collapse_all_nodes()">
+        <input class='btn btn-sm btn-default' type="button" value="Expand all" ng-click="expand_all_nodes()">
+      </div>
+    </div>
 
+    <div class="transfer-tree panel-body">
       <treecontrol class="tree-classic"
                    tree-model="transfers.data"
                    options="options"

--- a/app/front_page/content.html
+++ b/app/front_page/content.html
@@ -242,7 +242,7 @@
         <span ng-if="node.type === 'resource'" file-type="record">
           <i ng-if="node.has_children" class="fa fa-folder-o"></i>
           <i ng-if="!node.has_children" class="fa fa-file-o"></i>
-          {{ node.title }} <div ng-if="node.identifier">({{ node.identifier }})</div>
+          {{ node.title }} <span ng-if="node.identifier">({{ node.identifier }})</span>
         </span>
         <span ng-if="node.type === 'resource_component'" file-type="record">
           <i ng-if="node.has_children" class="fa fa-folder-o"></i>

--- a/app/services/transfer.service.js
+++ b/app/services/transfer.service.js
@@ -65,6 +65,17 @@ factory('Transfer', ['Facet', 'Tag', function(Facet, Tag) {
     }
   };
 
+  var expand_children = (self, nodes) => {
+    angular.forEach(nodes, node => {
+      if (node.type === 'transfer' || node.type === 'directory') {
+        self.expanded_nodes.push(node);
+        if (angular.isDefined(node.children) && node.children.length) {
+          expand_children(self, node.children);
+        }
+      }
+    });
+  };
+
   return {
     // A nested tree of transfer backlog data, populated using the format returned
     // by the Archivematica transfer backlog API.
@@ -81,6 +92,8 @@ factory('Transfer', ['Facet', 'Tag', function(Facet, Tag) {
     // This is initially populated by `resolve`, and is updated whenever tags are
     // added or removed using the methods on this service.
     tags: [],
+    // A list to keep track of the expanded nodes, used to expand/collapse nodes programmatically.
+    expanded_nodes: [],
     // Provided a set of data retrieved from the transfer backlog, performs the following:
     // * populates the `data`, `formats`, `id_map` and `tags` attributes.
     // * tracks a full list of all unique tags in the set of files.
@@ -188,5 +201,11 @@ factory('Transfer', ['Facet', 'Tag', function(Facet, Tag) {
     clear_tags: function() {
       this.tags = [];
     },
+    collapse_all_nodes: function() {
+      this.expanded_nodes = [];
+    },
+    expand_all_nodes: function() {
+      expand_children(this, this.data);
+    }
   };
 }]);

--- a/app/tree/tree.controller.js
+++ b/app/tree/tree.controller.js
@@ -19,6 +19,7 @@ controller('TreeController', ['$scope', 'SelectedFiles', 'Transfer', function($s
       li: 'file',
     },
   };
+  $scope.expanded_nodes = [];
   // Hides objects with display set to "false"
   $scope.filter_expression = {display: true};
   $scope.filter_comparator = true;
@@ -72,5 +73,24 @@ controller('TreeController', ['$scope', 'SelectedFiles', 'Transfer', function($s
 
     Transfer.add_list_of_tags(SelectedFiles.list_file_ids(), tag);
     this.tag = '';
+  };
+
+  var expand_children = nodes => {
+    angular.forEach(nodes, node => {
+      if (node.type === 'transfer' || node.type === 'directory') {
+        $scope.expanded_nodes.push(node);
+        if (angular.isDefined(node.children) && node.children.length) {
+          expand_children(node.children);
+        }
+      }
+    });
+  };
+
+  $scope.collapse_all_nodes = function() {
+    $scope.expanded_nodes = [];
+  };
+
+  $scope.expand_all_nodes = function() {
+    expand_children(Transfer.data);
   };
 }]);

--- a/app/tree/tree.controller.js
+++ b/app/tree/tree.controller.js
@@ -19,7 +19,6 @@ controller('TreeController', ['$scope', 'SelectedFiles', 'Transfer', function($s
       li: 'file',
     },
   };
-  $scope.expanded_nodes = [];
   // Hides objects with display set to "false"
   $scope.filter_expression = {display: true};
   $scope.filter_comparator = true;
@@ -73,24 +72,5 @@ controller('TreeController', ['$scope', 'SelectedFiles', 'Transfer', function($s
 
     Transfer.add_list_of_tags(SelectedFiles.list_file_ids(), tag);
     this.tag = '';
-  };
-
-  var expand_children = nodes => {
-    angular.forEach(nodes, node => {
-      if (node.type === 'transfer' || node.type === 'directory') {
-        $scope.expanded_nodes.push(node);
-        if (angular.isDefined(node.children) && node.children.length) {
-          expand_children(node.children);
-        }
-      }
-    });
-  };
-
-  $scope.collapse_all_nodes = function() {
-    $scope.expanded_nodes = [];
-  };
-
-  $scope.expand_all_nodes = function() {
-    expand_children(Transfer.data);
   };
 }]);

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "angular-mocks": "^1.3.20",
     "angular-route": "^1.3.20",
     "angular-route-segment": "^1.5.0",
+    "angular-ui-validate": "^1.2.2",
     "archivematica-browse-helpers": "git+https://github.com/artefactual-labs/archivematica-browse-helpers.git",
     "base64-helpers": "git+https://github.com/artefactual-labs/base64-helpers.git",
     "bootstrap": "^3.3.6",
@@ -47,6 +48,7 @@
     "jquery": "^1.11.3",
     "jquery-ui": "^1.10.5",
     "lodash": "^4.5.1",
+    "moment": "^2.15.1",
     "restangular": "^1.3.1"
   }
 }


### PR DESCRIPTION
I've included both things in the same PR to avoid conflicts while merging but I'll merge them in different commits.

ASpace:
- Dates are not required and don't default to today
- Fix required fields and dates creation matching ASpace behavior
- Change date-pickers for free text fields with help text and validation
- Add dates on display_title on child creation
- Style fixes in the ASpace panel: form, buttons, margins, etc.

Backlog:
- Add expand/collapse all nodes options
- Style fixes in the Backlog panel: form, buttons, margins, etc.

Related PRs:
- https://github.com/artefactual/archivematica/pull/496 (includes this PR)
- https://github.com/artefactual-labs/agentarchives/pull/35 (merged)
