### PR TITLE
Analysis/File list: fix format/group faceting

### DIFF
--- a/app/filters/aggregation.filter.js
+++ b/app/filters/aggregation.filter.js
@@ -14,8 +14,21 @@ filter('format_data', function() {
     var format_data = {};
     for (var i in records) {
       var record = records[i];
-      if (!record.format) {
+
+      // Don't count transfers or directories
+      if (record.type !== 'file') {
         continue;
+      }
+
+      // Set 'Unidentified' format and/or group for those
+      // files where they're missing. This also sets the 
+      // values in the records at the SelectedFiles service,
+      // allowing them to be filtered in the file list panel.
+      if (!record.format) {
+        record.format = 'Unidentified';
+      }
+      if (!record.group) {
+        record.group = 'Unidentified';
       }
 
       if (!format_data[record.format]) {


### PR DESCRIPTION
Creates 'Unidentified' format and group in the Analysis/Objects panel
for those files where those values are missing. Sets the values in the
actual file objects to allow filtering in the File list panel