### PR TITLE
use display_title instead of title for sip_name

### DIFF
--- a/app/archivesspace/archivesspace.controller.js
+++ b/app/archivesspace/archivesspace.controller.js
@@ -554,7 +554,7 @@ controller('ArchivesSpaceController', ['$scope', 'gettextCatalog', '$uibModal', 
       node.request_pending = false;
       Alert.alerts.push({
         type: 'success',
-        message: gettextCatalog.getString('Successfully started SIP from record "{{title}}"', { title: node.title }),
+        message: gettextCatalog.getString('Successfully started SIP from record "{{title}}"', { title: node.display_title }),
       });
 
       // Remove the digital object components so the user doesn't try to add new items
@@ -565,7 +565,7 @@ controller('ArchivesSpaceController', ['$scope', 'gettextCatalog', '$uibModal', 
       var message;
       // error.message won't be defined if this returned an HTML 500
       if (error.data.message && error.data.message.startsWith('No SIP Arrange')) {
-        message = gettextCatalog.getString('Unable to start SIP; no files arranged into record "{{title}}".', { title: node.title });
+        message = gettextCatalog.getString('Unable to start SIP; no files arranged into record "{{title}}".', { title: node.display_title });
       } else {
         message = gettextCatalog.getString('Unable to start SIP; check dashboard logs.');
       }

--- a/app/services/archivesspace.service.js
+++ b/app/services/archivesspace.service.js
@@ -86,7 +86,7 @@ factory('ArchivesSpace', ['Restangular', function(Restangular) {
       // as a directory within the new SIP.
       start_sip: function(node) {
         var url_fragment = id_to_urlsafe(node.id);
-        return ArchivesSpace.one(url_fragment).one('copy_from_arrange').customPOST({ sip_name: node.title });
+        return ArchivesSpace.one(url_fragment).one('copy_from_arrange').customPOST({ sip_name: node.display_title });
       },
     };
 }]);


### PR DESCRIPTION
This fixes a bug in which SIP creation failed if the archival object did not have a title (i.e., "2010-2015"). It uses the display_title instead, which is a concatenation of the object's title (if it exists) and dates (if they exist). 