### PR TITLE
Font-awesome added back into the dependencies

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,5 +1,6 @@
 // Styles
 import './app.css';
+import 'font-awesome/css/font-awesome.min.css';
 import './vendor/angular-tree-control/css/tree-control.css';
 import './vendor/angular-tree-control/css/tree-control-attribute.css';
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "archivematica-browse-helpers": "git+https://github.com/artefactual-labs/archivematica-browse-helpers.git",
     "base64-helpers": "git+https://github.com/artefactual-labs/base64-helpers.git",
     "d3": "^3.5.12",
+    "font-awesome": "^4.3.0",
     "lodash": "^4.5.1",
     "moment": "^2.15.1",
     "restangular": "^1.3.1"


### PR DESCRIPTION
Identified in 1.7.x font-awesome is required by the ArchivesSpace tree in the
Appraisal Tab. Identified components which remain between the regression and
now are:

* app.js
* package.json

`package-lock.json` is not part of this build unlike the current 1.7.x branch.

The reference to font-awesome has been added to both of these files.

Closes #161