### PR TITLE
Examine contents: show path in filename column

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -110,3 +110,7 @@ fieldset {
 .panel-heading .counts {
   float: right;
 }
+
+.examine-contents-form {
+  margin-bottom: 10px;
+}

--- a/app/examine_contents/examine_contents.controller.js
+++ b/app/examine_contents/examine_contents.controller.js
@@ -32,6 +32,12 @@ controller('ExamineContentsController', ['$routeSegment', 'SelectedFiles', 'Tran
     Transfer.add_list_of_tags(ids, tag);
     this.tag = '';
   };
+
+  vm.cutRelativePath = relative_path => {
+    // Return only the part after '/objects/',
+    // using pop to return the full path otherwise
+    return relative_path.split('/objects/').pop();
+  };
 }]).
 
 controller('ExamineContentsFileController', ['$routeSegment', 'File', function($routeSegment, File) {

--- a/app/examine_contents/examine_contents.html
+++ b/app/examine_contents/examine_contents.html
@@ -21,8 +21,9 @@
   <div ng-if="(vm.SelectedFiles.selected | find_files).length != 0">
   <h2>Files</h2>
 
-  <form ng-submit="vm.submit(vm.selected)">
+  <form ng-submit="vm.submit(vm.selected)" class="form-inline examine-contents-form">
     <input type="text"
+           class="form-control input-sm"
            ng-model="vm.tag"
            ng-disabled="vm.selected.length < 1">
     <input type="submit"
@@ -57,7 +58,7 @@
              all-selected="vm.all_selected">
       </td>
       <td>
-        <a href="#{{ vm.$routeSegment.getSegmentUrl('examine_contents.file_info', {id: record.id, type: vm.type}) }}">{{ record.title }}</a>
+        <a href="#{{ vm.$routeSegment.getSegmentUrl('examine_contents.file_info', {id: record.id, type: vm.type}) }}">{{ vm.cutRelativePath(record.relative_path) }}</a>
       </td>
       <td>
         <a href="#{{ vm.$routeSegment.getSegmentUrl('preview', {id: record.id}) }}">Preview</a>


### PR DESCRIPTION
Show the part after '/objects/' or the full path if the objects directory
is not present. Style tags form in the same panel

Redmine: https://projects.artefactual.com/issues/10803